### PR TITLE
Markdown support for spoilers

### DIFF
--- a/src/com/block-spoiler/spoiler.js
+++ b/src/com/block-spoiler/spoiler.js
@@ -11,8 +11,7 @@ export default class SidebarUpcoming extends Component {
 		this.onClick = this.onClick.bind(this);
 	}
 	
-	onClick( e ) {
-		//event.stopPropagation();
+	onClick( e ) {		
 		this.setState({'visible': true});
 	}
 	

--- a/src/com/block-spoiler/spoiler.js
+++ b/src/com/block-spoiler/spoiler.js
@@ -12,6 +12,7 @@ export default class SidebarUpcoming extends Component {
 	}
 	
 	onClick( e ) {
+		//event.stopPropagation();
 		this.setState({'visible': true});
 	}
 	

--- a/src/com/block-spoiler/spoiler.less
+++ b/src/com/block-spoiler/spoiler.less
@@ -7,6 +7,7 @@
 	color: @COL_NDDD;
 	background: @COL_NDDD;
 	
+	
 	/* Spoiler is visible */
 	&.-visible {
 		background: inherit;

--- a/src/com/block-spoiler/spoiler.less
+++ b/src/com/block-spoiler/spoiler.less
@@ -16,7 +16,8 @@
 	& p a, 
 	& p a:visited {
 		color: @COL_NDDD !important;
-
+		pointer-events: none;
+		
 		&:hover,
 		&:focus {
 			color: @COL_NDDD !important;
@@ -39,7 +40,8 @@
 	&.-visible p a, 
 	&.-visible p a:visited {
 		color: @COL_A !important;
-
+		pointer-events: auto;
+		
 		&:hover,
 		&:focus {
 			color: @COL_L !important;

--- a/src/com/block-spoiler/spoiler.less
+++ b/src/com/block-spoiler/spoiler.less
@@ -7,9 +7,43 @@
 	color: @COL_NDDD;
 	background: @COL_NDDD;
 	
+
+	& p * {
+		color: @COL_NDDD !important;
+		background: @COL_NDDD;	
+	}
+
+	& p a, 
+	& p a:visited {
+		color: @COL_NDDD !important;
+
+		&:hover,
+		&:focus {
+			color: @COL_NDDD !important;
+			background: @COL_NDDD;
+		}
+	}
+	
+	/* End Spoilers */
 	
 	/* Spoiler is visible */
 	&.-visible {
 		background: inherit;
 	}
+
+	&.-visible p * {
+		color: inherit;
+		background: inherit;	
+	}
+
+	&.-visible p a, 
+	&.-visible p a:visited {
+		color: @COL_A !important;
+
+		&:hover,
+		&:focus {
+			color: @COL_L !important;
+			background: @COL_A;
+		}
+	}	
 }

--- a/src/com/content-common/common-body-markup.less
+++ b/src/com/content-common/common-body-markup.less
@@ -17,47 +17,6 @@
 		overflow:auto;
 		box-sizing: border-box;
 	}
-	/* Spoilers */
-
-	& .spoiler:focus {
-		background-color: @BG;
-	}
-
-	& .spoiler:focus p * {
-		background-color: @BG;
-	}
-
-	& .spoiler:focus p * {
-		background-color: @BG;
-	}
-
-	& .spoiler:focus p a, 
-	& .spoiler:focus p a:visited {
-		color: @COL_A;
-
-		&:hover,
-		&:focus {
-			color: @COL_L;
-			background: @COL_A;
-		}
-	}
-
-	& .spoiler {
-		background-color: @DARK;
-		color: @DARK;
-	}
-
-	& .spoiler p {
-		background-color: @DARK;
-		color: @DARK;
-	}
-
-	& .spoiler p * {
-		background-color: @DARK;
-		color: @DARK !important;
-	}
-	
-	/* End Spoilers */
 
 	/* Code Blocks */
 	& pre code {

--- a/src/com/content-common/common-body-markup.less
+++ b/src/com/content-common/common-body-markup.less
@@ -1,5 +1,8 @@
 @import 'defs.less';
 
+@BG: @COL_L;
+@DARK: @COL_NDDD;
+
 #content .content-common-body.-markup {
 }
 
@@ -14,6 +17,47 @@
 		overflow:auto;
 		box-sizing: border-box;
 	}
+	/* Spoilers */
+
+	& .spoiler:focus {
+		background-color: @BG;
+	}
+
+	& .spoiler:focus p * {
+		background-color: @BG;
+	}
+
+	& .spoiler:focus p * {
+		background-color: @BG;
+	}
+
+	& .spoiler:focus p a, 
+	& .spoiler:focus p a:visited {
+		color: @COL_A;
+
+		&:hover,
+		&:focus {
+			color: @COL_L;
+			background: @COL_A;
+		}
+	}
+
+	& .spoiler {
+		background-color: @DARK;
+		color: @DARK;
+	}
+
+	& .spoiler p {
+		background-color: @DARK;
+		color: @DARK;
+	}
+
+	& .spoiler p * {
+		background-color: @DARK;
+		color: @DARK !important;
+	}
+	
+	/* End Spoilers */
 
 	/* Code Blocks */
 	& pre code {

--- a/src/internal/marked/Parser.js
+++ b/src/internal/marked/Parser.js
@@ -125,6 +125,16 @@ export default class Parser {
           }
           return this.renderer.table(header, body);
         }
+      case 'spoiler_start':
+        {
+          var body = [];
+
+          while (this.next().type !== 'spoiler_end') {
+            body.push(this.tok());
+          }
+
+          return this.renderer.spoiler(body);
+        }
       case 'blockquote_start':
         {
           var body = [];

--- a/src/internal/marked/Renderer.js
+++ b/src/internal/marked/Renderer.js
@@ -36,7 +36,11 @@ export default class Renderer {
       </code></pre>
     );
   };
-
+  spoiler(secret) {
+    return (
+      <blockquote class='spoiler'>{secret}</blockquote>
+    );
+  };
   blockquote(quote) {
     return (
       <blockquote>{quote}</blockquote>

--- a/src/internal/marked/Renderer.js
+++ b/src/internal/marked/Renderer.js
@@ -2,6 +2,8 @@ import {h} from 'preact/preact';
 
 import Util from './Util';
 
+import BlockSpoiler from 'com/block-spoiler/spoiler';
+
 //COMPONENT IMPORTS
 import NavLink from 'com/nav-link/link';
 import AutoEmbed from 'com/autoembed/autoembed';
@@ -38,7 +40,7 @@ export default class Renderer {
   };
   spoiler(secret) {
     return (
-      <blockquote class='spoiler'>{secret}</blockquote>
+      <BlockSpoiler>{secret}</BlockSpoiler>
     );
   };
   blockquote(quote) {


### PR DESCRIPTION
This implements `!>` block-quote type of spoiler syntax to markdown. Links are also spoiled and content click-through when deactivating spoiler feature in place.