### PR TITLE
InputTextarea component to wrap textarea to centralize errors

### DIFF
--- a/src/com/content-body/body-edit.js
+++ b/src/com/content-body/body-edit.js
@@ -1,4 +1,5 @@
 import { h, Component } 				from 'preact/preact';
+import InputTextArea					from 'com/input-textarea/input-textarea';
 
 export default class ContentBodyEdit extends Component {
 	constructor( props ) {
@@ -15,7 +16,7 @@ export default class ContentBodyEdit extends Component {
 		return (
 			<div class="content-body content-body-common content-body-edit">
 				<div class="-label">Description</div>
-				<div class="-textarea"><textarea name="paragraph_text" rows="18" value={children} oninput={onmodify} placeholder={PlaceholderText} /></div>
+				<div class="-textarea"><InputTextArea name="paragraph_text" rows="18" value={children} onModify={onmodify} placeholder={PlaceholderText} /></div>
 			</div>
 		);
 	}

--- a/src/com/content-comments/comments-markup.js
+++ b/src/com/content-comments/comments-markup.js
@@ -3,6 +3,7 @@ import { shallowDiff }	 				from 'shallow-compare/index';
 
 import NavLink							from 'com/nav-link/link';
 import SVGIcon							from 'com/svg-icon/icon';
+import InputTextArea					from 'com/input-textarea/input-textarea';
 
 export default class ContentCommentsMarkup extends Component {
 	constructor( props ) {
@@ -11,23 +12,6 @@ export default class ContentCommentsMarkup extends Component {
 
 	shouldComponentUpdate( nextProps ) {
 		return shallowDiff(this.props, nextProps);
-	}
-	
-	resizeTextarea() {
-		if ( this.textarea ) {
-			this.textarea.style.height = 0;	/* Shockingly, this is necessary. textarea wont shrink otherwise */
-			this.textarea.style.height = this.textarea.scrollHeight + 'px';
-		}		
-	}
-	
-	// After initial render
-	componentDidMount() {
-		this.resizeTextarea();
-	}
-	
-	// After every update
-	componentDidUpdate() {
-		this.resizeTextarea();
 	}
 	
 	render( props ) {
@@ -49,10 +33,10 @@ export default class ContentCommentsMarkup extends Component {
 				<div class={Class}>
 					<div class="-label">{props.label}</div>
 					<div class="-textarea">
-						<textarea 
+						<InputTextArea 
 							name="paragraph_text" 
 							value={props.children} 
-							oninput={props.onmodify} 
+							onModify={props.onmodify} 
 							placeholder={props.placeholder} 
 							ref={(input) => { this.textarea = input; }} 
 							maxlength={Limit}

--- a/src/com/content-common/common-body-markup.js
+++ b/src/com/content-common/common-body-markup.js
@@ -3,6 +3,7 @@ import { shallowDiff }	 				from 'shallow-compare/index';
 
 import NavLink							from 'com/nav-link/link';
 import SVGIcon							from 'com/svg-icon/icon';
+import InputTextArea					from 'com/input-textarea/input-textarea';
 
 export default class ContentCommonBodyMarkup extends Component {
 	constructor( props ) {
@@ -11,23 +12,6 @@ export default class ContentCommonBodyMarkup extends Component {
 
 	shouldComponentUpdate( nextProps ) {
 		return shallowDiff(this.props, nextProps);
-	}
-	
-	resizeTextarea() {
-		if ( this.textarea ) {
-			this.textarea.style.height = 0;	/* Shockingly, this is necessary. textarea wont shrink otherwise */
-			this.textarea.style.height = this.textarea.scrollHeight + 'px';
-		}		
-	}
-	
-	// After initial render
-	componentDidMount() {
-		this.resizeTextarea();
-	}
-	
-	// After every update
-	componentDidUpdate() {
-		this.resizeTextarea();
 	}
 	
 	render( props ) {
@@ -46,10 +30,10 @@ export default class ContentCommonBodyMarkup extends Component {
 				<div class={Class}>
 					<div class="-label">{props.label}</div>
 					<div class="-textarea">
-						<textarea 
+						<InputTextArea 
 							name="paragraph_text" 
 							value={props.children} 
-							oninput={props.onmodify} 
+							onModify={props.onmodify} 
 							placeholder={props.placeholder} 
 							ref={(input) => { this.textarea = input; }} 
 						/>

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -1,0 +1,48 @@
+import { h, Component } 				from 'preact/preact';
+import { shallowDiff }	 				from 'shallow-compare/index';
+
+export default class InputTextarea extends Component {
+	constructor( props ) {
+		super(props);
+		this.setState({'cursorPos': (props.value || '').length});
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		return shallowDiff(this.props, nextProps);
+	}
+	
+	resizeTextarea() {
+		if ( this.textarea ) {
+			this.textarea.style.height = 0;	/* Shockingly, this is necessary. textarea wont shrink otherwise */
+			this.textarea.style.height = this.textarea.scrollHeight + 'px';
+		}		
+	}
+	
+	// After initial render
+	componentDidMount() {
+		this.resizeTextarea();
+	}
+	
+	// After every update
+	componentDidUpdate() {
+		if ( this.textarea ) {
+			this.textarea.setSelectionRange(this.state.cursorPos, this.state.cursorPos);
+		}
+
+		this.resizeTextarea();
+	}
+	
+	onInput( e ) {
+		e.preventDefault();
+		this.setState({'cursorPos': e.target.selectionEnd});
+	}
+
+	render( props ) {
+		return (
+			<textarea {...props} 
+				onInput={(e) => { props.onModify(e); this.onInput(e); }}
+				ref={(input) => { this.textarea = input; }} 
+			/>
+		);
+	}
+}


### PR DESCRIPTION
Can be used the same way as textarea, except oninput is replaced with onModify.

Fixes #571.