### PR TITLE
better games counting

### DIFF
--- a/src/shrub/src/node/node_core.php
+++ b/src/shrub/src/node/node_core.php
@@ -336,7 +336,30 @@ function node_CountByAuthorType( $ids, $authors, $types = null, $subtypes = null
 //				GROUP BY id".($multi?';':' LIMIT 1;'),
 //				...$ARGS
 //			);
-	}
+			$QUERY[] = '`key`=?';
+			$ARGS[] = 'author';
+
+			$pre_query[] = 'b'.$node_query;
+			if ( isset($node_args) ) $ARGS[] = $node_args;
+			
+			$post_query[] = "id IN (SELECT MAX(id) FROM ".SH_TABLE_PREFIX.SH_TABLE_NODE_LINK." GROUP BY a, b, `key`)";
+			$post_query[] = "scope=?";
+			$ARGS[] = 0;
+			
+			$full_query = '';
+			if ( count($QUERY) )
+				$full_query = 'WHERE ('.implode(' AND ', $QUERY).')';
+	
+			$ret = db_QueryFetch(
+				"SELECT
+					a AS id, COUNT(id) AS count
+					".DB_FIELD_DATE('timestamp', 'modified')."
+				FROM ".SH_TABLE_PREFIX.SH_TABLE_NODE_LINK."
+				$full_query
+				;",
+				...$ARGS
+			);
+		}
 		else {
 			$ret = db_QueryFetch(
 				"SELECT author AS id, COUNT(id) AS count


### PR DESCRIPTION
I think this will include games like they are on `/user/games` into the
count given as response to the `/user`, that used to decide if `Games` button
appeared.

__NOTE__: It builds and it can return 0 without an issue in my
test environment, how it works when there are games, I don't
know / need help setting up a fuller test environment some day
after the LD is over.