### PR TITLE
Nav root fix

### DIFF
--- a/public-api/vx/note.php
+++ b/public-api/vx/note.php
@@ -34,6 +34,18 @@ switch ( $action ) {
 		$RESPONSE['note'] = noteComplete_GetByNode($ids[0]);
 
 		break; //case 'get': //note/get
+	case 'author': //note/author
+		json_ValidateHTTPMethod('GET');
+
+		$ids = explode('+', json_ArgGet(0));
+
+		if ( count($ids) !== 1 ) {
+			json_EmitFatalError_BadRequest(null, $RESPONSE);
+		}
+
+		$RESPONSE['note'] = noteInComplete_GetByAuthor($ids[0]);
+
+		break; //case 'get': //note/author	
 	case 'add': //note/add
 		json_ValidateHTTPMethod('POST');
 

--- a/src/com/content-nav/nav-root.js
+++ b/src/com/content-nav/nav-root.js
@@ -39,11 +39,9 @@ export default class ContentNavRoot extends Component {
 		var NewPath = '/'+ (extra ? extra.join('/') : '');
 		var PartPath = '/'+ (extra && extra.length ? extra[0] : '');
 		
-		var ShowMyFeed = null;
 		if ( user && user.id ) {
 			if ( NewPath == '/' )
 				NewPath = '/feed';
-			ShowMyFeed = <ContentNavButton path={NewPath} icon='feed' href='/feed'>Feed</ContentNavButton>;
 		}
 		// Default to /news if not logged in
 		else if ( NewPath == '/' ) {
@@ -52,7 +50,7 @@ export default class ContentNavRoot extends Component {
 		
 		return (
 			<div class="content-base content-nav content-nav-root">
-				{ShowMyFeed}
+				<ContentNavButton path={NewPath} icon='feed' href='/feed'>Feed</ContentNavButton>
 				<ContentNavButton path={NewPath} icon='news' href='/news'>News</ContentNavButton>
 				<ContentNavButton path={PartPath} icon='gamepad' href='/games'>Games</ContentNavButton>
 			</div>

--- a/src/shrub/src/note/note_complete.php
+++ b/src/shrub/src/note/note_complete.php
@@ -20,3 +20,25 @@ function noteComplete_GetByNode( $node ) {
 	// it's a shame to do this, but this is how I need the data client side :(
 	return array_values($notes);
 }
+
+function noteInComplete_GetByAuthor( $node ) {
+	$notes = note_GetByAuthor($node);
+	
+	/*
+	$loves = noteLove_CountByNode($node);
+	
+	// Populate Love
+	foreach ( $notes as &$note ) {
+		$note['love'] = 0;
+
+		foreach ( $loves as $love ) {
+			if ( $note['id'] === $love['note'] ) {
+				$note['love'] = $love['count'];
+				$note['love-timestamp'] = $love['timestamp'];
+			}
+		}
+	}
+	*/
+	// it's a shame to do this, but this is how I need the data client side :(
+	return array_values($notes);
+}

--- a/src/shrub/src/note/note_core.php
+++ b/src/shrub/src/note/note_core.php
@@ -173,6 +173,62 @@ function note_GetByNode( $ids ) {
 	return $ret;
 }
 
+function _note_GetByAuthor( $ids ) {
+	$multi = is_array($ids);
+	if ( !$multi )
+		$ids = [$ids];
+	
+	if ( is_array($ids) ) {
+		// Confirm that all IDs are not zero
+		foreach( $ids as $id ) {
+			if ( intval($id) == 0 )
+				return null;
+		}
+
+		// Build IN string
+		$ids_string = implode(',', $ids);
+
+		$ret = db_QueryFetch(
+			"SELECT id, parent, 
+				node, supernode, 
+				author, 
+				".DB_FIELD_DATE('created').",
+				".DB_FIELD_DATE('modified').",
+				version,
+				body
+			FROM ".SH_TABLE_PREFIX.SH_TABLE_NOTE." 
+			WHERE author IN ($ids_string)
+			;"
+		);
+		
+		return $ret;
+	}
+	
+	return null;
+}
+
+function note_GetByAuthor( $ids ) {
+	$notes = _note_GetByAuthor($ids);
+
+	$ret = [];
+
+	if ( is_array($ids) ) {
+		foreach( $ids as $id ) {
+			$ret[$id] = [];
+		}
+	
+		foreach( $notes as &$note ) {
+			$ret[$note['node']][$note['id']] = $note;
+		}
+	}
+	else {
+		foreach( $notes as &$note ) {
+			$ret[$note['id']] = $note;
+		}
+	}
+
+	return $ret;
+}
 
 function note_GetById( $ids ) {
 	$multi = is_array($ids);


### PR DESCRIPTION
Currently if you are not logged in you don't get the `Feed` option in the nav-root.
The feed is available while not logged in.

This adds feed to nav-root independent on being logged in but keeps the previous defaulting behaviour.