### PR TITLE
Prevent pictures from overflowing the comment box

### DIFF
--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -39,6 +39,10 @@
 	
 	& .-markup {
 		margin: 0.5em 0;
+
+		& img {
+			max-width: 100%;
+		}
 	}
 
 	& .-item {


### PR DESCRIPTION
An issue regarding big pictures in comments was noticed [by SirRucTheRandom](https://ldjam.com/events/ludum-dare/38/tub-of-war) (see one of the last comments).

A little CSS tweak fixed it:

![fixed](https://cloud.githubusercontent.com/assets/694508/25564521/53e5de9e-2db5-11e7-988d-a40681aa07b0.png)