### PR TITLE
[Untested] Modified display of results

### DIFF
--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -131,6 +131,16 @@ export default class ContentItem extends Component {
 		}
 	}
 	
+	positionSuffix(position) {
+	    let j = position % 10;
+		let k = position % 100;
+	
+	    if (j == 1 && k != 11) return "st";
+	    if (j == 2 && k != 12) return "nd";
+	    if (j == 3 && k != 13) return "rd";
+	    return "th";
+	}
+	
 	onUpload( name, e ) {
 		var node = this.props.node;
 		var user = this.props.user;
@@ -458,7 +468,7 @@ export default class ContentItem extends Component {
 				
 				//  {Score >= 20 ? <SVGIcon small baseline>check</SVGIcon> : <SVGIcon small baseline>cross</SVGIcon>}
 				
-				ResultLines.push(<div class="-grade"><span class="-title">{Title}:</span> <strong>{Place}</strong> ({Average} average in {Count} ratings)</div>);
+				ResultLines.push(<div class="-grade"><span class="-title">{Title}:</span> <strong>{Place}</strong><sup>{positionSuffix(Place)}</sup> ({Average} average from {Count} ratings)</div>);
 			}
 
 			ShowGrade = (


### PR DESCRIPTION
Some small modifications to the results screen. 
Currently untested (haven't opened VM in a month, so it might be fun getting back on track with that)

* Changes
    > Graphics: **414** (2.778 average in 29 ratings)
    to something more like
    > Graphics: **414**th (2.778 average from 29 ratings)