### PR TITLE
Updated the setup script's database creation

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,4 +10,4 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 cd $SCRIPTPATH
 
 (cd apache ; sh add-ports.sh)
-(cd db ; echo YES | php table-create)
+(cd /vagrant/www/src/shrub/tools; echo YES | php table_create)


### PR DESCRIPTION
Pointed setup.sh to new database creation script, I don't think the old one was doing anything useful... now the database will be recreated whenever vagrant creates the VM. (I feel like the desired behaviour might be to keep the DB, and have the user manually update it if needed).