### PR TITLE
Link checker

### DIFF
--- a/public-api/vx/fun.php
+++ b/public-api/vx/fun.php
@@ -2,7 +2,9 @@
 require_once __DIR__."/../config.php";
 
 include_once __DIR__."/".CONFIG_PATH."config.php";
+
 require_once __DIR__."/".SHRUB_PATH."api.php";
+require_once __DIR__."/".SHRUB_PATH."link/link.php";
 
 json_Begin();
 
@@ -27,6 +29,82 @@ switch ( $action ) {
 		$RESPONSE['message'] = 'This is a sample requiring the GET method';
 
 		break; //case 'get': //fun/get
+
+	case "link": //link/:sub_action/:linkhash
+		/* Sub-actions are:
+			out: For navigating to external page via internal linkhash
+			ping: Test if link responds with header
+			report: Flag a link, e.g. for not responding to ping
+			check: Investigate game link for what a link points to as way to assist user
+			
+			out action should not require being logged in, the other may need 
+			I figure linkhash creation shoul not be part of the public api but part of
+			the behind scenes things that happen when you publish a game page.
+			Pinging could be part of the API though if we want to defer checking for broken links
+			to let user looking at a page invoke ping if hasn't been done for long time.
+		*/
+				
+		$sub_action = json_ArgShift();
+		
+		switch ( $sub_action ) {
+			case 'check':				
+				$user_id = userAuth_GetID();
+				if ($user_id === null) {
+					json_EmitFatalError_Forbidden(null, $RESPONSE);
+				} else {
+					//TODO: should probably only allow post but easier testing with get
+					if ( isset($_POST['uri']) ) {			
+						json_ValidateHTTPMethod('POST');
+						$RESPONSE['link'] = linkComplete_GetFromURI($_POST['uri']);
+					} else if ( isset($_GET['uri']) ) {
+						json_ValidateHTTPMethod('GET');						
+						$RESPONSE['link'] = linkComplete_GetFromURI($_GET['uri']);				
+					} else {
+						json_EmitFatalError_BadRequest(null, $RESPONSE);
+					}
+				}
+				break;
+			case 'ping':
+				$user_id = userAuth_GetID();
+				if ($user_id === null) {
+					json_EmitFatalError_Forbidden(null, $RESPONSE);
+				} else {
+					$linkhash = json_ArgShift();
+					if ($linkhash == null) {
+						json_EmitFatalError_BadRequest(null, $RESPONSE);
+					} else {
+						$ping = link_Ping($linkhash, true);
+						$RESPONSE['message'] = $ping['message'];
+						$RESPONSE['broken'] = $ping['error'];
+					}
+				}
+				break;
+			case 'out':
+				$linkhash = json_ArgShift();
+				if ($linkhash == null) {
+					json_EmitFatalError_BadRequest(null, $RESPONSE);
+				} else {
+					//TODO: Do magic to redirect using link_getExternal and possibly something about setting data
+				}
+				break;
+			case 'report':
+				$user_id = userAuth_GetID();
+				if ($user_id === null) {
+					json_EmitFatalError_Forbidden(null, $RESPONSE);
+				} else {
+					$linkhash = json_ArgShift();
+					if ($linkhash == null) {
+						json_EmitFatalError_BadRequest(null, $RESPONSE);
+					} else {
+						//TODO: Check if $linkhash exists and if so flag it in database and email user perhaps
+					}
+				}
+				break;
+			default:
+				json_EmitFatalError_Forbidden(null, $RESPONSE);
+				break; // default
+		}
+		
 
 	default:
 		json_EmitFatalError_Forbidden(null, $RESPONSE);

--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -1080,7 +1080,7 @@ switch ( $action ) {
 				break; // case 'add': //node/meta/add/:node
 		};
 		break; // case 'meta': //node/meta
-	
+		
 	default:
 		json_EmitFatalError_Forbidden(null, $RESPONSE);
 		break; // default

--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -4,6 +4,7 @@ require_once __DIR__."/../config.php";
 include_once __DIR__."/".CONFIG_PATH."config.php";
 require_once __DIR__."/".SHRUB_PATH."api.php";
 require_once __DIR__."/".SHRUB_PATH."node/node.php";
+require_once __DIR__."/".SHRUB_PATH."link/link.php";
 
 json_Begin();
 
@@ -1080,6 +1081,28 @@ switch ( $action ) {
 				break; // case 'add': //node/meta/add/:node
 		};
 		break; // case 'meta': //node/meta
+	
+	case "external": //node/external/:type/:node_id/
+
+	//TODO:  Add user auth for storing this data
+		
+		//json_ValidateHTTPMethod('POST');
+		
+		$type = json_ArgShift();
+		$node_id = intval(json_ArgShift());
+		$RESPONSE['node'] = $node_id;
+		
+		switch ( $type ) {
+			case 'game_link':
+				if ( isset($_POST['uri']) ) {			
+					$RESPONSE['link'] = linkComplete_GetFromURI($_POST['uri']);
+				} else if ( isset($_GET['uri']) ) {		
+					$RESPONSE['link'] = linkComplete_GetFromURI($_GET['uri']);				
+				} else {
+					json_EmitFatalError_BadRequest(null, $RESPONSE);
+				}
+				break;
+		}
 		
 	default:
 		json_EmitFatalError_Forbidden(null, $RESPONSE);

--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -4,7 +4,6 @@ require_once __DIR__."/../config.php";
 include_once __DIR__."/".CONFIG_PATH."config.php";
 require_once __DIR__."/".SHRUB_PATH."api.php";
 require_once __DIR__."/".SHRUB_PATH."node/node.php";
-require_once __DIR__."/".SHRUB_PATH."link/link.php";
 
 json_Begin();
 
@@ -1082,28 +1081,6 @@ switch ( $action ) {
 		};
 		break; // case 'meta': //node/meta
 	
-	case "external": //node/external/:type/:node_id/
-
-	//TODO:  Add user auth for storing this data
-		
-		//json_ValidateHTTPMethod('POST');
-		
-		$type = json_ArgShift();
-		$node_id = intval(json_ArgShift());
-		$RESPONSE['node'] = $node_id;
-		
-		switch ( $type ) {
-			case 'game_link':
-				if ( isset($_POST['uri']) ) {			
-					$RESPONSE['link'] = linkComplete_GetFromURI($_POST['uri']);
-				} else if ( isset($_GET['uri']) ) {		
-					$RESPONSE['link'] = linkComplete_GetFromURI($_GET['uri']);				
-				} else {
-					json_EmitFatalError_BadRequest(null, $RESPONSE);
-				}
-				break;
-		}
-		
 	default:
 		json_EmitFatalError_Forbidden(null, $RESPONSE);
 		break; // default

--- a/src/shrub/src/link/link.php
+++ b/src/shrub/src/link/link.php
@@ -5,6 +5,8 @@ require_once __DIR__."/link_util.php";
 require_once __DIR__."/link_itchio.php";
 require_once __DIR__."/link_gamejolt.php";
 require_once __DIR__."/link_dropbox.php";
+require_once __DIR__."/link_github.php";
+require_once __DIR__."/link_googledrive.php";
 
 
 function linkComplete_GetFromURI( $uri) {
@@ -35,7 +37,30 @@ function linkComplete_GetFromURI( $uri) {
 			if (!$broken) {
 				$contents = link_ScrapeDropbox($html, $link);
 			}
-		
+		} else if ($link['domain'] == 'github.com'){
+			//Github source
+			$contents = link_GitHubLinkAsReleaseDownload($link);
+				if ($contents === null) {
+				$html = file_get_html($link['full']);
+				$broken = is_null($html) || trim($html) === '';
+				if (!$broken) {
+					$contents = link_GitHub($html, $link);
+				}
+			}
+		} else if ($link['domain'] == 'github.io') {
+			//Github pages
+			$html = file_get_html($link['full']);
+			$broken = is_null($html) || trim($html) === '';
+			if (!$broken) {
+				$contents = link_GitHubPages($html, $link);
+			}
+		} else if (explode('.', $link['domain'])[0] === 'google' && $link['subdomain'] === 'drive') {
+			$html = file_get_html($link['full']);
+			$broken = is_null($html) || trim($html) === '';
+			if (!$broken) {
+				$contents = link_GoogleDrive($html, $link);
+			}
+			//$contents['text'] = file_get_contents($uri);
 		} else {
 			
 			//Guessing

--- a/src/shrub/src/link/link.php
+++ b/src/shrub/src/link/link.php
@@ -14,9 +14,15 @@ function linkComplete_GetFromURI( $uri) {
 
 	$link = link_Parse($uri);
 	$contents = null;
-	$broken = false;
+
+	$headers = get_headers($link['full'], 1);
+	if (is_null($headers) || count($headers) === 0 || strpos($headers['0'], '200') === false) {
+		$broken = true;
+	} else {
+		$broken = false;
+	}
 	
-	if ($link['valid']) {
+	if (!$broken && $link['valid']) {
 
 		if ($link['domain'] == 'itch.io') {
 			$html = file_get_html($link['full']);
@@ -102,6 +108,7 @@ function linkComplete_GetFromURI( $uri) {
 			}
 			$contents['user-page'] = null;
 			$contents['provider-name'] = 'Custom Site';
+			
 		}
 	}
 	

--- a/src/shrub/src/link/link.php
+++ b/src/shrub/src/link/link.php
@@ -1,0 +1,63 @@
+<?PHP
+require_once __DIR__."/simple_html_dom.php";
+require_once __DIR__."/link_util.php";
+
+require_once __DIR__."/link_itchio.php";
+require_once __DIR__."/link_gamejolt.php";
+require_once __DIR__."/link_dropbox.php";
+
+
+function linkComplete_GetFromURI( $uri) {
+
+	$link = link_Parse($uri);
+	$contents = null;
+	$broken = false;
+	
+	if ($link['valid']) {
+
+		if ($link['domain'] == 'itch.io') {
+			$html = file_get_html($link['full']);
+			$broken = is_null($html) || trim($html) === '';
+			if (!$broken) {
+				$contents = link_ScrapeItchIO($html, $link);
+			}
+		} else if ($link['domain'] == 'gamejolt.com') {
+			$uri = link_getGameJoltDataLink($link);
+			$text = file_get_contents($uri);
+			$broken = is_null($text) || trim($text) === '';
+			if (!$broken) {
+				$json = json_decode($text, true);
+				$contents = link_ParseGameJolt($json, $link);
+			}
+		}  else if ($link['domain'] == 'dropbox.com') {
+			$html = file_get_html($link['full']);
+			$broken = is_null($html) || trim($html) === '';
+			if (!$broken) {
+				$contents = link_ScrapeDropbox($html, $link);
+			}
+		
+		} else {
+			
+			//Guessing
+			$platforms = link_GuessPlatforms($link['full']);
+			if (count($platforms)) {
+				$item = null;
+				$item['platforms'] = $platforms;
+				$contents['items'][] = $item;
+			} else {
+				$contents['items'] = null;
+			}
+			$contents['user-page'] = null;
+			$contents['provider-name'] = 'Custom Site';
+		}
+	}
+	
+	$results['link'] = $link;
+	$results['link-broken'] = $broken;
+	$results['contents'] = $contents;
+	return $results;
+}
+
+
+
+?>

--- a/src/shrub/src/link/link.php
+++ b/src/shrub/src/link/link.php
@@ -10,17 +10,43 @@ require_once __DIR__."/link_googledrive.php";
 require_once __DIR__."/link_newgrounds.php";
 
 
+function link_getExternal( $linkHash ) {
+	//TODO: Implement database thing
+	return 'http://www.ldjam.com';
+}
+
+function link_Ping( $linkHash, $isHash ) {
+	
+	if ($isHash === true) {
+		$uri = link_getExternal($linkHash);
+	} else {
+		$uri = $linkHash;
+	}
+	if ($uri === null) {
+		$ping['error'] = true;
+		$ping['message'] = 'Unknown hash';
+	}
+	$headers = get_headers($uri, 1);
+	if (is_null($headers) || count($headers) === 0) {
+		$ping['error'] = true;
+		$ping['message'] = 'No response';
+	} else if (strpos($headers['0'], '200') === false) {
+		$ping['error'] = true;
+		$ping['message'] = $headers['0'];
+	} else {
+		$ping['error'] = false;
+		$ping['message'] = $headers['0'];		
+	}
+	return $ping;
+}
+
 function linkComplete_GetFromURI( $uri) {
 
 	$link = link_Parse($uri);
 	$contents = null;
 
-	$headers = get_headers($link['full'], 1);
-	if (is_null($headers) || count($headers) === 0 || strpos($headers['0'], '200') === false) {
-		$broken = true;
-	} else {
-		$broken = false;
-	}
+	$ping = link_Ping($link['full'], false);
+	$broken = $ping['error'];
 	
 	if (!$broken && $link['valid']) {
 

--- a/src/shrub/src/link/link_dropbox.php
+++ b/src/shrub/src/link/link_dropbox.php
@@ -16,4 +16,10 @@ function link_ScrapeDropbox( $html, $link ) {
 
 }
 
+function link_DropboxDownloadLink( $link ) {
+	
+	return $link['without_params'] . '?dl=1';
+	
+}
+
 ?>

--- a/src/shrub/src/link/link_dropbox.php
+++ b/src/shrub/src/link/link_dropbox.php
@@ -1,0 +1,19 @@
+<?PHP
+require_once __DIR__."/link_util.php";
+
+function link_ScrapeDropbox( $html, $link ) {
+	$item['version'] = null;
+		//substr($html -> find('.preview-box', 0) -> children(0) -> getAttribute('class'), 9);
+	$item['name'] = $html -> find('title', 0) -> innertext;
+	$item['platforms'] = link_GuessPlatforms($item['name']);
+	
+	$items[] = $item;
+	$response['items'] = $items;
+	$response['user-page'] = implode(".", [$link['subdomain'], $link['domain']]);
+	$response['provider-name'] = 'Dropbox';
+	
+	return $response;
+
+}
+
+?>

--- a/src/shrub/src/link/link_gamejolt.php
+++ b/src/shrub/src/link/link_gamejolt.php
@@ -1,0 +1,96 @@
+<?PHP
+require_once __DIR__."/link_util.php";
+
+function link_getGameJoltDataLink($link) {
+	$parts = explode('/', $link['without_params']);
+	$last = count($parts) - 1;
+	if (trim($parts[$last]) === '') {
+		$game_id = $parts[$last - 1];
+	} else {
+		$game_id = $parts[$last];
+	}
+	$uri = 'https://gamejolt.com/site-api/web/discover/games/' . $game_id;
+	
+	return $uri;
+}
+
+function link_ParseGameJolt($json, $link) {
+	$user = $json['payload']['game']['developer']['url'];
+	$response['items'] = array();
+	
+	$item['name'] = $json['payload']['game']['title'];
+	$platforms = array();
+	
+	foreach($json['payload']['game']['compatibility'] as $compat => $val) {
+		if ($val === true && substr($compat, 0, 3) === 'os_') {			
+			$platform = link_resolvePlaformAlias(explode('_', $compat)[1]);
+			if ($platform !== null) {
+				array_push($platforms, $platform);
+			}
+		} else if ($val === true && $compat == 'type_html') {
+			$web_item['platforms'] = [link_resolvePlaformAlias('html')];
+			$web_item['name'] = $json['payload']['game']['title'];
+			$web_item['valid'] = true;
+			$web_item['uri'] = null;
+			$web_item['version'] = $json['payload']['game']['modified_on'];			
+			array_push($response['items'], $web_item);
+		}
+	}
+	if (count($platforms) === 0) {
+		$item['error-message'] = 'You have not specified platforms on Game Jolt. Please fix this.';
+		$item['valid'] = false;
+	} else {
+		$item['platforms'] = $platforms;
+		$item['valid'] = false;
+	}
+	$item['version'] = $json['payload']['game']['modified_on'];
+	array_push($response['items'], $item);
+	$response['user-page'] = implode("", ["gamejolt.com", $user]);
+	$response['provider-name'] = 'Game Jolt';
+
+	return $response;
+}
+
+function link_ScrapeGameJolt( $html, $link ) {
+	
+	//TODO: Handle lazy loading? Or just don't care about gamejolt?
+	
+	//Releases
+	$items = array();
+	foreach($html->find('gj-game-package-card') as $release) {	
+		$name = $release -> find('.card-title', 0) -> children(0) -> innertext;
+		
+		foreach($release -> find('button') as $button) {
+			$item = null;
+			$item['uri'] = null;
+			$item['name'] = $name;
+			$item['version'] = null; 
+			$item['platforms'] = array();
+			
+			foreach($button -> find('span') as $platform) {
+				if (strpos($platform -> innertext, 'html5' )) {
+					array_push($item['platforms'], link_resolvePlaformAlias('html5'));
+				} else if (strpos($platform -> innertext, 'html5' )) {
+					array_push($item['platforms'], link_resolvePlaformAlias('windows'));
+				}
+
+			}
+			
+			if (count($item['platforms']) === 0) {
+				$item['error-message'] = 'You have forgotten to mark download type on your game on itch.io. Please fix this.';
+				$item['valid'] = false;
+			} else {
+				$item['valid'] = true;
+			}
+			
+			array_push($items, $item);
+		}
+	}
+	$user = '';
+	$response['items'] = $items;
+	$response['user-page'] = implode("/", ["gamejolt.com", $user]);
+	$response['provider-name'] = 'Game Jolt';
+
+	return $response;
+}
+?>

--- a/src/shrub/src/link/link_github.php
+++ b/src/shrub/src/link/link_github.php
@@ -1,0 +1,71 @@
+<?PHP
+require_once __DIR__."/link_util.php";
+
+function link_GitHubPages( $html, $link ) {
+	$item['version'] = null;		
+	$item['name'] = $html -> find('title', 0) -> innertext;
+	$item['platforms'] = [link_resolvePlaformAlias('web')];
+	$item['valid'] = true;
+	
+	$items[] = $item;
+	$response['items'] = $items;
+	//$response['user-page'] = implode(".", [$link['subdomain'], $link['domain']]);
+	$response['provider-name'] = 'GitHub';
+	
+	return $response;
+	
+}
+
+function link_GitHub( $html, $link ) {
+	
+	$rel_parts = explode('/', $link['relative']);
+	
+	$items = array();
+	if (count($rel_parts) > 3 && $rel_parts[3] == 'releases') {
+		//Release
+		$tag = $html -> find('.tag-references', 0) -> children(0) -> children(0) -> href;
+		$tag = explode('/', $tag);
+		$version = $tag;
+		foreach($html -> find('.release-downloads', 0) -> find("li") as $downloads) {
+			$item = null;
+			$item['name'] = $downloads -> find('a', 0) -> find('strong', 0) -> innertext;
+			$item['platforms'] = link_GuessPlatforms($item['name']);			
+			$item['version'] = $tag[count($tag) - 1];
+			$item['valid'] = count($item['platforms']) > 0;
+			array_push($items, $item);
+		}
+		
+	} else {
+		//Source
+		$item['name'] = $html -> find('title', 0) -> innertext;
+		$item['version'] = trim($html -> find('.commit-tease-sha', 0) -> innertext);	
+		$item['platforms'] = [link_resolvePlaformAlias('source')];
+		$item['valid'] = true;
+		$items[] = $item;
+	}
+	
+	$response['items'] = $items;
+	$response['user-page'] = $link['protocol'] . implode(".", [$link['subdomain'], $link['domain']]) . '/' . explode('/', $link['relative'])[1];
+	$response['provider-name'] = 'GitHub';
+	
+	return $response;
+	
+}
+
+function link_GitHubLinkAsReleaseDownload($link) {
+	$rel_parts = explode('/', $link['relative']);
+	if (count($rel_parts) === 7 && $rel_parts[3] === 'releases' && $rel_parts[4] === 'download') {
+		$item['version'] = $rel_parts[5];		
+		$item['name'] = $rel_parts[6];
+		$item['platforms'] = link_GuessPlatforms($item['name']);
+		$item['valid'] = count($item['platforms']) > 0;
+		
+		$items[] = $item;
+		$response['items'] = $items;
+		$response['user-page'] = $link['protocol'] . implode(".", [$link['subdomain'], $link['domain']]) . "/" . $rel_parts[1];
+		$response['provider-name'] = 'GitHub';
+		
+		return $response;
+	}
+}
+?>

--- a/src/shrub/src/link/link_googledrive.php
+++ b/src/shrub/src/link/link_googledrive.php
@@ -1,0 +1,19 @@
+<?PHP
+require_once __DIR__."/link_util.php";
+
+function link_GoogleDrive( $html, $link ) {
+	$item['version'] = link_GetParamValue($link['params'], 'id');		
+	$title = $html -> find('title', 0) -> innertext;	
+	$item['name'] = substr($title, 0, count($title) - 16);
+	//$item['platforms'] = [link_resolvePlaformAlias('web')];
+	$item['valid'] = false;
+	
+	$items[] = $item;
+	$response['items'] = $items;
+	//$response['user-page'] = implode(".", [$link['subdomain'], $link['domain']]);
+	$response['provider-name'] = 'Google Drive';
+	
+	return $response;
+	
+}
+?>

--- a/src/shrub/src/link/link_itchio.php
+++ b/src/shrub/src/link/link_itchio.php
@@ -1,0 +1,58 @@
+<?PHP
+require_once __DIR__."/link_util.php";
+
+function link_ScrapeItchIO( $html, $link ) {
+	
+	//Downloads
+	$items = array();
+	foreach($html->find('.upload') as $downloadable) {
+		$item = null;
+		$dl_link = $downloadable->find('a', 0);
+		
+		$item['name'] = $downloadable->find('.upload_name', 0)->find('strong', 0)->innertext;
+		$item['platforms'] = array();
+		
+		if ($dl_link === null) {
+			//This is a priced result
+			$item['uri'] = null;
+		} else {
+			
+			//This is a free result
+			$item['version'] =  $dl_link -> getAttribute('data-upload_id');
+			$game_link = link_Parse($dl_link -> href);
+			$item['uri'] = $game_link['valid'] ? $game_link['original'] : null;
+		}
+
+		foreach ($downloadable->find('.download_platforms', 0) -> children() as $platform) {
+			$platform_name = link_resolvePlaformAlias(substr($platform->getAttribute('title'), 13));
+			if ($platform_name !== false) {
+				array_push($item['platforms'], $platform_name);
+			}
+		}
+		if (count($item['platforms']) === 0) {
+			$item['error-message'] = 'You have forgotten to mark download type on your game on itch.io. Please fix this.';
+			$item['valid'] = false;
+		} else {
+			$item['valid'] = true;
+		}
+
+		array_push($items, $item);
+	}
+	
+	//Web
+	$web = $html->find('div.game_frame');
+	if (count($web) === 1) {
+		$item = null;
+		$item['name'] = ''; //TODO: How to resolve naming, needed?
+		$item['version'] = null; //TODO: Unclear if any
+		$item['platforms'][] =  link_resolvePlaformAlias('webGL');
+		array_push($items, $item);
+	}
+	
+	$response['items'] = $items;
+	$response['user-page'] = implode(".", [$link['subdomain'], $link['domain']]);
+	$response['provider-name'] = 'Itch.io';
+	
+	return $response;
+}
+?>

--- a/src/shrub/src/link/link_newgrounds.php
+++ b/src/shrub/src/link/link_newgrounds.php
@@ -1,0 +1,20 @@
+<?PHP
+require_once __DIR__."/link_util.php";
+
+function link_NewGrounds( $html, $link ) {
+	
+	$items = array();
+	$item['version'] = null;
+	$item['name'] = $html -> find('title', 0) -> innertext;
+	$item['platforms'] = link_resolvePlaformAlias('web');
+	$items[] = $item;		
+	
+	$response['items'] = $items;
+	$response['user-page'] = $html -> find('.authorlinks', 0) -> find('a', 0) -> href;
+	$response['provider-name'] = 'Kongregate';
+	
+	return $response;
+
+}
+
+?>

--- a/src/shrub/src/link/link_util.php
+++ b/src/shrub/src/link/link_util.php
@@ -24,7 +24,10 @@ function link_resolvePlaformAlias($platform) {
 }
 
 function link_GuessPlatforms($text) {
-	if (strpos($text, '.jar') !== false) {
+
+	$lowertext = strtolower($text);
+
+	if (strpos($lowertext, '.jar') !== false) {
 		return [
 			link_resolvePlaformAlias('windows'),
 			link_resolvePlaformAlias('macOS'),
@@ -32,8 +35,11 @@ function link_GuessPlatforms($text) {
 		];
 	}
 
+	if (strpos($lowertext, '.apk') === count($lowertext) - 4) {
+		return [link_resolvePlaformAlias('android')];
+	}
+
 	$platforms = array();
-	$lowertext = strtolower($text);
 	
 	if (strpos($lowertext, 'win') !== false) {
 		array_push($platforms, link_resolvePlaformAlias('windows'));
@@ -125,10 +131,13 @@ function link_Parse( $uri, $default_protocol = 'http://' ) {
 	$params_start = strpos($uri, '?');
 	if ($params_start === false) {
 		$params = null;
-		$without_params = $uri;
+		$without_params = $full_uri;
 	} else {
 		$params = substr($uri, $params_start + 1);
 		$without_params = substr($uri, 0, $params_start);
+		if (strpos($without_params, $protocol) === false) {
+			$without_params = $protocol . $without_params;
+		}
 		if ($relative !== null) {
 			$relative = substr($relative, 0, strpos($relative, '?'));
 		}
@@ -154,6 +163,10 @@ function link_GetParamValue($params, $key) {
 			return $kvp[1];
 		}		
 	}
+}
+
+function link_NoContent($text) {
+	return is_null($text) || trim($text) === '';
 }
 
 ?>

--- a/src/shrub/src/link/link_util.php
+++ b/src/shrub/src/link/link_util.php
@@ -1,0 +1,131 @@
+<?
+
+function link_resolvePlaformAlias($platform) {
+	$platform = strtolower(trim($platform));
+	
+	switch($platform) {
+		case "win":
+		case "windows":
+			return "Windows";
+		case "mac":
+		case "macos":
+			return "macOS";
+		case "linux":
+			return "Linux";
+		case "web":
+		case "webgl":
+		case "html":
+			return "webGL";
+		case "android":
+			return "Android";
+	}
+}
+
+function link_GuessPlatforms($text) {
+	if (strpos($text, '.jar') !== false) {
+		return [
+			link_resolvePlaformAlias('windows'),
+			link_resolvePlaformAlias('macOS'),
+			link_resolvePlaformAlias('linux')
+		];
+	}
+
+	$platforms = array();
+	
+	if (strpos(strtolower($text), 'win') !== false) {
+		array_push($platforms, link_resolvePlaformAlias('windows'));
+	}
+	if (strpos(strtolower($text), 'mac') !== false) {
+		array_push($platforms, link_resolvePlaformAlias('macOS'));
+	}
+	if (strpos(strtolower($text), 'linux') !== false) {
+		array_push($platforms, link_resolvePlaformAlias('linux'));
+	}
+	if (strpos(strtolower($text), 'android') !== false) {
+		array_push($platforms, link_resolvePlaformAlias('android'));
+	}
+	
+	return $platforms;
+}
+
+function link_Parse( $uri, $default_protocol = 'http://' ) {
+	$protocol_end = strpos($uri, '://');
+	$valid = true;
+	if ($protocol_end === false) {
+		$protocol = $default_protocol;
+		$domain_start = 0;
+		$full_uri = $protocol . $uri;
+	} else {
+		$protocol = substr($uri, 0, $protocol_end + 3);
+		$domain_start = $protocol_end + 3;
+		$full_uri = $uri;
+	}
+	
+	$domain_end = strpos($uri, '/', $domain_start);
+	
+	if ($domain_end === false) {
+		$domain = null;
+		$subdomain = null;
+		$valid = false;
+	} else {
+		$domain_parts = explode('.', substr($uri, $domain_start, $domain_end - $domain_start));
+		$n_parts = count($domain_parts);
+		switch ($n_parts) {
+			case 1:
+				$domain = null;
+				$subdomain = null;
+				$valid = false;
+				break;
+			case 2:
+				$domain = implode('.', $domain_parts);
+				$subdomain = null;
+				break;
+			case 3:
+				if ($domain_parts[$n_parts - 2] === 'co' && $domain_parts[$n_parts - 1] === 'uk') {
+					$domain = implode('.', $domain_parts);
+					$subdomain = null;
+				} else {
+					$domain = implode('.', array_slice($domain_parts, 1));
+					$subdomain = $domain_parts[0];
+				}
+				break;
+			case 4:
+				if ($domain_parts[$n_parts - 2] === 'co' && $domain_parts[$n_parts - 1] === 'uk') {
+					$domain = implode('.', array_slice($domain_parts, 1));
+					$subdomain = $domain_parts[0];
+				} else {
+					$domain = implode('.', array_slice($domain_parts, 1));
+					$subdomain = $domain_parts[0];
+					$valid = false;										
+				}
+				break;
+			default:
+				$domain = implode('.', array_slice($domain_parts, 1));
+				$subdomain = $domain_parts[0];
+				$valid = false;										
+				break;		
+		}
+	}
+
+	$params_start = strpos($uri, '?');
+	if ($params_start === false) {
+		$params = null;
+		$without_params = $uri;
+	} else {
+		$params = substr($uri, $params_start + 1);
+		$without_params = substr($uri, 0, $params_start);
+	}
+	
+	$link['valid'] = $valid;
+	$link['protocol'] = $protocol;
+	$link['domain'] = $domain;
+	$link['subdomain'] = $subdomain;
+	$link['original'] = $uri;
+	$link['full'] = $full_uri;
+	$link['params'] = $params;
+	$link['without_params'] = $without_params;
+	return $link;
+	
+}
+
+?>

--- a/src/shrub/src/link/link_util.php
+++ b/src/shrub/src/link/link_util.php
@@ -18,6 +18,8 @@ function link_resolvePlaformAlias($platform) {
 			return "webGL";
 		case "android":
 			return "Android";
+		case "source":
+			return "Source";
 	}
 }
 
@@ -31,18 +33,28 @@ function link_GuessPlatforms($text) {
 	}
 
 	$platforms = array();
+	$lowertext = strtolower($text);
 	
-	if (strpos(strtolower($text), 'win') !== false) {
+	if (strpos($lowertext, 'win') !== false) {
 		array_push($platforms, link_resolvePlaformAlias('windows'));
 	}
-	if (strpos(strtolower($text), 'mac') !== false) {
+	if (strpos($lowertext, 'mac') !== false) {
 		array_push($platforms, link_resolvePlaformAlias('macOS'));
 	}
-	if (strpos(strtolower($text), 'linux') !== false) {
+	if (strpos($lowertext, 'linux') !== false) {
 		array_push($platforms, link_resolvePlaformAlias('linux'));
 	}
-	if (strpos(strtolower($text), 'android') !== false) {
+	if (strpos($lowertext, 'android') !== false) {
 		array_push($platforms, link_resolvePlaformAlias('android'));
+	}
+	
+	if (count($platforms) === 0) {
+		if (strpos($lowertext, 'web') !== false || strpos($lowertext, 'html') !== false){ 
+			array_push($platforms, link_resolvePlaformAlias('web'));
+		}
+		if (strpos($lowertext, 'source') !== false){ 
+			array_push($platforms, link_resolvePlaformAlias('source'));
+		}
 	}
 	
 	return $platforms;
@@ -62,6 +74,7 @@ function link_Parse( $uri, $default_protocol = 'http://' ) {
 	}
 	
 	$domain_end = strpos($uri, '/', $domain_start);
+	$relative = null;	
 	
 	if ($domain_end === false) {
 		$domain = null;
@@ -105,6 +118,8 @@ function link_Parse( $uri, $default_protocol = 'http://' ) {
 				$valid = false;										
 				break;		
 		}
+		
+		$relative = substr($uri, $domain_end);
 	}
 
 	$params_start = strpos($uri, '?');
@@ -114,6 +129,9 @@ function link_Parse( $uri, $default_protocol = 'http://' ) {
 	} else {
 		$params = substr($uri, $params_start + 1);
 		$without_params = substr($uri, 0, $params_start);
+		if ($relative !== null) {
+			$relative = substr($relative, 0, strpos($relative, '?'));
+		}
 	}
 	
 	$link['valid'] = $valid;
@@ -122,10 +140,20 @@ function link_Parse( $uri, $default_protocol = 'http://' ) {
 	$link['subdomain'] = $subdomain;
 	$link['original'] = $uri;
 	$link['full'] = $full_uri;
+	$link['relative'] = $relative;
 	$link['params'] = $params;
 	$link['without_params'] = $without_params;
-	return $link;
-	
+	return $link;	
+}
+
+function link_GetParamValue($params, $key) {
+	$params = explode('+', $params);
+	foreach($params as $value) {		
+		$kvp = explode('=', $value);		
+		if ($kvp[0] === $key) {
+			return $kvp[1];
+		}		
+	}
 }
 
 ?>

--- a/src/shrub/src/link/simple_html_dom.php
+++ b/src/shrub/src/link/simple_html_dom.php
@@ -1,0 +1,1721 @@
+<?php
+/**
+ * Website: http://sourceforge.net/projects/simplehtmldom/
+ * Acknowledge: Jose Solorzano (https://sourceforge.net/projects/php-html/)
+ * Contributions by:
+ *     Yousuke Kumakura (Attribute filters)
+ *     Vadim Voituk (Negative indexes supports of "find" method)
+ *     Antcs (Constructor with automatically load contents either text or file/url)
+ *
+ * all affected sections have comments starting with "PaperG"
+ *
+ * Paperg - Added case insensitive testing of the value of the selector.
+ * Paperg - Added tag_start for the starting index of tags - NOTE: This works but not accurately.
+ *  This tag_start gets counted AFTER \r\n have been crushed out, and after the remove_noice calls so it will not reflect the REAL position of the tag in the source,
+ *  it will almost always be smaller by some amount.
+ *  We use this to determine how far into the file the tag in question is.  This "percentage will never be accurate as the $dom->size is the "real" number of bytes the dom was created from.
+ *  but for most purposes, it's a really good estimation.
+ * Paperg - Added the forceTagsClosed to the dom constructor.  Forcing tags closed is great for malformed html, but it CAN lead to parsing errors.
+ * Allow the user to tell us how much they trust the html.
+ * Paperg add the text and plaintext to the selectors for the find syntax.  plaintext implies text in the innertext of a node.  text implies that the tag is a text node.
+ * This allows for us to find tags based on the text they contain.
+ * Create find_ancestor_tag to see if a tag is - at any level - inside of another specific tag.
+ * Paperg: added parse_charset so that we know about the character set of the source document.
+ *  NOTE:  If the user's system has a routine called get_last_retrieve_url_contents_content_type availalbe, we will assume it's returning the content-type header from the
+ *  last transfer or curl_exec, and we will parse that and use it in preference to any other method of charset detection.
+ *
+ * Found infinite loop in the case of broken html in restore_noise.  Rewrote to protect from that.
+ * PaperG (John Schlick) Added get_display_size for "IMG" tags.
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author S.C. Chen <me578022@gmail.com>
+ * @author John Schlick
+ * @author Rus Carroll
+ * @version 1.5 ($Rev: 196 $)
+ * @package PlaceLocalInclude
+ * @subpackage simple_html_dom
+ */
+
+/**
+ * All of the Defines for the classes below.
+ * @author S.C. Chen <me578022@gmail.com>
+ */
+define('HDOM_TYPE_ELEMENT', 1);
+define('HDOM_TYPE_COMMENT', 2);
+define('HDOM_TYPE_TEXT',    3);
+define('HDOM_TYPE_ENDTAG',  4);
+define('HDOM_TYPE_ROOT',    5);
+define('HDOM_TYPE_UNKNOWN', 6);
+define('HDOM_QUOTE_DOUBLE', 0);
+define('HDOM_QUOTE_SINGLE', 1);
+define('HDOM_QUOTE_NO',     3);
+define('HDOM_INFO_BEGIN',   0);
+define('HDOM_INFO_END',     1);
+define('HDOM_INFO_QUOTE',   2);
+define('HDOM_INFO_SPACE',   3);
+define('HDOM_INFO_TEXT',    4);
+define('HDOM_INFO_INNER',   5);
+define('HDOM_INFO_OUTER',   6);
+define('HDOM_INFO_ENDSPACE',7);
+define('DEFAULT_TARGET_CHARSET', 'UTF-8');
+define('DEFAULT_BR_TEXT', "\r\n");
+define('DEFAULT_SPAN_TEXT', " ");
+define('MAX_FILE_SIZE', 600000);
+// helper functions
+// -----------------------------------------------------------------------------
+// get html dom from file
+// $maxlen is defined in the code as PHP_STREAM_COPY_ALL which is defined as -1.
+function file_get_html($url, $use_include_path = false, $context=null, $offset = -1, $maxLen=-1, $lowercase = true, $forceTagsClosed=true, $target_charset = DEFAULT_TARGET_CHARSET, $stripRN=true, $defaultBRText=DEFAULT_BR_TEXT, $defaultSpanText=DEFAULT_SPAN_TEXT)
+{
+    // We DO force the tags to be terminated.
+    $dom = new simple_html_dom(null, $lowercase, $forceTagsClosed, $target_charset, $stripRN, $defaultBRText, $defaultSpanText);
+    // For sourceforge users: uncomment the next line and comment the retreive_url_contents line 2 lines down if it is not already done.
+    $contents = file_get_contents($url, $use_include_path, $context, $offset);
+    // Paperg - use our own mechanism for getting the contents as we want to control the timeout.
+    //$contents = retrieve_url_contents($url);
+    if (empty($contents) || strlen($contents) > MAX_FILE_SIZE)
+    {
+        return false;
+    }
+    // The second parameter can force the selectors to all be lowercase.
+    $dom->load($contents, $lowercase, $stripRN);
+    return $dom;
+}
+
+// get html dom from string
+function str_get_html($str, $lowercase=true, $forceTagsClosed=true, $target_charset = DEFAULT_TARGET_CHARSET, $stripRN=true, $defaultBRText=DEFAULT_BR_TEXT, $defaultSpanText=DEFAULT_SPAN_TEXT)
+{
+    $dom = new simple_html_dom(null, $lowercase, $forceTagsClosed, $target_charset, $stripRN, $defaultBRText, $defaultSpanText);
+    if (empty($str) || strlen($str) > MAX_FILE_SIZE)
+    {
+        $dom->clear();
+        return false;
+    }
+    $dom->load($str, $lowercase, $stripRN);
+    return $dom;
+}
+
+// dump html dom tree
+function dump_html_tree($node, $show_attr=true, $deep=0)
+{
+    $node->dump($node);
+}
+
+
+/**
+ * simple html dom node
+ * PaperG - added ability for "find" routine to lowercase the value of the selector.
+ * PaperG - added $tag_start to track the start position of the tag in the total byte index
+ *
+ * @package PlaceLocalInclude
+ */
+class simple_html_dom_node
+{
+    public $nodetype = HDOM_TYPE_TEXT;
+    public $tag = 'text';
+    public $attr = array();
+    public $children = array();
+    public $nodes = array();
+    public $parent = null;
+    // The "info" array - see HDOM_INFO_... for what each element contains.
+    public $_ = array();
+    public $tag_start = 0;
+    private $dom = null;
+
+    function __construct($dom)
+    {
+        $this->dom = $dom;
+        $dom->nodes[] = $this;
+    }
+
+    function __destruct()
+    {
+        $this->clear();
+    }
+
+    function __toString()
+    {
+        return $this->outertext();
+    }
+
+    // clean up memory due to php5 circular references memory leak...
+    function clear()
+    {
+        $this->dom = null;
+        $this->nodes = null;
+        $this->parent = null;
+        $this->children = null;
+    }
+
+    // dump node's tree
+    function dump($show_attr=true, $deep=0)
+    {
+        $lead = str_repeat('    ', $deep);
+
+        echo $lead.$this->tag;
+        if ($show_attr && count($this->attr)>0)
+        {
+            echo '(';
+            foreach ($this->attr as $k=>$v)
+                echo "[$k]=>\"".$this->$k.'", ';
+            echo ')';
+        }
+        echo "\n";
+
+        if ($this->nodes)
+        {
+            foreach ($this->nodes as $c)
+            {
+                $c->dump($show_attr, $deep+1);
+            }
+        }
+    }
+
+
+    // Debugging function to dump a single dom node with a bunch of information about it.
+    function dump_node($echo=true)
+    {
+
+        $string = $this->tag;
+        if (count($this->attr)>0)
+        {
+            $string .= '(';
+            foreach ($this->attr as $k=>$v)
+            {
+                $string .= "[$k]=>\"".$this->$k.'", ';
+            }
+            $string .= ')';
+        }
+        if (count($this->_)>0)
+        {
+            $string .= ' $_ (';
+            foreach ($this->_ as $k=>$v)
+            {
+                if (is_array($v))
+                {
+                    $string .= "[$k]=>(";
+                    foreach ($v as $k2=>$v2)
+                    {
+                        $string .= "[$k2]=>\"".$v2.'", ';
+                    }
+                    $string .= ")";
+                } else {
+                    $string .= "[$k]=>\"".$v.'", ';
+                }
+            }
+            $string .= ")";
+        }
+
+        if (isset($this->text))
+        {
+            $string .= " text: (" . $this->text . ")";
+        }
+
+        $string .= " HDOM_INNER_INFO: '";
+        if (isset($node->_[HDOM_INFO_INNER]))
+        {
+            $string .= $node->_[HDOM_INFO_INNER] . "'";
+        }
+        else
+        {
+            $string .= ' NULL ';
+        }
+
+        $string .= " children: " . count($this->children);
+        $string .= " nodes: " . count($this->nodes);
+        $string .= " tag_start: " . $this->tag_start;
+        $string .= "\n";
+
+        if ($echo)
+        {
+            echo $string;
+            return;
+        }
+        else
+        {
+            return $string;
+        }
+    }
+
+    // returns the parent of node
+    // If a node is passed in, it will reset the parent of the current node to that one.
+    function parent($parent=null)
+    {
+        // I am SURE that this doesn't work properly.
+        // It fails to unset the current node from it's current parents nodes or children list first.
+        if ($parent !== null)
+        {
+            $this->parent = $parent;
+            $this->parent->nodes[] = $this;
+            $this->parent->children[] = $this;
+        }
+
+        return $this->parent;
+    }
+
+    // verify that node has children
+    function has_child()
+    {
+        return !empty($this->children);
+    }
+
+    // returns children of node
+    function children($idx=-1)
+    {
+        if ($idx===-1)
+        {
+            return $this->children;
+        }
+        if (isset($this->children[$idx])) return $this->children[$idx];
+        return null;
+    }
+
+    // returns the first child of node
+    function first_child()
+    {
+        if (count($this->children)>0)
+        {
+            return $this->children[0];
+        }
+        return null;
+    }
+
+    // returns the last child of node
+    function last_child()
+    {
+        if (($count=count($this->children))>0)
+        {
+            return $this->children[$count-1];
+        }
+        return null;
+    }
+
+    // returns the next sibling of node
+    function next_sibling()
+    {
+        if ($this->parent===null)
+        {
+            return null;
+        }
+
+        $idx = 0;
+        $count = count($this->parent->children);
+        while ($idx<$count && $this!==$this->parent->children[$idx])
+        {
+            ++$idx;
+        }
+        if (++$idx>=$count)
+        {
+            return null;
+        }
+        return $this->parent->children[$idx];
+    }
+
+    // returns the previous sibling of node
+    function prev_sibling()
+    {
+        if ($this->parent===null) return null;
+        $idx = 0;
+        $count = count($this->parent->children);
+        while ($idx<$count && $this!==$this->parent->children[$idx])
+            ++$idx;
+        if (--$idx<0) return null;
+        return $this->parent->children[$idx];
+    }
+
+    // function to locate a specific ancestor tag in the path to the root.
+    function find_ancestor_tag($tag)
+    {
+        global $debugObject;
+        if (is_object($debugObject)) { $debugObject->debugLogEntry(1); }
+
+        // Start by including ourselves in the comparison.
+        $returnDom = $this;
+
+        while (!is_null($returnDom))
+        {
+            if (is_object($debugObject)) { $debugObject->debugLog(2, "Current tag is: " . $returnDom->tag); }
+
+            if ($returnDom->tag == $tag)
+            {
+                break;
+            }
+            $returnDom = $returnDom->parent;
+        }
+        return $returnDom;
+    }
+
+    // get dom node's inner html
+    function innertext()
+    {
+        if (isset($this->_[HDOM_INFO_INNER])) return $this->_[HDOM_INFO_INNER];
+        if (isset($this->_[HDOM_INFO_TEXT])) return $this->dom->restore_noise($this->_[HDOM_INFO_TEXT]);
+
+        $ret = '';
+        foreach ($this->nodes as $n)
+            $ret .= $n->outertext();
+        return $ret;
+    }
+
+    // get dom node's outer text (with tag)
+    function outertext()
+    {
+        global $debugObject;
+        if (is_object($debugObject))
+        {
+            $text = '';
+            if ($this->tag == 'text')
+            {
+                if (!empty($this->text))
+                {
+                    $text = " with text: " . $this->text;
+                }
+            }
+            $debugObject->debugLog(1, 'Innertext of tag: ' . $this->tag . $text);
+        }
+
+        if ($this->tag==='root') return $this->innertext();
+
+        // trigger callback
+        if ($this->dom && $this->dom->callback!==null)
+        {
+            call_user_func_array($this->dom->callback, array($this));
+        }
+
+        if (isset($this->_[HDOM_INFO_OUTER])) return $this->_[HDOM_INFO_OUTER];
+        if (isset($this->_[HDOM_INFO_TEXT])) return $this->dom->restore_noise($this->_[HDOM_INFO_TEXT]);
+
+        // render begin tag
+        if ($this->dom && $this->dom->nodes[$this->_[HDOM_INFO_BEGIN]])
+        {
+            $ret = $this->dom->nodes[$this->_[HDOM_INFO_BEGIN]]->makeup();
+        } else {
+            $ret = "";
+        }
+
+        // render inner text
+        if (isset($this->_[HDOM_INFO_INNER]))
+        {
+            // If it's a br tag...  don't return the HDOM_INNER_INFO that we may or may not have added.
+            if ($this->tag != "br")
+            {
+                $ret .= $this->_[HDOM_INFO_INNER];
+            }
+        } else {
+            if ($this->nodes)
+            {
+                foreach ($this->nodes as $n)
+                {
+                    $ret .= $this->convert_text($n->outertext());
+                }
+            }
+        }
+
+        // render end tag
+        if (isset($this->_[HDOM_INFO_END]) && $this->_[HDOM_INFO_END]!=0)
+            $ret .= '</'.$this->tag.'>';
+        return $ret;
+    }
+
+    // get dom node's plain text
+    function text()
+    {
+        if (isset($this->_[HDOM_INFO_INNER])) return $this->_[HDOM_INFO_INNER];
+        switch ($this->nodetype)
+        {
+            case HDOM_TYPE_TEXT: return $this->dom->restore_noise($this->_[HDOM_INFO_TEXT]);
+            case HDOM_TYPE_COMMENT: return '';
+            case HDOM_TYPE_UNKNOWN: return '';
+        }
+        if (strcasecmp($this->tag, 'script')===0) return '';
+        if (strcasecmp($this->tag, 'style')===0) return '';
+
+        $ret = '';
+        // In rare cases, (always node type 1 or HDOM_TYPE_ELEMENT - observed for some span tags, and some p tags) $this->nodes is set to NULL.
+        // NOTE: This indicates that there is a problem where it's set to NULL without a clear happening.
+        // WHY is this happening?
+        if (!is_null($this->nodes))
+        {
+            foreach ($this->nodes as $n)
+            {
+                $ret .= $this->convert_text($n->text());
+            }
+
+            // If this node is a span... add a space at the end of it so multiple spans don't run into each other.  This is plaintext after all.
+            if ($this->tag == "span")
+            {
+                $ret .= $this->dom->default_span_text;
+            }
+
+
+        }
+        return $ret;
+    }
+
+    function xmltext()
+    {
+        $ret = $this->innertext();
+        $ret = str_ireplace('<![CDATA[', '', $ret);
+        $ret = str_replace(']]>', '', $ret);
+        return $ret;
+    }
+
+    // build node's text with tag
+    function makeup()
+    {
+        // text, comment, unknown
+        if (isset($this->_[HDOM_INFO_TEXT])) return $this->dom->restore_noise($this->_[HDOM_INFO_TEXT]);
+
+        $ret = '<'.$this->tag;
+        $i = -1;
+
+        foreach ($this->attr as $key=>$val)
+        {
+            ++$i;
+
+            // skip removed attribute
+            if ($val===null || $val===false)
+                continue;
+
+            $ret .= $this->_[HDOM_INFO_SPACE][$i][0];
+            //no value attr: nowrap, checked selected...
+            if ($val===true)
+                $ret .= $key;
+            else {
+                switch ($this->_[HDOM_INFO_QUOTE][$i])
+                {
+                    case HDOM_QUOTE_DOUBLE: $quote = '"'; break;
+                    case HDOM_QUOTE_SINGLE: $quote = '\''; break;
+                    default: $quote = '';
+                }
+                $ret .= $key.$this->_[HDOM_INFO_SPACE][$i][1].'='.$this->_[HDOM_INFO_SPACE][$i][2].$quote.$val.$quote;
+            }
+        }
+        $ret = $this->dom->restore_noise($ret);
+        return $ret . $this->_[HDOM_INFO_ENDSPACE] . '>';
+    }
+
+    // find elements by css selector
+    //PaperG - added ability for find to lowercase the value of the selector.
+    function find($selector, $idx=null, $lowercase=false)
+    {
+        $selectors = $this->parse_selector($selector);
+        if (($count=count($selectors))===0) return array();
+        $found_keys = array();
+
+        // find each selector
+        for ($c=0; $c<$count; ++$c)
+        {
+            // The change on the below line was documented on the sourceforge code tracker id 2788009
+            // used to be: if (($levle=count($selectors[0]))===0) return array();
+            if (($levle=count($selectors[$c]))===0) return array();
+            if (!isset($this->_[HDOM_INFO_BEGIN])) return array();
+
+            $head = array($this->_[HDOM_INFO_BEGIN]=>1);
+
+            // handle descendant selectors, no recursive!
+            for ($l=0; $l<$levle; ++$l)
+            {
+                $ret = array();
+                foreach ($head as $k=>$v)
+                {
+                    $n = ($k===-1) ? $this->dom->root : $this->dom->nodes[$k];
+                    //PaperG - Pass this optional parameter on to the seek function.
+                    $n->seek($selectors[$c][$l], $ret, $lowercase);
+                }
+                $head = $ret;
+            }
+
+            foreach ($head as $k=>$v)
+            {
+                if (!isset($found_keys[$k]))
+                    $found_keys[$k] = 1;
+            }
+        }
+
+        // sort keys
+        ksort($found_keys);
+
+        $found = array();
+        foreach ($found_keys as $k=>$v)
+            $found[] = $this->dom->nodes[$k];
+
+        // return nth-element or array
+        if (is_null($idx)) return $found;
+        else if ($idx<0) $idx = count($found) + $idx;
+        return (isset($found[$idx])) ? $found[$idx] : null;
+    }
+
+    // seek for given conditions
+    // PaperG - added parameter to allow for case insensitive testing of the value of a selector.
+    protected function seek($selector, &$ret, $lowercase=false)
+    {
+        global $debugObject;
+        if (is_object($debugObject)) { $debugObject->debugLogEntry(1); }
+
+        list($tag, $key, $val, $exp, $no_key) = $selector;
+
+        // xpath index
+        if ($tag && $key && is_numeric($key))
+        {
+            $count = 0;
+            foreach ($this->children as $c)
+            {
+                if ($tag==='*' || $tag===$c->tag) {
+                    if (++$count==$key) {
+                        $ret[$c->_[HDOM_INFO_BEGIN]] = 1;
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+
+        $end = (!empty($this->_[HDOM_INFO_END])) ? $this->_[HDOM_INFO_END] : 0;
+        if ($end==0) {
+            $parent = $this->parent;
+            while (!isset($parent->_[HDOM_INFO_END]) && $parent!==null) {
+                $end -= 1;
+                $parent = $parent->parent;
+            }
+            $end += $parent->_[HDOM_INFO_END];
+        }
+
+        for ($i=$this->_[HDOM_INFO_BEGIN]+1; $i<$end; ++$i) {
+            $node = $this->dom->nodes[$i];
+
+            $pass = true;
+
+            if ($tag==='*' && !$key) {
+                if (in_array($node, $this->children, true))
+                    $ret[$i] = 1;
+                continue;
+            }
+
+            // compare tag
+            if ($tag && $tag!=$node->tag && $tag!=='*') {$pass=false;}
+            // compare key
+            if ($pass && $key) {
+                if ($no_key) {
+                    if (isset($node->attr[$key])) $pass=false;
+                } else {
+                    if (($key != "plaintext") && !isset($node->attr[$key])) $pass=false;
+                }
+            }
+            // compare value
+            if ($pass && $key && $val  && $val!=='*') {
+                // If they have told us that this is a "plaintext" search then we want the plaintext of the node - right?
+                if ($key == "plaintext") {
+                    // $node->plaintext actually returns $node->text();
+                    $nodeKeyValue = $node->text();
+                } else {
+                    // this is a normal search, we want the value of that attribute of the tag.
+                    $nodeKeyValue = $node->attr[$key];
+                }
+                if (is_object($debugObject)) {$debugObject->debugLog(2, "testing node: " . $node->tag . " for attribute: " . $key . $exp . $val . " where nodes value is: " . $nodeKeyValue);}
+
+                //PaperG - If lowercase is set, do a case insensitive test of the value of the selector.
+                if ($lowercase) {
+                    $check = $this->match($exp, strtolower($val), strtolower($nodeKeyValue));
+                } else {
+                    $check = $this->match($exp, $val, $nodeKeyValue);
+                }
+                if (is_object($debugObject)) {$debugObject->debugLog(2, "after match: " . ($check ? "true" : "false"));}
+
+                // handle multiple class
+                if (!$check && strcasecmp($key, 'class')===0) {
+                    foreach (explode(' ',$node->attr[$key]) as $k) {
+                        // Without this, there were cases where leading, trailing, or double spaces lead to our comparing blanks - bad form.
+                        if (!empty($k)) {
+                            if ($lowercase) {
+                                $check = $this->match($exp, strtolower($val), strtolower($k));
+                            } else {
+                                $check = $this->match($exp, $val, $k);
+                            }
+                            if ($check) break;
+                        }
+                    }
+                }
+                if (!$check) $pass = false;
+            }
+            if ($pass) $ret[$i] = 1;
+            unset($node);
+        }
+        // It's passed by reference so this is actually what this function returns.
+        if (is_object($debugObject)) {$debugObject->debugLog(1, "EXIT - ret: ", $ret);}
+    }
+
+    protected function match($exp, $pattern, $value) {
+        global $debugObject;
+        if (is_object($debugObject)) {$debugObject->debugLogEntry(1);}
+
+        switch ($exp) {
+            case '=':
+                return ($value===$pattern);
+            case '!=':
+                return ($value!==$pattern);
+            case '^=':
+                return preg_match("/^".preg_quote($pattern,'/')."/", $value);
+            case '$=':
+                return preg_match("/".preg_quote($pattern,'/')."$/", $value);
+            case '*=':
+                if ($pattern[0]=='/') {
+                    return preg_match($pattern, $value);
+                }
+                return preg_match("/".$pattern."/i", $value);
+        }
+        return false;
+    }
+
+    protected function parse_selector($selector_string) {
+        global $debugObject;
+        if (is_object($debugObject)) {$debugObject->debugLogEntry(1);}
+
+        // pattern of CSS selectors, modified from mootools
+        // Paperg: Add the colon to the attrbute, so that it properly finds <tag attr:ibute="something" > like google does.
+        // Note: if you try to look at this attribute, yo MUST use getAttribute since $dom->x:y will fail the php syntax check.
+// Notice the \[ starting the attbute?  and the @? following?  This implies that an attribute can begin with an @ sign that is not captured.
+// This implies that an html attribute specifier may start with an @ sign that is NOT captured by the expression.
+// farther study is required to determine of this should be documented or removed.
+//        $pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+        $pattern = "/([\w-:\*]*)(?:\#([\w-]+)|\.([\w-]+))?(?:\[@?(!?[\w-:]+)(?:([!*^$]?=)[\"']?(.*?)[\"']?)?\])?([\/, ]+)/is";
+        preg_match_all($pattern, trim($selector_string).' ', $matches, PREG_SET_ORDER);
+        if (is_object($debugObject)) {$debugObject->debugLog(2, "Matches Array: ", $matches);}
+
+        $selectors = array();
+        $result = array();
+        //print_r($matches);
+
+        foreach ($matches as $m) {
+            $m[0] = trim($m[0]);
+            if ($m[0]==='' || $m[0]==='/' || $m[0]==='//') continue;
+            // for browser generated xpath
+            if ($m[1]==='tbody') continue;
+
+            list($tag, $key, $val, $exp, $no_key) = array($m[1], null, null, '=', false);
+            if (!empty($m[2])) {$key='id'; $val=$m[2];}
+            if (!empty($m[3])) {$key='class'; $val=$m[3];}
+            if (!empty($m[4])) {$key=$m[4];}
+            if (!empty($m[5])) {$exp=$m[5];}
+            if (!empty($m[6])) {$val=$m[6];}
+
+            // convert to lowercase
+            if ($this->dom->lowercase) {$tag=strtolower($tag); $key=strtolower($key);}
+            //elements that do NOT have the specified attribute
+            if (isset($key[0]) && $key[0]==='!') {$key=substr($key, 1); $no_key=true;}
+
+            $result[] = array($tag, $key, $val, $exp, $no_key);
+            if (trim($m[7])===',') {
+                $selectors[] = $result;
+                $result = array();
+            }
+        }
+        if (count($result)>0)
+            $selectors[] = $result;
+        return $selectors;
+    }
+
+    function __get($name) {
+        if (isset($this->attr[$name]))
+        {
+            return $this->convert_text($this->attr[$name]);
+        }
+        switch ($name) {
+            case 'outertext': return $this->outertext();
+            case 'innertext': return $this->innertext();
+            case 'plaintext': return $this->text();
+            case 'xmltext': return $this->xmltext();
+            default: return array_key_exists($name, $this->attr);
+        }
+    }
+
+    function __set($name, $value) {
+        switch ($name) {
+            case 'outertext': return $this->_[HDOM_INFO_OUTER] = $value;
+            case 'innertext':
+                if (isset($this->_[HDOM_INFO_TEXT])) return $this->_[HDOM_INFO_TEXT] = $value;
+                return $this->_[HDOM_INFO_INNER] = $value;
+        }
+        if (!isset($this->attr[$name])) {
+            $this->_[HDOM_INFO_SPACE][] = array(' ', '', '');
+            $this->_[HDOM_INFO_QUOTE][] = HDOM_QUOTE_DOUBLE;
+        }
+        $this->attr[$name] = $value;
+    }
+
+    function __isset($name) {
+        switch ($name) {
+            case 'outertext': return true;
+            case 'innertext': return true;
+            case 'plaintext': return true;
+        }
+        //no value attr: nowrap, checked selected...
+        return (array_key_exists($name, $this->attr)) ? true : isset($this->attr[$name]);
+    }
+
+    function __unset($name) {
+        if (isset($this->attr[$name]))
+            unset($this->attr[$name]);
+    }
+
+    // PaperG - Function to convert the text from one character set to another if the two sets are not the same.
+    function convert_text($text)
+    {
+        global $debugObject;
+        if (is_object($debugObject)) {$debugObject->debugLogEntry(1);}
+
+        $converted_text = $text;
+
+        $sourceCharset = "";
+        $targetCharset = "";
+
+        if ($this->dom)
+        {
+            $sourceCharset = strtoupper($this->dom->_charset);
+            $targetCharset = strtoupper($this->dom->_target_charset);
+        }
+        if (is_object($debugObject)) {$debugObject->debugLog(3, "source charset: " . $sourceCharset . " target charaset: " . $targetCharset);}
+
+        if (!empty($sourceCharset) && !empty($targetCharset) && (strcasecmp($sourceCharset, $targetCharset) != 0))
+        {
+            // Check if the reported encoding could have been incorrect and the text is actually already UTF-8
+            if ((strcasecmp($targetCharset, 'UTF-8') == 0) && ($this->is_utf8($text)))
+            {
+                $converted_text = $text;
+            }
+            else
+            {
+                $converted_text = iconv($sourceCharset, $targetCharset, $text);
+            }
+        }
+
+        // Lets make sure that we don't have that silly BOM issue with any of the utf-8 text we output.
+        if ($targetCharset == 'UTF-8')
+        {
+            if (substr($converted_text, 0, 3) == "\xef\xbb\xbf")
+            {
+                $converted_text = substr($converted_text, 3);
+            }
+            if (substr($converted_text, -3) == "\xef\xbb\xbf")
+            {
+                $converted_text = substr($converted_text, 0, -3);
+            }
+        }
+
+        return $converted_text;
+    }
+
+    /**
+    * Returns true if $string is valid UTF-8 and false otherwise.
+    *
+    * @param mixed $str String to be tested
+    * @return boolean
+    */
+    static function is_utf8($str)
+    {
+        $c=0; $b=0;
+        $bits=0;
+        $len=strlen($str);
+        for($i=0; $i<$len; $i++)
+        {
+            $c=ord($str[$i]);
+            if($c > 128)
+            {
+                if(($c >= 254)) return false;
+                elseif($c >= 252) $bits=6;
+                elseif($c >= 248) $bits=5;
+                elseif($c >= 240) $bits=4;
+                elseif($c >= 224) $bits=3;
+                elseif($c >= 192) $bits=2;
+                else return false;
+                if(($i+$bits) > $len) return false;
+                while($bits > 1)
+                {
+                    $i++;
+                    $b=ord($str[$i]);
+                    if($b < 128 || $b > 191) return false;
+                    $bits--;
+                }
+            }
+        }
+        return true;
+    }
+    /*
+    function is_utf8($string)
+    {
+        //this is buggy
+        return (utf8_encode(utf8_decode($string)) == $string);
+    }
+    */
+
+    /**
+     * Function to try a few tricks to determine the displayed size of an img on the page.
+     * NOTE: This will ONLY work on an IMG tag. Returns FALSE on all other tag types.
+     *
+     * @author John Schlick
+     * @version April 19 2012
+     * @return array an array containing the 'height' and 'width' of the image on the page or -1 if we can't figure it out.
+     */
+    function get_display_size()
+    {
+        global $debugObject;
+
+        $width = -1;
+        $height = -1;
+
+        if ($this->tag !== 'img')
+        {
+            return false;
+        }
+
+        // See if there is aheight or width attribute in the tag itself.
+        if (isset($this->attr['width']))
+        {
+            $width = $this->attr['width'];
+        }
+
+        if (isset($this->attr['height']))
+        {
+            $height = $this->attr['height'];
+        }
+
+        // Now look for an inline style.
+        if (isset($this->attr['style']))
+        {
+            // Thanks to user gnarf from stackoverflow for this regular expression.
+            $attributes = array();
+            preg_match_all("/([\w-]+)\s*:\s*([^;]+)\s*;?/", $this->attr['style'], $matches, PREG_SET_ORDER);
+            foreach ($matches as $match) {
+              $attributes[$match[1]] = $match[2];
+            }
+
+            // If there is a width in the style attributes:
+            if (isset($attributes['width']) && $width == -1)
+            {
+                // check that the last two characters are px (pixels)
+                if (strtolower(substr($attributes['width'], -2)) == 'px')
+                {
+                    $proposed_width = substr($attributes['width'], 0, -2);
+                    // Now make sure that it's an integer and not something stupid.
+                    if (filter_var($proposed_width, FILTER_VALIDATE_INT))
+                    {
+                        $width = $proposed_width;
+                    }
+                }
+            }
+
+            // If there is a width in the style attributes:
+            if (isset($attributes['height']) && $height == -1)
+            {
+                // check that the last two characters are px (pixels)
+                if (strtolower(substr($attributes['height'], -2)) == 'px')
+                {
+                    $proposed_height = substr($attributes['height'], 0, -2);
+                    // Now make sure that it's an integer and not something stupid.
+                    if (filter_var($proposed_height, FILTER_VALIDATE_INT))
+                    {
+                        $height = $proposed_height;
+                    }
+                }
+            }
+
+        }
+
+        // Future enhancement:
+        // Look in the tag to see if there is a class or id specified that has a height or width attribute to it.
+
+        // Far future enhancement
+        // Look at all the parent tags of this image to see if they specify a class or id that has an img selector that specifies a height or width
+        // Note that in this case, the class or id will have the img subselector for it to apply to the image.
+
+        // ridiculously far future development
+        // If the class or id is specified in a SEPARATE css file thats not on the page, go get it and do what we were just doing for the ones on the page.
+
+        $result = array('height' => $height,
+                        'width' => $width);
+        return $result;
+    }
+
+    // camel naming conventions
+    function getAllAttributes() {return $this->attr;}
+    function getAttribute($name) {return $this->__get($name);}
+    function setAttribute($name, $value) {$this->__set($name, $value);}
+    function hasAttribute($name) {return $this->__isset($name);}
+    function removeAttribute($name) {$this->__set($name, null);}
+    function getElementById($id) {return $this->find("#$id", 0);}
+    function getElementsById($id, $idx=null) {return $this->find("#$id", $idx);}
+    function getElementByTagName($name) {return $this->find($name, 0);}
+    function getElementsByTagName($name, $idx=null) {return $this->find($name, $idx);}
+    function parentNode() {return $this->parent();}
+    function childNodes($idx=-1) {return $this->children($idx);}
+    function firstChild() {return $this->first_child();}
+    function lastChild() {return $this->last_child();}
+    function nextSibling() {return $this->next_sibling();}
+    function previousSibling() {return $this->prev_sibling();}
+    function hasChildNodes() {return $this->has_child();}
+    function nodeName() {return $this->tag;}
+    function appendChild($node) {$node->parent($this); return $node;}
+
+}
+
+/**
+ * simple html dom parser
+ * Paperg - in the find routine: allow us to specify that we want case insensitive testing of the value of the selector.
+ * Paperg - change $size from protected to public so we can easily access it
+ * Paperg - added ForceTagsClosed in the constructor which tells us whether we trust the html or not.  Default is to NOT trust it.
+ *
+ * @package PlaceLocalInclude
+ */
+class simple_html_dom
+{
+    public $root = null;
+    public $nodes = array();
+    public $callback = null;
+    public $lowercase = false;
+    // Used to keep track of how large the text was when we started.
+    public $original_size;
+    public $size;
+    protected $pos;
+    protected $doc;
+    protected $char;
+    protected $cursor;
+    protected $parent;
+    protected $noise = array();
+    protected $token_blank = " \t\r\n";
+    protected $token_equal = ' =/>';
+    protected $token_slash = " />\r\n\t";
+    protected $token_attr = ' >';
+    // Note that this is referenced by a child node, and so it needs to be public for that node to see this information.
+    public $_charset = '';
+    public $_target_charset = '';
+    protected $default_br_text = "";
+    public $default_span_text = "";
+
+    // use isset instead of in_array, performance boost about 30%...
+    protected $self_closing_tags = array('img'=>1, 'br'=>1, 'input'=>1, 'meta'=>1, 'link'=>1, 'hr'=>1, 'base'=>1, 'embed'=>1, 'spacer'=>1);
+    protected $block_tags = array('root'=>1, 'body'=>1, 'form'=>1, 'div'=>1, 'span'=>1, 'table'=>1);
+    // Known sourceforge issue #2977341
+    // B tags that are not closed cause us to return everything to the end of the document.
+    protected $optional_closing_tags = array(
+        'tr'=>array('tr'=>1, 'td'=>1, 'th'=>1),
+        'th'=>array('th'=>1),
+        'td'=>array('td'=>1),
+        'li'=>array('li'=>1),
+        'dt'=>array('dt'=>1, 'dd'=>1),
+        'dd'=>array('dd'=>1, 'dt'=>1),
+        'dl'=>array('dd'=>1, 'dt'=>1),
+        'p'=>array('p'=>1),
+        'nobr'=>array('nobr'=>1),
+        'b'=>array('b'=>1),
+		'option'=>array('option'=>1),
+    );
+
+    function __construct($str=null, $lowercase=true, $forceTagsClosed=true, $target_charset=DEFAULT_TARGET_CHARSET, $stripRN=true, $defaultBRText=DEFAULT_BR_TEXT, $defaultSpanText=DEFAULT_SPAN_TEXT)
+    {
+        if ($str)
+        {
+            if (preg_match("/^http:\/\//i",$str) || is_file($str))
+            {
+                $this->load_file($str);
+            }
+            else
+            {
+                $this->load($str, $lowercase, $stripRN, $defaultBRText, $defaultSpanText);
+            }
+        }
+        // Forcing tags to be closed implies that we don't trust the html, but it can lead to parsing errors if we SHOULD trust the html.
+        if (!$forceTagsClosed) {
+            $this->optional_closing_array=array();
+        }
+        $this->_target_charset = $target_charset;
+    }
+
+    function __destruct()
+    {
+        $this->clear();
+    }
+
+    // load html from string
+    function load($str, $lowercase=true, $stripRN=true, $defaultBRText=DEFAULT_BR_TEXT, $defaultSpanText=DEFAULT_SPAN_TEXT)
+    {
+        global $debugObject;
+
+        // prepare
+        $this->prepare($str, $lowercase, $stripRN, $defaultBRText, $defaultSpanText);
+        // strip out comments
+        $this->remove_noise("'<!--(.*?)-->'is");
+        // strip out cdata
+        $this->remove_noise("'<!\[CDATA\[(.*?)\]\]>'is", true);
+        // Per sourceforge http://sourceforge.net/tracker/?func=detail&aid=2949097&group_id=218559&atid=1044037
+        // Script tags removal now preceeds style tag removal.
+        // strip out <script> tags
+        $this->remove_noise("'<\s*script[^>]*[^/]>(.*?)<\s*/\s*script\s*>'is");
+        $this->remove_noise("'<\s*script\s*>(.*?)<\s*/\s*script\s*>'is");
+        // strip out <style> tags
+        $this->remove_noise("'<\s*style[^>]*[^/]>(.*?)<\s*/\s*style\s*>'is");
+        $this->remove_noise("'<\s*style\s*>(.*?)<\s*/\s*style\s*>'is");
+        // strip out preformatted tags
+        $this->remove_noise("'<\s*(?:code)[^>]*>(.*?)<\s*/\s*(?:code)\s*>'is");
+        // strip out server side scripts
+        $this->remove_noise("'(<\?)(.*?)(\?>)'s", true);
+        // strip smarty scripts
+        $this->remove_noise("'(\{\w)(.*?)(\})'s", true);
+
+        // parsing
+        while ($this->parse());
+        // end
+        $this->root->_[HDOM_INFO_END] = $this->cursor;
+        $this->parse_charset();
+
+        // make load function chainable
+        return $this;
+
+    }
+
+    // load html from file
+    function load_file()
+    {
+        $args = func_get_args();
+        $this->load(call_user_func_array('file_get_contents', $args), true);
+        // Throw an error if we can't properly load the dom.
+        if (($error=error_get_last())!==null) {
+            $this->clear();
+            return false;
+        }
+    }
+
+    // set callback function
+    function set_callback($function_name)
+    {
+        $this->callback = $function_name;
+    }
+
+    // remove callback function
+    function remove_callback()
+    {
+        $this->callback = null;
+    }
+
+    // save dom as string
+    function save($filepath='')
+    {
+        $ret = $this->root->innertext();
+        if ($filepath!=='') file_put_contents($filepath, $ret, LOCK_EX);
+        return $ret;
+    }
+
+    // find dom node by css selector
+    // Paperg - allow us to specify that we want case insensitive testing of the value of the selector.
+    function find($selector, $idx=null, $lowercase=false)
+    {
+        return $this->root->find($selector, $idx, $lowercase);
+    }
+
+    // clean up memory due to php5 circular references memory leak...
+    function clear()
+    {
+        foreach ($this->nodes as $n) {$n->clear(); $n = null;}
+        // This add next line is documented in the sourceforge repository. 2977248 as a fix for ongoing memory leaks that occur even with the use of clear.
+        if (isset($this->children)) foreach ($this->children as $n) {$n->clear(); $n = null;}
+        if (isset($this->parent)) {$this->parent->clear(); unset($this->parent);}
+        if (isset($this->root)) {$this->root->clear(); unset($this->root);}
+        unset($this->doc);
+        unset($this->noise);
+    }
+
+    function dump($show_attr=true)
+    {
+        $this->root->dump($show_attr);
+    }
+
+    // prepare HTML data and init everything
+    protected function prepare($str, $lowercase=true, $stripRN=true, $defaultBRText=DEFAULT_BR_TEXT, $defaultSpanText=DEFAULT_SPAN_TEXT)
+    {
+        $this->clear();
+
+        // set the length of content before we do anything to it.
+        $this->size = strlen($str);
+        // Save the original size of the html that we got in.  It might be useful to someone.
+        $this->original_size = $this->size;
+
+        //before we save the string as the doc...  strip out the \r \n's if we are told to.
+        if ($stripRN) {
+            $str = str_replace("\r", " ", $str);
+            $str = str_replace("\n", " ", $str);
+
+            // set the length of content since we have changed it.
+            $this->size = strlen($str);
+        }
+
+        $this->doc = $str;
+        $this->pos = 0;
+        $this->cursor = 1;
+        $this->noise = array();
+        $this->nodes = array();
+        $this->lowercase = $lowercase;
+        $this->default_br_text = $defaultBRText;
+        $this->default_span_text = $defaultSpanText;
+        $this->root = new simple_html_dom_node($this);
+        $this->root->tag = 'root';
+        $this->root->_[HDOM_INFO_BEGIN] = -1;
+        $this->root->nodetype = HDOM_TYPE_ROOT;
+        $this->parent = $this->root;
+        if ($this->size>0) $this->char = $this->doc[0];
+    }
+
+    // parse html content
+    protected function parse()
+    {
+        if (($s = $this->copy_until_char('<'))==='')
+        {
+            return $this->read_tag();
+        }
+
+        // text
+        $node = new simple_html_dom_node($this);
+        ++$this->cursor;
+        $node->_[HDOM_INFO_TEXT] = $s;
+        $this->link_nodes($node, false);
+        return true;
+    }
+
+    // PAPERG - dkchou - added this to try to identify the character set of the page we have just parsed so we know better how to spit it out later.
+    // NOTE:  IF you provide a routine called get_last_retrieve_url_contents_content_type which returns the CURLINFO_CONTENT_TYPE from the last curl_exec
+    // (or the content_type header from the last transfer), we will parse THAT, and if a charset is specified, we will use it over any other mechanism.
+    protected function parse_charset()
+    {
+        global $debugObject;
+
+        $charset = null;
+
+        if (function_exists('get_last_retrieve_url_contents_content_type'))
+        {
+            $contentTypeHeader = get_last_retrieve_url_contents_content_type();
+            $success = preg_match('/charset=(.+)/', $contentTypeHeader, $matches);
+            if ($success)
+            {
+                $charset = $matches[1];
+                if (is_object($debugObject)) {$debugObject->debugLog(2, 'header content-type found charset of: ' . $charset);}
+            }
+
+        }
+
+        if (empty($charset))
+        {
+            $el = $this->root->find('meta[http-equiv=Content-Type]',0);
+            if (!empty($el))
+            {
+                $fullvalue = $el->content;
+                if (is_object($debugObject)) {$debugObject->debugLog(2, 'meta content-type tag found' . $fullvalue);}
+
+                if (!empty($fullvalue))
+                {
+                    $success = preg_match('/charset=(.+)/', $fullvalue, $matches);
+                    if ($success)
+                    {
+                        $charset = $matches[1];
+                    }
+                    else
+                    {
+                        // If there is a meta tag, and they don't specify the character set, research says that it's typically ISO-8859-1
+                        if (is_object($debugObject)) {$debugObject->debugLog(2, 'meta content-type tag couldn\'t be parsed. using iso-8859 default.');}
+                        $charset = 'ISO-8859-1';
+                    }
+                }
+            }
+        }
+
+        // If we couldn't find a charset above, then lets try to detect one based on the text we got...
+        if (empty($charset))
+        {
+            // Have php try to detect the encoding from the text given to us.
+            $charset = mb_detect_encoding($this->root->plaintext . "ascii", $encoding_list = array( "UTF-8", "CP1252" ) );
+            if (is_object($debugObject)) {$debugObject->debugLog(2, 'mb_detect found: ' . $charset);}
+
+            // and if this doesn't work...  then we need to just wrongheadedly assume it's UTF-8 so that we can move on - cause this will usually give us most of what we need...
+            if ($charset === false)
+            {
+                if (is_object($debugObject)) {$debugObject->debugLog(2, 'since mb_detect failed - using default of utf-8');}
+                $charset = 'UTF-8';
+            }
+        }
+
+        // Since CP1252 is a superset, if we get one of it's subsets, we want it instead.
+        if ((strtolower($charset) == strtolower('ISO-8859-1')) || (strtolower($charset) == strtolower('Latin1')) || (strtolower($charset) == strtolower('Latin-1')))
+        {
+            if (is_object($debugObject)) {$debugObject->debugLog(2, 'replacing ' . $charset . ' with CP1252 as its a superset');}
+            $charset = 'CP1252';
+        }
+
+        if (is_object($debugObject)) {$debugObject->debugLog(1, 'EXIT - ' . $charset);}
+
+        return $this->_charset = $charset;
+    }
+
+    // read tag info
+    protected function read_tag()
+    {
+        if ($this->char!=='<')
+        {
+            $this->root->_[HDOM_INFO_END] = $this->cursor;
+            return false;
+        }
+        $begin_tag_pos = $this->pos;
+        $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+
+        // end tag
+        if ($this->char==='/')
+        {
+            $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+            // This represents the change in the simple_html_dom trunk from revision 180 to 181.
+            // $this->skip($this->token_blank_t);
+            $this->skip($this->token_blank);
+            $tag = $this->copy_until_char('>');
+
+            // skip attributes in end tag
+            if (($pos = strpos($tag, ' '))!==false)
+                $tag = substr($tag, 0, $pos);
+
+            $parent_lower = strtolower($this->parent->tag);
+            $tag_lower = strtolower($tag);
+
+            if ($parent_lower!==$tag_lower)
+            {
+                if (isset($this->optional_closing_tags[$parent_lower]) && isset($this->block_tags[$tag_lower]))
+                {
+                    $this->parent->_[HDOM_INFO_END] = 0;
+                    $org_parent = $this->parent;
+
+                    while (($this->parent->parent) && strtolower($this->parent->tag)!==$tag_lower)
+                        $this->parent = $this->parent->parent;
+
+                    if (strtolower($this->parent->tag)!==$tag_lower) {
+                        $this->parent = $org_parent; // restore origonal parent
+                        if ($this->parent->parent) $this->parent = $this->parent->parent;
+                        $this->parent->_[HDOM_INFO_END] = $this->cursor;
+                        return $this->as_text_node($tag);
+                    }
+                }
+                else if (($this->parent->parent) && isset($this->block_tags[$tag_lower]))
+                {
+                    $this->parent->_[HDOM_INFO_END] = 0;
+                    $org_parent = $this->parent;
+
+                    while (($this->parent->parent) && strtolower($this->parent->tag)!==$tag_lower)
+                        $this->parent = $this->parent->parent;
+
+                    if (strtolower($this->parent->tag)!==$tag_lower)
+                    {
+                        $this->parent = $org_parent; // restore origonal parent
+                        $this->parent->_[HDOM_INFO_END] = $this->cursor;
+                        return $this->as_text_node($tag);
+                    }
+                }
+                else if (($this->parent->parent) && strtolower($this->parent->parent->tag)===$tag_lower)
+                {
+                    $this->parent->_[HDOM_INFO_END] = 0;
+                    $this->parent = $this->parent->parent;
+                }
+                else
+                    return $this->as_text_node($tag);
+            }
+
+            $this->parent->_[HDOM_INFO_END] = $this->cursor;
+            if ($this->parent->parent) $this->parent = $this->parent->parent;
+
+            $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+            return true;
+        }
+
+        $node = new simple_html_dom_node($this);
+        $node->_[HDOM_INFO_BEGIN] = $this->cursor;
+        ++$this->cursor;
+        $tag = $this->copy_until($this->token_slash);
+        $node->tag_start = $begin_tag_pos;
+
+        // doctype, cdata & comments...
+        if (isset($tag[0]) && $tag[0]==='!') {
+            $node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until_char('>');
+
+            if (isset($tag[2]) && $tag[1]==='-' && $tag[2]==='-') {
+                $node->nodetype = HDOM_TYPE_COMMENT;
+                $node->tag = 'comment';
+            } else {
+                $node->nodetype = HDOM_TYPE_UNKNOWN;
+                $node->tag = 'unknown';
+            }
+            if ($this->char==='>') $node->_[HDOM_INFO_TEXT].='>';
+            $this->link_nodes($node, true);
+            $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+            return true;
+        }
+
+        // text
+        if ($pos=strpos($tag, '<')!==false) {
+            $tag = '<' . substr($tag, 0, -1);
+            $node->_[HDOM_INFO_TEXT] = $tag;
+            $this->link_nodes($node, false);
+            $this->char = $this->doc[--$this->pos]; // prev
+            return true;
+        }
+
+        if (!preg_match("/^[\w-:]+$/", $tag)) {
+            $node->_[HDOM_INFO_TEXT] = '<' . $tag . $this->copy_until('<>');
+            if ($this->char==='<') {
+                $this->link_nodes($node, false);
+                return true;
+            }
+
+            if ($this->char==='>') $node->_[HDOM_INFO_TEXT].='>';
+            $this->link_nodes($node, false);
+            $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+            return true;
+        }
+
+        // begin tag
+        $node->nodetype = HDOM_TYPE_ELEMENT;
+        $tag_lower = strtolower($tag);
+        $node->tag = ($this->lowercase) ? $tag_lower : $tag;
+
+        // handle optional closing tags
+        if (isset($this->optional_closing_tags[$tag_lower]) )
+        {
+            while (isset($this->optional_closing_tags[$tag_lower][strtolower($this->parent->tag)]))
+            {
+                $this->parent->_[HDOM_INFO_END] = 0;
+                $this->parent = $this->parent->parent;
+            }
+            $node->parent = $this->parent;
+        }
+
+        $guard = 0; // prevent infinity loop
+        $space = array($this->copy_skip($this->token_blank), '', '');
+
+        // attributes
+        do
+        {
+            if ($this->char!==null && $space[0]==='')
+            {
+                break;
+            }
+            $name = $this->copy_until($this->token_equal);
+            if ($guard===$this->pos)
+            {
+                $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                continue;
+            }
+            $guard = $this->pos;
+
+            // handle endless '<'
+            if ($this->pos>=$this->size-1 && $this->char!=='>') {
+                $node->nodetype = HDOM_TYPE_TEXT;
+                $node->_[HDOM_INFO_END] = 0;
+                $node->_[HDOM_INFO_TEXT] = '<'.$tag . $space[0] . $name;
+                $node->tag = 'text';
+                $this->link_nodes($node, false);
+                return true;
+            }
+
+            // handle mismatch '<'
+            if ($this->doc[$this->pos-1]=='<') {
+                $node->nodetype = HDOM_TYPE_TEXT;
+                $node->tag = 'text';
+                $node->attr = array();
+                $node->_[HDOM_INFO_END] = 0;
+                $node->_[HDOM_INFO_TEXT] = substr($this->doc, $begin_tag_pos, $this->pos-$begin_tag_pos-1);
+                $this->pos -= 2;
+                $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                $this->link_nodes($node, false);
+                return true;
+            }
+
+            if ($name!=='/' && $name!=='') {
+                $space[1] = $this->copy_skip($this->token_blank);
+                $name = $this->restore_noise($name);
+                if ($this->lowercase) $name = strtolower($name);
+                if ($this->char==='=') {
+                    $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                    $this->parse_attr($node, $name, $space);
+                }
+                else {
+                    //no value attr: nowrap, checked selected...
+                    $node->_[HDOM_INFO_QUOTE][] = HDOM_QUOTE_NO;
+                    $node->attr[$name] = true;
+                    if ($this->char!='>') $this->char = $this->doc[--$this->pos]; // prev
+                }
+                $node->_[HDOM_INFO_SPACE][] = $space;
+                $space = array($this->copy_skip($this->token_blank), '', '');
+            }
+            else
+                break;
+        } while ($this->char!=='>' && $this->char!=='/');
+
+        $this->link_nodes($node, true);
+        $node->_[HDOM_INFO_ENDSPACE] = $space[0];
+
+        // check self closing
+        if ($this->copy_until_char_escape('>')==='/')
+        {
+            $node->_[HDOM_INFO_ENDSPACE] .= '/';
+            $node->_[HDOM_INFO_END] = 0;
+        }
+        else
+        {
+            // reset parent
+            if (!isset($this->self_closing_tags[strtolower($node->tag)])) $this->parent = $node;
+        }
+        $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+
+        // If it's a BR tag, we need to set it's text to the default text.
+        // This way when we see it in plaintext, we can generate formatting that the user wants.
+        // since a br tag never has sub nodes, this works well.
+        if ($node->tag == "br")
+        {
+            $node->_[HDOM_INFO_INNER] = $this->default_br_text;
+        }
+
+        return true;
+    }
+
+    // parse attributes
+    protected function parse_attr($node, $name, &$space)
+    {
+        // Per sourceforge: http://sourceforge.net/tracker/?func=detail&aid=3061408&group_id=218559&atid=1044037
+        // If the attribute is already defined inside a tag, only pay atetntion to the first one as opposed to the last one.
+        if (isset($node->attr[$name]))
+        {
+            return;
+        }
+
+        $space[2] = $this->copy_skip($this->token_blank);
+        switch ($this->char) {
+            case '"':
+                $node->_[HDOM_INFO_QUOTE][] = HDOM_QUOTE_DOUBLE;
+                $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                $node->attr[$name] = $this->restore_noise($this->copy_until_char_escape('"'));
+                $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                break;
+            case '\'':
+                $node->_[HDOM_INFO_QUOTE][] = HDOM_QUOTE_SINGLE;
+                $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                $node->attr[$name] = $this->restore_noise($this->copy_until_char_escape('\''));
+                $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+                break;
+            default:
+                $node->_[HDOM_INFO_QUOTE][] = HDOM_QUOTE_NO;
+                $node->attr[$name] = $this->restore_noise($this->copy_until($this->token_attr));
+        }
+        // PaperG: Attributes should not have \r or \n in them, that counts as html whitespace.
+        $node->attr[$name] = str_replace("\r", "", $node->attr[$name]);
+        $node->attr[$name] = str_replace("\n", "", $node->attr[$name]);
+        // PaperG: If this is a "class" selector, lets get rid of the preceeding and trailing space since some people leave it in the multi class case.
+        if ($name == "class") {
+            $node->attr[$name] = trim($node->attr[$name]);
+        }
+    }
+
+    // link node's parent
+    protected function link_nodes(&$node, $is_child)
+    {
+        $node->parent = $this->parent;
+        $this->parent->nodes[] = $node;
+        if ($is_child)
+        {
+            $this->parent->children[] = $node;
+        }
+    }
+
+    // as a text node
+    protected function as_text_node($tag)
+    {
+        $node = new simple_html_dom_node($this);
+        ++$this->cursor;
+        $node->_[HDOM_INFO_TEXT] = '</' . $tag . '>';
+        $this->link_nodes($node, false);
+        $this->char = (++$this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+        return true;
+    }
+
+    protected function skip($chars)
+    {
+        $this->pos += strspn($this->doc, $chars, $this->pos);
+        $this->char = ($this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+    }
+
+    protected function copy_skip($chars)
+    {
+        $pos = $this->pos;
+        $len = strspn($this->doc, $chars, $pos);
+        $this->pos += $len;
+        $this->char = ($this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+        if ($len===0) return '';
+        return substr($this->doc, $pos, $len);
+    }
+
+    protected function copy_until($chars)
+    {
+        $pos = $this->pos;
+        $len = strcspn($this->doc, $chars, $pos);
+        $this->pos += $len;
+        $this->char = ($this->pos<$this->size) ? $this->doc[$this->pos] : null; // next
+        return substr($this->doc, $pos, $len);
+    }
+
+    protected function copy_until_char($char)
+    {
+        if ($this->char===null) return '';
+
+        if (($pos = strpos($this->doc, $char, $this->pos))===false) {
+            $ret = substr($this->doc, $this->pos, $this->size-$this->pos);
+            $this->char = null;
+            $this->pos = $this->size;
+            return $ret;
+        }
+
+        if ($pos===$this->pos) return '';
+        $pos_old = $this->pos;
+        $this->char = $this->doc[$pos];
+        $this->pos = $pos;
+        return substr($this->doc, $pos_old, $pos-$pos_old);
+    }
+
+    protected function copy_until_char_escape($char)
+    {
+        if ($this->char===null) return '';
+
+        $start = $this->pos;
+        while (1)
+        {
+            if (($pos = strpos($this->doc, $char, $start))===false)
+            {
+                $ret = substr($this->doc, $this->pos, $this->size-$this->pos);
+                $this->char = null;
+                $this->pos = $this->size;
+                return $ret;
+            }
+
+            if ($pos===$this->pos) return '';
+
+            if ($this->doc[$pos-1]==='\\') {
+                $start = $pos+1;
+                continue;
+            }
+
+            $pos_old = $this->pos;
+            $this->char = $this->doc[$pos];
+            $this->pos = $pos;
+            return substr($this->doc, $pos_old, $pos-$pos_old);
+        }
+    }
+
+    // remove noise from html content
+    // save the noise in the $this->noise array.
+    protected function remove_noise($pattern, $remove_tag=false)
+    {
+        global $debugObject;
+        if (is_object($debugObject)) { $debugObject->debugLogEntry(1); }
+
+        $count = preg_match_all($pattern, $this->doc, $matches, PREG_SET_ORDER|PREG_OFFSET_CAPTURE);
+
+        for ($i=$count-1; $i>-1; --$i)
+        {
+            $key = '___noise___'.sprintf('% 5d', count($this->noise)+1000);
+            if (is_object($debugObject)) { $debugObject->debugLog(2, 'key is: ' . $key); }
+            $idx = ($remove_tag) ? 0 : 1;
+            $this->noise[$key] = $matches[$i][$idx][0];
+            $this->doc = substr_replace($this->doc, $key, $matches[$i][$idx][1], strlen($matches[$i][$idx][0]));
+        }
+
+        // reset the length of content
+        $this->size = strlen($this->doc);
+        if ($this->size>0)
+        {
+            $this->char = $this->doc[0];
+        }
+    }
+
+    // restore noise to html content
+    function restore_noise($text)
+    {
+        global $debugObject;
+        if (is_object($debugObject)) { $debugObject->debugLogEntry(1); }
+
+        while (($pos=strpos($text, '___noise___'))!==false)
+        {
+            // Sometimes there is a broken piece of markup, and we don't GET the pos+11 etc... token which indicates a problem outside of us...
+            if (strlen($text) > $pos+15)
+            {
+                $key = '___noise___'.$text[$pos+11].$text[$pos+12].$text[$pos+13].$text[$pos+14].$text[$pos+15];
+                if (is_object($debugObject)) { $debugObject->debugLog(2, 'located key of: ' . $key); }
+
+                if (isset($this->noise[$key]))
+                {
+                    $text = substr($text, 0, $pos).$this->noise[$key].substr($text, $pos+16);
+                }
+                else
+                {
+                    // do this to prevent an infinite loop.
+                    $text = substr($text, 0, $pos).'UNDEFINED NOISE FOR KEY: '.$key . substr($text, $pos+16);
+                }
+            }
+            else
+            {
+                // There is no valid key being given back to us... We must get rid of the ___noise___ or we will have a problem.
+                $text = substr($text, 0, $pos).'NO NUMERIC NOISE KEY' . substr($text, $pos+11);
+            }
+        }
+        return $text;
+    }
+
+    // Sometimes we NEED one of the noise elements.
+    function search_noise($text)
+    {
+        global $debugObject;
+        if (is_object($debugObject)) { $debugObject->debugLogEntry(1); }
+
+        foreach($this->noise as $noiseElement)
+        {
+            if (strpos($noiseElement, $text)!==false)
+            {
+                return $noiseElement;
+            }
+        }
+    }
+    function __toString()
+    {
+        return $this->root->innertext();
+    }
+
+    function __get($name)
+    {
+        switch ($name)
+        {
+            case 'outertext':
+                return $this->root->innertext();
+            case 'innertext':
+                return $this->root->innertext();
+            case 'plaintext':
+                return $this->root->text();
+            case 'charset':
+                return $this->_charset;
+            case 'target_charset':
+                return $this->_target_charset;
+        }
+    }
+
+    // camel naming conventions
+    function childNodes($idx=-1) {return $this->root->childNodes($idx);}
+    function firstChild() {return $this->root->first_child();}
+    function lastChild() {return $this->root->last_child();}
+    function createElement($name, $value=null) {return @str_get_html("<$name>$value</$name>")->first_child();}
+    function createTextNode($value) {return @end(str_get_html($value)->nodes);}
+    function getElementById($id) {return $this->find("#$id", 0);}
+    function getElementsById($id, $idx=null) {return $this->find("#$id", $idx);}
+    function getElementByTagName($name) {return $this->find($name, 0);}
+    function getElementsByTagName($name, $idx=-1) {return $this->find($name, $idx);}
+    function loadFile() {$args = func_get_args();$this->load_file($args);}
+}
+
+?>


### PR DESCRIPTION
This is a partial implementation with placeholder API for some `/fun/link` features. I don't understand how I get rid of the error-status when the response is actually constructed as intended.

Also I haven't even started to attempt any database implementations for link-hashes as I'm not sure if you even want me dabbing about them. And I would be more comfortable working on them if I had a full system up an running.

The response from `/link/check` needs of course something on the js-side that reacts to it, when/if we have link-hashing for links out we probably also want a table for link-tags such as the different OS:es and technologies and so on. Then the `/link/check/` should check against these tags before returning the check-results. Now it's just standardized strings like `Linux`.