### PR TITLE
Fix for issue #314 in Firefox and other browsers

### DIFF
--- a/src/com/sidebar-calendar/calendar.js
+++ b/src/com/sidebar-calendar/calendar.js
@@ -54,7 +54,9 @@ export default class SidebarCalendar extends Component {
 	}
 
 	genRow( row ) {
-		return row.map( function(col) {
+		return row.map( function(col, index) {
+			if(col[index])
+				col = col[index];
 			let props = {};
 			if ( col.selected ) {
 				props.class = "selected";
@@ -66,10 +68,10 @@ export default class SidebarCalendar extends Component {
 			props.title = col.month+"-"+col.day+"-"+col.year;
 			if ( window.Intl ) {
 				// http://stackoverflow.com/a/18648314/5678759
-				let objDate = new Date(props.title);
+				let objDate = new Date( col.year, col.month-1, col.day );
 				props.title = objDate.toLocaleString("en-us", {month:"long", day:"numeric", year:"numeric"});
 			}
-			
+
 			var ShowIcon = null;
 			if ( col.year == 2016 && col.month == 12 && (col.day >= 9 && col.day <= 12) ) {
 				ShowIcon = <SVGIcon class="-icon">trophy</SVGIcon>;


### PR DESCRIPTION
**Fix Issue #314**

In firefox, and other earlier browsers it seems as though they haven't fully implemented the map functionality. Through setting the index of the Col, this should allow it to access the correct variables inside the object.
Whilst also experimenting, I found that setting the Date from a string wasn't working and was only supported in Chrome. As you can see, I've manually set it up to put the year, month and day in, rather than doing it from the string.