### PR TITLE
Added styling to markdown tables

### DIFF
--- a/src/com/content-common/common-body-markup.less
+++ b/src/com/content-common/common-body-markup.less
@@ -49,22 +49,24 @@
     /* Tables */
 
     table{
-        border: 1px solid #bbb;
+        border: 1px solid @COL_NLLL;
         margin: 2% 0;
         border-collapse: collapse;
     }
 
     th, td {
         vertical-align: center;
-        border: 1px solid #ccc;
+        border: 1px solid @COL_NLLL;
         padding: 0.5em;
     }
 
-    tr:nth-child(even) {
-        background-color: #eee
-    }
+    tbody{
+        tr:nth-child(even) {
+            background-color: @COL_NLLLL;
+        }
 
-    tr:nth-child(even) {
-        background-color: #ddd;
+        tr:nth-child(odd) {
+            background-color: inherit;
+        }
     }
 }

--- a/src/com/content-common/common-body-markup.less
+++ b/src/com/content-common/common-body-markup.less
@@ -45,4 +45,26 @@
 	& pre code {
 		font-size: 0.75em;
 	}
+
+    /* Tables */
+
+    table{
+        border: 1px solid #bbb;
+        margin: 2% 0;
+        border-collapse: collapse;
+    }
+
+    th, td {
+        vertical-align: center;
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+
+    tr:nth-child(even) {
+        background-color: #eee
+    }
+
+    tr:nth-child(even) {
+        background-color: #ddd;
+    }
 }


### PR DESCRIPTION
Currently markdown tables look like this.
![](http://image.prntscr.com/image/d86acd1b43164880b6aca73fa72f764c.png)

This pr changes them to look more like the tables on github
![](http://image.prntscr.com/image/e30b9db378074162b4d7711d8c979990.png)