### PR TITLE
Fixed emojis with _ in them

### DIFF
--- a/src/internal/marked/Renderer.js
+++ b/src/internal/marked/Renderer.js
@@ -119,7 +119,7 @@ export default class Renderer {
   };
 
   emoji(text) {
-    return (<img class="emoji" alt={text} title={':' + text + ':'} src={window.emoji.shortnameToURL(text)}/>);
+    return (<img class="emoji" alt={text} title={':' + text + ':'} src={window.emoji.shortnameToURL(text.join(''))}/>);
   };
 
   //email(text) {


### PR DESCRIPTION
#Fixed emojis with underscores in them.
issue raised in #855 .
Any emoji with underscores in them have stopped working. 
Bug was most likely introduced during the markdown parser rewrite (it's so much better btw!!). 

### broken behaviour
![image](https://cloud.githubusercontent.com/assets/18352787/25784642/af05a238-3368-11e7-8890-69985ecf61dc.png)

### fixed behaviour
![image](https://cloud.githubusercontent.com/assets/18352787/25784611/492d7238-3368-11e7-8bfe-510c7ce028cb.png)

Closes #855