### PR TITLE
Fixed setup script

### DIFF
--- a/scripts/apache/add-ports.sh
+++ b/scripts/apache/add-ports.sh
@@ -2,9 +2,7 @@
 # This script adds the extra ports for other Ludum Dare services.
 # i.e. 8080 for api.ludumdare.com, 8081 for static.ludumdare.com, etc.
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-cd $SCRIPTPATH
+cd /var/www/scripts/apache
 
 echo "Adding additional server ports to Apache"
 cat apache-ports-conf.txt>>/etc/apache2/ports.conf

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,9 +5,8 @@
 
 # TODO: Check if it's Apache or nginx.
 
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
-cd $SCRIPTPATH
-
+cd /var/www/scripts
 (cd apache ; sh add-ports.sh)
+
+cd /var/www/scripts
 (cd db ; echo YES | php table-create)


### PR DESCRIPTION
Hey Mike,

I tried to start up Dairybox on my Windows 10 machine and that didn't work. The setup.sh turned out to be the problem. Getting the path in the fashion the old script did it, didn't work, so I replaced them with fixed paths. So now it works, but when I try to display http://192.168.48.48:8084/ I do get the following:

![image](https://cloud.githubusercontent.com/assets/596986/17632479/c2cc4880-60c8-11e6-8d6d-83ace6ded0a0.png)

Not sure what causes that message to be there for over 10 minutes now, but that would be a different problem, I guess.

