### PR TITLE
Fixed issue with inline codespan not decoding

### DIFF
--- a/src/internal/marked/Renderer.js
+++ b/src/internal/marked/Renderer.js
@@ -140,7 +140,7 @@ export default class Renderer {
 
   codespan(text) {
     return (
-      <code>{text}</code>
+      <code>{Util.htmldecode(text)}</code>
     );
     // text.replace('\n','') // ??
   };


### PR DESCRIPTION
It uses the same `Util.htmldecode` as is used for the normal text-blocks.