### PR TITLE
Remove word-wrap: break-word; on body text

### DIFF
--- a/src/com/content-common/common.less
+++ b/src/com/content-common/common.less
@@ -48,9 +48,6 @@
 		overflow: hidden;
 		
 		overflow-wrap: break-word;
-		word-wrap: break-word;
-		word-break: break-all;
-		word-break: break-word;
 		hyphens: auto;
 	}
 }


### PR DESCRIPTION
word-wrap: break-word doesn't exist anymore, and should be changed to overflow-wrap: break-word (which was already in the CSS and was being overwritten by word-break: break-all). This fixes the odd wrapping behaviour:
![screen shot 2017-04-18 at 13 47 32](https://cloud.githubusercontent.com/assets/118267/25145013/d97ddbbe-243d-11e7-8ee5-d36bc4270d9e.png)
