### PR TITLE
Fixed the Calendar Issue #314

### DIFF
--- a/src/com/sidebar-calendar/calendar.js
+++ b/src/com/sidebar-calendar/calendar.js
@@ -14,11 +14,11 @@ export default class SidebarCalendar extends Component {
 		// TODO: Adjust selected day/week when time itself rolls over
 
 		let thisDay = today.getDate();
-		let thisMonth = today.getMonth()+1;
+		let thisMonth = today.getMonth();
 		let thisYear = today.getFullYear();
 		
 		/* Months and Weeks start at 0. Years and Days start at 1. Using 0th day is like -1 */
-		let monthEndsOn = new Date(today.getFullYear(), today.getMonth()+1, 0).getDate();
+		let monthEndsOn = new Date(today.getFullYear(), today.getMonth(), 0).getDate();
 		let nextDay = today.getDate() - today.getDay();
 		
 		if ( nextDay < 1 ) {


### PR DESCRIPTION
this fixed issue #314
Removed the addition to the months, as it was not being converted correctly. It now displays the calendar 100% correctly - (even with the trophies, that's a neat feature PoV!)

![image](https://cloud.githubusercontent.com/assets/11025073/20841374/79289218-b903-11e6-8b57-9776d8ae2ae7.png)
