### PR TITLE
Scroll area

### DIFF
--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -14,8 +14,7 @@ export default class InputTextarea extends Component {
 
 		this.state = {
 			'cursorPos': (props.value || '').length,
-			'cachedScrollHeight': this.textarea.scrollHeight,
-			'edge': /Edge/.test(navigator.userAgent) 
+			'edge': /Edge/.test(navigator.userAgent)
 		};
 		
 		this.onInput = this.onInput.bind(this);
@@ -27,11 +26,22 @@ export default class InputTextarea extends Component {
 	}
 	
 	resizeTextarea() {
-		if ( this.textarea  && this.cachedScrollHeight !== this.textarea.scrollHeight) {
-			if (this.cachedScrollHeight > this.textarea.scrollHeight) {
-				this.textarea.style.height = 0;	/* Shockingly, this is necessary. textarea wont shrink otherwise */
-			}
+
+		var doc = document;
+		var top = (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0);
+
+		if ( this.textarea) {
+			var before = this.textarea.style.height;
+			window.onscroll = function () {};
+
+			this.textarea.style.height = '1px';	/* Shockingly, this is necessary. textarea wont shrink otherwise */
 			this.textarea.style.height = this.textarea.scrollHeight + 'px';
+
+			var delta = parseInt(this.textarea.style.height) - parseInt(before) || 0;
+
+			window.scrollTo(0, delta + top);
+			window.onscroll = null;
+			
 		}
 	}
 	

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -14,7 +14,8 @@ export default class InputTextarea extends Component {
 
 		this.state = {
 			'cursorPos': (props.value || '').length,
-			'edge': /Edge/.test(navigator.userAgent)
+			'cachedScrollHeight': this.textarea.scrollHeight,
+			'edge': /Edge/.test(navigator.userAgent) 
 		};
 		
 		this.onInput = this.onInput.bind(this);
@@ -26,10 +27,12 @@ export default class InputTextarea extends Component {
 	}
 	
 	resizeTextarea() {
-		if ( this.textarea ) {
-			this.textarea.style.height = 0;	/* Shockingly, this is necessary. textarea wont shrink otherwise */
+		if ( this.textarea  && this.cachedScrollHeight !== this.textarea.scrollHeight) {
+			if (this.cachedScrollHeight > this.textarea.scrollHeight) {
+				this.textarea.style.height = 0;	/* Shockingly, this is necessary. textarea wont shrink otherwise */
+			}
 			this.textarea.style.height = this.textarea.scrollHeight + 'px';
-		}		
+		}
 	}
 	
 	// After initial render


### PR DESCRIPTION
This prevents the horrible scrolling that happens in long posts/comments. Basically it calculates the expansion of the area and scrolls accordingly but due to the issue of shrinking the area it also disables the window's scroll management while resizing itself. The manual scrolling is nice, because that means you can scroll down a bit so your not writing at the absolute bottom of the screen / still see info about markdown and characters left.

Line 30 & 31 could have been in the if-statement but it's only once that it's not running the if so not really a problem.

Tested on

- [X] Firefox
- [X] Chrome
- [ ] Edge (couldn't get to show local pages)
- [ ] Mobile, don't know how I'd test that.