### PR TITLE
Event simulation

### DIFF
--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -51,12 +51,33 @@ else
 
 ////////////////////////////////
 // Some global settings
+
+$apibase = "http://api.ludumdare.org/";
 $usercount = 40;
 $keepallposts = true;
 $keeppostcount = 100; // Number of posts per user to keep, when keep all posts is false (which it should be for high user counts or long runtimes / stress environments.)
 $verbose = true; // Display all of the details about what's going on?
 $verboselog = true; // Keep all details about what's going on in a log.
 $useprevioususers = false; // (not implemented) Load the set of users from the previous test event, instead of creating new users.
+
+$errorcount = 0;
+
+function TimeString()
+{
+  $d = new DateTime();
+  return $d->format("Y-m-d H:i:s");
+}
+
+function ReportError($text)
+{
+	global $errorcount;
+	$errorcount++;
+	print("[" . TimeString() . "] Error: " . $text . "\n");
+}
+function Verbose($text)
+{
+	print("[" . TimeString() . "] Verbose: " . $text . "\n");
+}
 
 
 
@@ -144,12 +165,21 @@ $stages = array(
 );
 
 
+$event_admin_user = null;
+$event_users = array();
+
+
 // Prepare the event. Create an admin superuser. Create all the compo users. Create the new LudumDare event. Publish the event node.
 // Some of this has to be done through the database directly (finding the email verification links, and creating the ludumdare event and setting it up)
 // We'll also use some data from the database to make the naming a bit more friendly.
 function SetupEvent()
 {
-
+	global $event_admin_user, $event_users;
+	
+	$event_admin_user = User_Create();
+	
+	
+	exit(0);
 }
 
 // Set up for each of the phases of the theme selection, in sequence.
@@ -235,10 +265,6 @@ function CompoPublishGame($user, $phase)
 ////
 $stagecount = count($stages);
 
-function Verbose($text)
-{
-	print($text . "\n");
-}
 
 for($curStage = 0; $curStage < $stagecount; $curStage++)
 {
@@ -272,7 +298,7 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 			}
 			$end = (new DateTime()).Add(new DateInterval("PT".$minutes."M"));
 			
-			while($end < new DateTime())
+			while($end > new DateTime())
 			{
 				ExecuteStageAction($stage, $phase);
 			}
@@ -285,9 +311,7 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 				ExecuteStageAction($stage, $phase);
 			}
 		}
-
-		// Excecute actions as available until limit is hit
-
+		
 		// Ensure promised conditions about mandatory actions hold
 		CompleteMandatoryStageActions($stage, $phase);
 
@@ -320,15 +344,302 @@ function CompleteMandatoryStageActions($stage, $phase)
 //// Common functions to assist in doing normal tasks in the site
 ////
 
+function User_Create()
+{
+	$username = GenerateRandomUsername();
+	$password = GenerateRandomPassword();
+	
+	// Construct a user object
+	$user = [
+		"username" => $username,
+		"password" => $password,
+		"cookies" => array(),
+		
+		// Further info for tracking data this user has posted and interacted with.
+		"posts" => array(),
+		"publishedgame" => "false"
+	];
+	
+	// Determine if username is in use
+	for($i = 0; $i < 20; $i++)
+	{
+		if(ApiUserHave($username))
+		{
+			// Username is in use, pick another
+			$username = GenerateRandomUsername();
+			$user["username"] = $username;
+		}
+		else
+		{
+			break;
+		}
+	}
+	
+	// API request to create user
+	$email = $username . "@ludumdare.org";
+	
+	$mailsent = ApiUserCreate($email, $user);
+	if(!$mailsent)
+	{
+		Verbose("Warning: User create didn't send mail. It's not strictly necessary to catch mail for this, but you probably don't have the mail catcher running.");
+	}
+	
+	// Dig out the email auth token from the database and activate the user
+	$userdata = user_GetByMail($email);
+	$id = $userdata["id"];
+	$key = $userdata["auth_key"];
+	
+	if(!ApiUserActivate($user, $id, $key))
+	{
+		ReportError("Error while creating user.");
+		return null;
+	}
+	
+	$user["id"] = $id;
+	
+	// Login the user
+	if(!ApiUserLogin($user))
+	{
+		ReportError("Unable to login new user.");
+		return null;	
+	}
+	
+	return $user;
+}
 
 
+
+
+// Does the site have this username already?
+function ApiUserHave($username)
+{
+	$value = LdApi::Post("vx/user/have","name=".$username);
+	if($value != null)
+	{
+		return !($value["available"]);
+	}
+	return false;
+}
+
+// Create a new user (by email address)
+function ApiUserCreate($email, &$user)
+{
+	$value = LdApi::Post("vx/user/create","mail=".$email, $user);
+	if($value != null)
+	{
+		return $value["sent"];
+	}
+	return false;
+}
+
+function ApiUserActivate(&$user, $id, $auth_key)
+{
+	$name = $user["username"];
+	$pw = $user["password"];
+	
+	$postString = "id=".$id."&key=".$auth_key."&name=".$name."&pw=".$pw;
+	$value = LdApi::Post("vx/user/activate",$postString,$user);
+	
+	if($value != null)
+	{
+		return $value["response_httpcode"] == "201";
+	}
+	return false;
+}
+
+function ApiUserLogin(&$user)
+{
+	$login = $user["username"];
+	$pw = $user["password"];
+	
+	$value = LdApi::Post("vx/user/login", "login=".$login."&pw=".$pw, $user);
+	
+	if($value != null)
+	{
+		return $value["response_httpcode"] == "200"; 
+	}
+	return $false;
+}
 
 ////
-//// Now that we're far enough down in the file that nobody will ever see it, it's time to unleash the true dark magic
-//// Below is code to greatly simplify the process of poking the LD API from the script. Its features will be summarized above for mere mortals.
+//// Low level helper / generation code
 ////
 
+function GenerateRandomUsername()
+{
+  $length = random_int(2, 10);
+  return bin2hex(random_bytes($length));
+}
 
+function GenerateRandomPassword()
+{
+  $length = random_int(5, 10);
+  return bin2hex(random_bytes($length));
+}
+
+// Future: something much more meaningful. Also figure out how to include image uploads, links, other fun feathres.
+function GenerateRandomPostText($minWords = 10, $maxWords = 200)
+{
+	$words = random_int($minWords, $maxWords);
+	$allwords = array();
+	for($i=0;$i<$words;$i++)
+	{
+		$wordlength = random_int(1,5);
+		$word = bin2hex(random_bytes($wordlength));
+		$allwords[] = $word;
+	}
+	return implode(" ",$allwords);
+}
+
+////
+//// Low level API interface code
+////
+
+class LdApi
+{
+	static $debug_api = true;
+
+	static function SetRequestUser($curl, &$user)
+	{
+		if($user != null)
+		{
+			// Generate cookie string for user and set it.
+			$cookies = [];
+			foreach($user["cookies"] as $c => $v)
+			{
+				$cookies[] = $c."=".$v;
+			}
+			$cookiestring = implode("; ", $cookies);
+			curl_setopt($curl, CURLOPT_COOKIE, $cookiestring);
+			if($cookiestring != "")
+			{
+				Verbose("Sending Cookie: ".$cookiestring);
+			}
+		}
+	}
+	static function UpdateUserCookie($headers, &$user)
+	{
+		if($user != null)
+		{
+			$lines = explode("\r\n", $headers);
+			foreach($lines as $v)
+			{
+				$parts = explode(": ",$v, 2);
+				if($parts[0] == "Set-Cookie")
+				{
+					Verbose("Receive Set-Cookie: ".$parts[1]);
+					$c = explode(";", $parts[1]);
+					$cookiedata = explode("=",$c[0],2);
+					// interpret "=deleted" as the condition to delete a cookie, as the code to check the expires time is annoying in php.
+					if($cookiedata[1] == "deleted")
+					{
+						unset($user["cookies"][$cookiedata[0]]);
+					}
+					else
+					{
+						$user["cookies"][$cookiedata[0]] = $cookiedata[1];
+					}
+				}			
+			}
+		}
+	}
+	static function ForUser(&$user)
+	{
+		if($user != null)
+		{
+			return " for user " . $user["username"];
+		}
+		return "";
+	}
+  
+	public static function Get($url, &$user = NULL, $report_error=true)
+	{
+		global $apibase;
+		$outputObject = NULL;
+		$url = $apibase . $url;
+		if(LdApi::$debug_api)
+		{
+			Verbose("GET '".$url."'".LdApi::ForUser($user));
+		}
+		
+		$c = curl_init($url);
+		
+		curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($c, CURLOPT_HTTPGET, true);
+		
+		LdApi::SetRequestUser($c, $user);
+		
+		$result = curl_exec($c);
+		$success = !($result === false);
+		if($success)
+		{
+			$outputObject = json_decode($result, true);
+			$httpcode = curl_getinfo($c, CURLINFO_HTTP_CODE);
+			$outputObject["response_httpcode"] = $httpcode;			
+			LdApi::UpdateUserCookie($c, $user);
+		}
+		if(!$success && $report_error)
+		{
+			ReportError("Error getting '".$url ."'". LdApi::ForUser($user). " - " . curl_error($c));
+		}
+		
+		if(LdApi::$debug_api)
+		{
+			Verbose("Response '" . $result . "'");
+		}
+		curl_close($c);
+		
+		return $outputObject;
+	}
+	public static function Post($url, $postdata, &$user = NULL)
+	{
+		global $apibase;
+
+		$outputObject = NULL;
+		$url = $apibase . $url;		
+
+		if(LdApi::$debug_api)
+		{
+			Verbose("POST '".$url."' with data '".$postdata."'".LdApi::ForUser($user));
+		}
+		
+		$c = curl_init($url);
+		
+		curl_setopt($c, CURLOPT_HEADER, true);
+		curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($c, CURLOPT_POST, true);
+		curl_setopt($c, CURLOPT_POSTFIELDS, $postdata);
+		
+		LdApi::SetRequestUser($c, $user);
+		
+		$content = "";
+		$result = curl_exec($c);
+		$success = !($result === false);
+		if($success)
+		{
+			$parts = explode("\r\n\r\n",$result);
+			$headers = $parts[0];
+			$content = $parts[1];
+		
+			$outputObject = json_decode($content, true);
+			$httpcode = curl_getinfo($c, CURLINFO_HTTP_CODE);
+			$outputObject["response_httpcode"] = $httpcode;
+			
+			LdApi::UpdateUserCookie($headers, $user);
+		}
+		if(!$success && $report_error)
+		{
+			ReportError("Error getting '".$url ."'". LdApi::ForUser($user) . " - " . curl_error($c));
+		}
+		if(LdApi::$debug_api)
+		{
+			Verbose("Response '" . $content . "'");
+		}
+		curl_close($c);
+		return $outputObject;	
+	
+	}
+}
 
 
 

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -78,8 +78,11 @@ function TimeString()
 function ReportError($text)
 {
 	global $errorcount;
-	$errorcount++;
+	$errorcount++;	
 	$text = "[" . TimeString() . "] Error: " . $text . "\n";
+	
+	LdApi::PrintLastRequestResponse();
+	
 	print( "\x1b[1;31m" . $text . "\x1b[m"); // Draw with intense red color
 	LogFull($text);
 	LogErr($text);
@@ -90,6 +93,12 @@ function Verbose($text)
 	print($text);
 	LogFull($text);
 }
+function VerboseHidden($text)
+{
+	$text = "[" . TimeString() . "] Verbose: " . $text . "\n";
+	LogFull($text);
+}
+
 function VerboseAction($text)
 {
 	$text = "[" . TimeString() . "] Verbose: " . $text . "\n";
@@ -227,13 +236,13 @@ $stages = array(
 		"MaxEventsPerUser" => 200,
 		"PhaseStart" => 'SetupThemePhase',
 		"HighChance" => ['UserVoteOnTheme'],
-		"LowChance" => array('PostImIn', 'CommentOnPost')  // More various "I'm In" posts will trickle in
+		"LowChance" => array('PostImIn', 'CommentOnPost', 'LikePosts')  // More various "I'm In" posts will trickle in
 	),
 	// Third stage, LD Starts!
 	array(
 		"Name" => "Compo Running",
 		"StageStart" => 'StartCompo',
-		"HighChance" => array('CompoPostUpdate', 'CompoEditGame', 'CommentOnPost'),
+		"HighChance" => array('CompoPostUpdate', 'CompoEditGame', 'CommentOnPost', 'LikePosts'),
 		"LowChance" => array('CommentOnGame', 'CompoPublishGame', 'CommentUnlike')
 	),
 	// Fourth stage, Submission deadline
@@ -242,7 +251,7 @@ $stages = array(
 		"StageStart" => 'SetupSubmission',
 		"MaxMinutes" => 2,
 		"MaxEventsPerUser" => 20,
-		"HighChance" => array('CommentOnGame', 'CompoPublishGame'),
+		"HighChance" => array('CommentOnGame', 'CompoPublishGame', 'LikePosts'),
 		"LowChance" => array('CompoPostUpdate', 'CompoEditGame', 'CommentOnPost', 'CommentUnlike'),
 	),
 	// Fifth stage, Voting
@@ -250,20 +259,21 @@ $stages = array(
 		"Name" => "Compo Voting",
 		"StageStart" => 'SetupVoting',
 		"MaxEventsPerUser" => 300,
-		"HighChance" => array('CommentOnGame', 'VoteOnGame'),
+		"HighChance" => array('CommentOnGame', 'VoteOnGame', 'LikePosts', 'LikeGames'),
 		"LowChance" => array('CommentOnPost', 'CompoEditGame', 'CompoPostUpdate', 'CommentUnlike')
 	),
 	// Sixth stage - Closed / resuts
 	array(
 		"Name" => "Compo Results",
 		"StageStart" => 'EndCompo',
-		"LowChance" => array('CommentOnGame', 'CommentOnPost', 'CompoEditGame', 'CompoPostUpdate', 'CommentUnlike', 'CompoPostResults')
+		"LowChance" => array('CommentOnGame', 'CommentOnPost', 'CompoEditGame', 'CompoPostUpdate', 'CommentUnlike', 'CompoPostResults', 'LikePosts', 'LikeGames')
 	)
 );
 
 
 $event_admin_user = null;
-$event_users = array();
+$event_users = array(); // Only use for reference (e.g. getting usernames)
+$event_user_lookup = array(); // Only use this as a source for user objects, and get them by reference.
 
 $event_nodeid = null;
 
@@ -272,15 +282,19 @@ $event_nodeid = null;
 // We'll also use some data from the database to make the naming a bit more friendly.
 function SetupEvent()
 {
-	global $event_admin_user, $event_users;
+	global $event_admin_user, $event_users, $event_user_lookup;
 	
-	$event_admin_user = &User_Create();
+	$event_admin_user = User_Create();
 	
 	// Now create the normal users
 	global $usercount;
 	for($i=0;$i < $usercount; $i++)
 	{
 		$event_users[] = User_Create();
+	}
+	foreach($event_users as $user)
+	{
+		$event_user_lookup[$user["username"]] = $user;
 	}
 	
 	// Now generate an event
@@ -413,11 +427,71 @@ function PostImIn(&$user, $phase)
 	return false;
 }
 
-// Find a recent post in the feed, and post a comment - and optionally give it or one of its comments a like.
-function CommentOnPost(&$user, $phase)
+
+// Read through recent posts and comments on them, and randomly like comments
+function LikePosts(&$user, $phase)
+{
+	$posts = GetRecentEventPosts($posts);
+	if($posts != null)
+	{
+		LikeFeed($user, $posts);
+	}
+	return true;
+}
+
+// Read through highly sorted games and comments on them, and randomly like comments
+function LikeGames(&$user, $phase)
 {
 	return false;
 }
+
+// Helper: given a list of nodes, like at least one of them, and examine comments.
+function LikeFeed(&$user, $nodes)
+{
+	if($nodes == null || count($nodes) == 0) return;
+	
+	$likecount = 0;
+	foreach($nodes as $n)
+	{
+		if(random_int(1,10) == 1) LikeCommentsNode($user, $n);
+		if(random_int(1,40) == 1)
+		{
+			$likecount++;
+			LikeNode($user, $n["id"]);
+		}
+	}
+	if($likecount == 0)
+	{
+		$n = $nodes[random_int(1,count($nodes))-1];
+		LikeNode($user, $n["id"]);		
+	}	
+}
+
+// Helper: fetch a node's comments, and maybe like some of them.
+function LikeCommentsNode(&$user, $node)
+{
+	$comments = GetNodeComments($user, $node["id"]);
+	if($comments != null)
+	{
+		foreach($comments as $c)
+		{
+			if(random_int(1,20) == 1) LikeComment($user, $c["id"]);
+		}
+	}
+}
+
+// Find a recent post in the feed, and post a comment - and optionally give it or one of its comments a like.
+function CommentOnPost(&$user, $phase)
+{
+	$post = GetRandomRecentPost($user);
+	if($post != null)
+	{
+		$body = GenerateRandomPostText();
+		CreateComment($user, $post["id"], $body);
+	}
+	return true;
+}
+
 // Find a game through one of the game lists, and give it a comment, and optionally give it or one of its comments a like.
 function CommentOnGame(&$user, $phase)
 {
@@ -441,7 +515,9 @@ function CompoPostUpdate(&$user, $phase)
 	$title = GenerateRandomPostTitle();
 	$body = GenerateRandomPostText();
 	CreatePost($user, $title, $body);
-	return true;
+	
+	// There's a limit to how many posts a user should make. Try not to make too many more.
+	return count($user["posts"]) < 3;
 }
 
 // And this is the part of the game where some users wish to parade their stats into the news feed, or complain about PoV :)
@@ -573,20 +649,16 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 	if(key_exists("StageEnd",$stage)) { $stage["StageEnd"](); }
   
 }
+Message("All Stages Complete!");
 
 $currentstageactions = null;
 
 function PrepareStageActions($stage, $phase)
 {
 	global $event_users;
+	global $event_user_lookup;
 	global $currentstageactions;
 	$currentstageactions = [ "Allowed" => [], "Required" => [], "Users" => [], "ActiveUsernames" => [] ];
-	
-	// Generate a reference list of users for the current stage
-	foreach($event_users as $u)
-	{
-		$currentstageactions["Users"][$u["username"]] = &$u;
-	}
 	
 	// Extract actions out from stage	
 	// Always => List of functions (actions) to be called by all simulated users in this phase
@@ -597,14 +669,14 @@ function PrepareStageActions($stage, $phase)
 	{
 		foreach($stage["Always"] as $action)
 		{
-			foreach($currentstageactions["Users"] as $u)
+			foreach($event_users as $u)
 			{	
 				$currentstageactions["Allowed"][$u["username"]][] = $action;
 				$currentstageactions["Required"][$u["username"]][] = $action;
 			}
 		}
 	}
-	$usercount = count($currentstageactions["Users"]);
+	$usercount = count($event_users);
 	$halflow = floor($usercount/2);
 	$halfhigh = ceil($usercount/2);
 	
@@ -641,7 +713,7 @@ function PrepareStageActions($stage, $phase)
 	foreach($event_users as $u)
 	{
 		$n = $u["username"];
-		if(count($currentstageactions["Allowed"][$n]) > 0)
+		if(key_exists($n,$currentstageactions["Allowed"]) && count($currentstageactions["Allowed"][$n]) > 0)
 		{
 			$currentstageactions["ActiveUsernames"][] = $n;
 		}
@@ -686,12 +758,13 @@ function ExecuteAction(&$user, $action, $phase)
 function ExecuteStageAction($stage, $phase)
 {
 	global $currentstageactions;	
+	global $event_user_lookup;	
 	if(count($currentstageactions["ActiveUsernames"]) == 0) return false; // Nothing to do!
 	
 	// Pick a random user from the active usernames
 	$userindex = random_int(1,count($currentstageactions["ActiveUsernames"]))-1;
 	$username = $currentstageactions["ActiveUsernames"][$userindex];
-	$user = $currentstageactions["Users"][$username];
+	$user = &$event_user_lookup[$username];
 	
 	// Pick a random action from the available actions
 	$actions = $currentstageactions["Allowed"][$username];
@@ -728,9 +801,10 @@ function CompleteMandatoryStageActions($stage, $phase)
 {
 	// Complete any remaining Required actions that we didn't get to already (and remove from the list).
 	global $currentstageactions;	
+	global $event_user_lookup;	
 	foreach($currentstageactions["Required"] as $u => $actions)
 	{
-		$user = $currentstageactions["Users"][$u];
+		$user = &$event_user_lookup[$u];
 		
 		foreach($actions as $action)
 		{
@@ -759,6 +833,8 @@ function User_Create()
 		"joinedevent" => false,
 		"game_node" => 0,
 		"posts" => array(),
+		"notes" => array(),
+		"love" => array(),
 		"postedimin" => false,
 		"publishedgame" => false,
 	];
@@ -809,6 +885,8 @@ function User_Create()
 	
 	$user["id"] = $userid;
 	
+	Verbose("Created user " . $username);
+	
 	return $user;
 }
 
@@ -817,21 +895,101 @@ function User_EnsureJoined(&$user)
 	global $event_nodeid;
 	if(!$user["joinedevent"])
 	{
+		Verbose("Creating a game to join the event...");
 		$user["game_node"] = ApiNodeAdd($user, $event_nodeid, "item/game");
 		$user["joinedevent"] = true;
 	}
 }
 
-
-function GetRecentEventPosts($count = 30)
+function GetRandomRecentPost(&$user)
 {
+	Verbose("Fetching a random post...");
+	$nodes = GetRecentEventPostNodes($user);
+	if(count($nodes) == 0) return null;
+	$i = random_int(1,count($nodes))-1;
+	$data = ApiNodeGet($user, $nodes[$i]["id"]);
+	if($data == null)
+	{
+		ReportError("Error fetching node " . $nodes[$i]);
+		return null;
+	}
+	return $data[0];
+}
+
+function WalkFeedId(&$feed, $key) { $feed = $feed["id"]; }
+
+function GetRecentEventPosts(&$user)
+{
+	Verbose("Reading over the recent posts...");
+	$nodes = GetRecentEventPostNodes($user);
+	$fullnodes = [];
+	$chunks = array_chunk($nodes, 30);
+	foreach($chunks as $c)
+	{
+		array_walk($c, "WalkFeedId");
+		$idjoin = implode("+",$c);
+		$data = ApiNodeGet($user, $idjoin);
+		if($data != null)
+		{
+			foreach($data as $n)
+			{
+				$fullnodes[$n["id"]] = $n;
+			}
+		}
+	}
+	$outdata = [];
+	foreach($nodes as $n)
+	{
+		$data = $fullnodes[$n["id"]];
+		if($data != null) { $outdata[] = $data; }
+	}
+	if(count($outdata) == 0) return null;
+	return $outdata;
+}
+
+function GetRecentEventPostNodes(&$user, $count = 60)
+{
+	global $event_nodeid;
+	$maxpage = 30;
+	$have = 0;
+	$out = [];
+	while($have < $count)
+	{
+		$fetch = $count - $have;
+		if($fetch > $maxpage) $fetch = $maxpage;
+		
+		$newdata = ApiNodeFeed($user, $event_nodeid, "all", "post", $fetch, $have);
+		if($newdata === null)
+		{
+			ReportError("Error getting feed.");
+		}
+		else
+		{
+			$out = array_merge($out, $newdata);
+		}
+		$have += $fetch;
+	}
 	
+	if(count($out) == 0) return null;
+	return $out;
+}
+
+function GetNodeComments(&$user, $nodeid)
+{
+	Verbose("Reading Comments for node ".$nodeid."...");
+	$notes = ApiNoteGet($user, $nodeid);
+	if($notes === null)
+	{
+		ReportError("Failed to get notes for node ".$nodeid);
+	}
+	return $notes;
 }
 
 function CreatePost(&$user, $title, $body)
 {
 	User_EnsureJoined($user);
 	
+	Verbose("Creating a new post.");
 	$nodeid = ApiNodeAdd($user, $user["game_node"], "post");
 	if($nodeid == null)
 	{
@@ -854,7 +1012,48 @@ function CreatePost(&$user, $title, $body)
 function CreateComment(&$user, $nodeid, $body)
 {
 	User_EnsureJoined($user);
+	Verbose("Posting a comment to node " . $nodeid);
+	$id = ApiNoteAdd($user, $nodeid, $body);
+	if(!$id)
+	{
+		ReportError("Failed to add comment");
+		return null;
+	}
+	$user["notes"][] = [ "Node" => $nodeid, "Note" => $id ];
+}
 
+function LikeNode(&$user, $nodeid)
+{
+	# If we haven't already, add a like to this node. 
+	if(array_key_exists($nodeid, $user["love"])) return;
+
+	Verbose("Add like for Node " . $nodeid);
+	if(!ApiNodeLoveAdd($user, $nodeid))
+	{
+		ReportError("Error adding node love for ".$nodeid);
+		return;
+	}
+	$user["love"][] = $nodeid;
+}
+
+function LikeComment(&$user, $commentid)
+{
+	# If we haven't already, add a like to this comment
+	if(array_key_exists(-$commentid, $user["love"])) return;
+	
+	Verbose("Add like for Note " . $commentid);
+	if(!ApiNoteLoveAdd($user, $commentid))
+	{
+		ReportError("Error adding note love for ".$commentid);
+		return;
+	}
+	$user["love"][] = -$commentid;
+}
+
+function RemoveLike(&$user, $thing)
+{
+	// Positive numbers = node love, Negative numbers = note love
+	
 }
 
 
@@ -866,7 +1065,7 @@ function CreateComment(&$user, $nodeid, $body)
 // Get one or more nodes
 function ApiNodeGet(&$user, $nodeidlist)
 {
-	$value = LdApi::Post("vx/node/get/".$nodeidlist, $user);
+	$value = LdApi::Get("vx/node/get/".$nodeidlist, $user);
 	if($value != null)
 	{
 		return $value["node"];
@@ -878,7 +1077,7 @@ function ApiNodeGet(&$user, $nodeidlist)
 function ApiNodeFeed(&$user, $parentid, $methods, $type, $count, $offset = 0)
 { // GET node/feed/:node_id/:methods[]/:type/[:subtype]/[:subsubtype] ?offset= ?limit=
 
-	$value = LdApi::Post("vx/node/feed/" . $methods . "/" . $type . "?offset=" . $offset . "&limit=" . $count, $user);
+	$value = LdApi::Get("vx/node/feed/" . $parentid . "/" . $methods . "/" . $type . "?offset=" . $offset . "&limit=" . $count, $user);
 	if($value != null)
 	{
 		return $value["feed"];
@@ -929,13 +1128,13 @@ function ApiNodePublish(&$user, $nodeid)
 
 function ApiNodeLoveAdd(&$user, $nodeid) //GET node/love/add/:node_id
 {
-	$value = LdApi::Get("vx/node/love/add" . $nodeid, $user);
+	$value = LdApi::Get("vx/node/love/add/" . $nodeid, $user);
 	return ResponseIs200($value);
 }
 
 function ApiNodeLoveRemove(&$user, $nodeid) //GET node/love/remove/:node_id
 {
-	$value = LdApi::Get("vx/node/love/add" . $nodeid, $user);
+	$value = LdApi::Get("vx/node/love/remove/" . $nodeid, $user);
 	return ResponseIs200($value);
 }
 
@@ -952,9 +1151,9 @@ function ApiNodeMetaRemove(&$user, $nodeid, $key) // POST node/meta/remove/:node
 }
 
 
-function ApiNoteAdd(&$user, $parentid, $body) // POST note/add
+function ApiNoteAdd(&$user, $nodeid, $body) // POST note/add
 {
-	$value = LdApi::Post("vx/note/add","parent=".$parentid."&body=".$body, $user);
+	$value = LdApi::Post("vx/note/add/".$nodeid,"parent=0&body=".$body, $user);
 	if($value) { return $value["note"]; }
 	return null;
 }
@@ -966,9 +1165,9 @@ function ApiNoteUpdate(&$user, $parentid, $noteid, $newbody)
 }
 
 // Get all notes for a node
-function ApiNoteGet(&$user, $nodeId)
+function ApiNoteGet(&$user, $nodeid)
 {
-	$value = LdApi::Get("vx/note/get/" + $nodeid, $user);
+	$value = LdApi::Get("vx/note/get/" . $nodeid, $user);
 	if($value)
 	{
 		return $value["note"];
@@ -978,13 +1177,13 @@ function ApiNoteGet(&$user, $nodeId)
 
 function ApiNoteLoveAdd(&$user, $noteid)
 {
-	$value = LdApi::Get("vx/note/love/add" . $noteid, $user);
+	$value = LdApi::Get("vx/note/love/add/" . $noteid, $user);
 	return ResponseIs200($value);
 }
 
 function ApiNoteLoveRemove(&$user, $noteid)
 {
-	$value = LdApi::Get("vx/note/love/remove" . $noteid, $user);
+	$value = LdApi::Get("vx/note/love/remove/" . $noteid, $user);
 	return ResponseIs200($value);
 }
 
@@ -1092,7 +1291,42 @@ function GenerateRandomPostText($minWords = 10, $maxWords = 200)
 
 class LdApi
 {
-	static $debug_api = true;
+	static $debug_api = false;
+
+	static $lastRequestLog = null;
+	static $lastResponseLog = null;
+
+	public static function PrintLastRequestResponse()
+	{
+		print( "\x1b[31mLast Request/Response:\x1b[m\n"); 
+		print( "\x1b[31m" . LdApi::$lastRequestLog . "\x1b[m\n"); 
+		print( "\x1b[31m" . LdApi::$lastResponseLog . "\x1b[m\n"); 
+	}
+
+	static function DebugRequestLog($log)
+	{
+		if(LdApi::$debug_api)
+		{
+			Verbose($log);
+		}
+		else
+		{
+			VerboseHidden($log);
+		}		
+		LdApi::$lastRequestLog = $log;
+	}
+	static function DebugResponseLog($log)
+	{
+		if(LdApi::$debug_api)
+		{
+			Verbose($log);
+		}
+		else
+		{
+			VerboseHidden($log);
+		}		
+		LdApi::$lastResponseLog = $log;	
+	}
 
 	static function SetRequestUser($curl, &$user)
 	{
@@ -1153,10 +1387,8 @@ class LdApi
 		global $apibase;
 		$outputObject = NULL;
 		$url = $apibase . $url;
-		if(LdApi::$debug_api)
-		{
-			Verbose("GET '".$url."'".LdApi::ForUser($user));
-		}
+		
+		LdApi::DebugRequestLog("GET '".$url."'".LdApi::ForUser($user));
 		
 		$c = curl_init($url);
 		
@@ -1172,23 +1404,26 @@ class LdApi
 		if($success)
 		{
 			$parts = explode("\r\n\r\n",$result);
+			while($parts[0] == "HTTP/1.1 100 Continue") { array_shift($parts); }
 			$headers = $parts[0];
 			$content = $parts[1];
 		
 			$outputObject = json_decode($content, true);
 			$httpcode = curl_getinfo($c, CURLINFO_HTTP_CODE);
 			$outputObject["response_httpcode"] = $httpcode;			
-			LdApi::UpdateUserCookie($c, $user);
+			LdApi::UpdateUserCookie($headers, $user);
 		}
 		if(!$success && $report_error)
 		{
 			ReportError("Error getting '".$url ."'". LdApi::ForUser($user). " - " . curl_error($c));
 		}
 		
-		if(LdApi::$debug_api)
+		LdApi::DebugResponseLog("Response '" . $content . "'");
+		if(substr($content,0,4) == "HTTP")
 		{
-			Verbose("Response '" . $content . "'");
-		}
+			Verbose("Debug: '" . $result);
+		}			
+
 		curl_close($c);
 		
 		return $outputObject;
@@ -1200,10 +1435,7 @@ class LdApi
 		$outputObject = NULL;
 		$url = $apibase . $url;		
 
-		if(LdApi::$debug_api)
-		{
-			Verbose("POST '".$url."' with data '".$postdata."'".LdApi::ForUser($user));
-		}
+		LdApi::DebugRequestLog("POST '".$url."' with data '".$postdata."'".LdApi::ForUser($user));
 		
 		$c = curl_init($url);
 		
@@ -1220,6 +1452,7 @@ class LdApi
 		if($success)
 		{
 			$parts = explode("\r\n\r\n",$result);
+			while($parts[0] == "HTTP/1.1 100 Continue") { array_shift($parts); }
 			$headers = $parts[0];
 			$content = $parts[1];
 		
@@ -1233,10 +1466,13 @@ class LdApi
 		{
 			ReportError("Error getting '".$url ."'". LdApi::ForUser($user) . " - " . curl_error($c));
 		}
-		if(LdApi::$debug_api)
+		
+		LdApi::DebugResponseLog("Response '" . $content . "'");
+		if(substr($content,0,4) == "HTTP")
 		{
-			Verbose("Response '" . $content . "'");
+			Verbose("Debug: '" . $result);
 		}
+
 		curl_close($c);
 		return $outputObject;	
 	

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -60,7 +60,7 @@ $logbase = "/tmp/ld_event"; // Logs will be put in /tmp
 //   <name>.<eventIndex>.err (Summary log and errors)
 
 $apibase = "http://api.ludumdare.org/";
-$usercount = 3; // Something like 40-50 is good for reasonable size tests.
+$usercount = 10; // Something like 40-50 is good for reasonable size tests.
 $keepallposts = true;
 $keeppostcount = 100; // Number of posts per user to keep, when keep all posts is false (which it should be for high user counts or long runtimes / stress environments.)
 $verbose = true; // Display all of the details about what's going on?
@@ -225,7 +225,7 @@ $stages = array(
 		"Name" => "Setup",
 		"StageStart" => 'SetupEvent',
 		"MaxMinutes" => 1,
-		"MaxEventsPerUser" => 15,
+		"MaxEventsPerUser" => 3,
 		"LowChance" => array('PostImIn', 'CommentOnPost') // Early "I'm In" posts
 	),
 	// Second stage, Theme voting
@@ -233,10 +233,10 @@ $stages = array(
 		"Name" => "Theme Voting",
 		"Phases" => 7, // Theme suggestion + theme slaughter + 4 rounds of voting + theme selection
 		"MaxMinutes" => 1, // This is per phase
-		"MaxEventsPerUser" => 200,
+		"MaxEventsPerUser" => 5,
 		"PhaseStart" => 'SetupThemePhase',
 		"HighChance" => ['UserVoteOnTheme'],
-		"LowChance" => array('PostImIn', 'CommentOnPost', 'LikePosts')  // More various "I'm In" posts will trickle in
+		"LowChance" => array('PostImIn', 'CommentOnPost', 'LikePosts', 'CommentUnlike')  // More various "I'm In" posts will trickle in
 	),
 	// Third stage, LD Starts!
 	array(
@@ -250,7 +250,7 @@ $stages = array(
 		"Name" => "Compo Submission Period",
 		"StageStart" => 'SetupSubmission',
 		"MaxMinutes" => 2,
-		"MaxEventsPerUser" => 20,
+		"MaxEventsPerUser" => 10,
 		"HighChance" => array('CommentOnGame', 'CompoPublishGame', 'LikePosts'),
 		"LowChance" => array('CompoPostUpdate', 'CompoEditGame', 'CommentOnPost', 'CommentUnlike'),
 	),
@@ -258,7 +258,7 @@ $stages = array(
 	array(
 		"Name" => "Compo Voting",
 		"StageStart" => 'SetupVoting',
-		"MaxEventsPerUser" => 300,
+		"MaxEventsPerUser" => 80,
 		"HighChance" => array('CommentOnGame', 'VoteOnGame', 'LikePosts', 'LikeGames'),
 		"LowChance" => array('CommentOnPost', 'CompoEditGame', 'CompoPostUpdate', 'CommentUnlike')
 	),
@@ -431,7 +431,7 @@ function PostImIn(&$user, $phase)
 // Read through recent posts and comments on them, and randomly like comments
 function LikePosts(&$user, $phase)
 {
-	$posts = GetRecentEventPosts($posts);
+	$posts = GetRecentEventPosts($user);
 	if($posts != null)
 	{
 		LikeFeed($user, $posts);
@@ -442,6 +442,11 @@ function LikePosts(&$user, $phase)
 // Read through highly sorted games and comments on them, and randomly like comments
 function LikeGames(&$user, $phase)
 {
+	$posts = GetTopGames($user);
+	if($posts != null)
+	{
+		LikeFeed($user, $posts);
+	}
 	return false;
 }
 
@@ -483,11 +488,15 @@ function LikeCommentsNode(&$user, $node)
 // Find a recent post in the feed, and post a comment - and optionally give it or one of its comments a like.
 function CommentOnPost(&$user, $phase)
 {
-	$post = GetRandomRecentPost($user);
-	if($post != null)
+	$commentcount = random_int(1,5);
+	for($i=0;$i<$commentcount;$i++)
 	{
-		$body = GenerateRandomPostText();
-		CreateComment($user, $post["id"], $body);
+		$post = GetRandomRecentPost($user);
+		if($post != null)
+		{
+			$body = GenerateRandomPostText();
+			CreateComment($user, $post["id"], $body);
+		}
 	}
 	return true;
 }
@@ -495,7 +504,17 @@ function CommentOnPost(&$user, $phase)
 // Find a game through one of the game lists, and give it a comment, and optionally give it or one of its comments a like.
 function CommentOnGame(&$user, $phase)
 {
-	return false;
+	$commentcount = random_int(1,3);
+	for($i=0;$i<$commentcount;$i++)
+	{
+		$post = GetRandomTopGame($user);
+		if($post != null)
+		{
+			$body = GenerateRandomPostText();
+			CreateComment($user, $post["id"], $body);
+		}
+	}
+	return true;
 }
 // Find a game through one of the game lists, and vote on it. Or change the votes to something else.
 function VoteOnGame(&$user, $phase)
@@ -506,6 +525,7 @@ function VoteOnGame(&$user, $phase)
 // Remove a like from some post/comment/game that was liked previously. The simulated user revisits the node and comments, and removes the like.
 function CommentUnlike(&$user, $phase)
 {
+	UnlikeRandom($user);
 	return false;
 }
 
@@ -529,11 +549,21 @@ function CompoPostResults(&$user, $phase)
 // Modify the record for the current user's game and submit an update.
 function CompoEditGame(&$user, $phase)
 {
-	return false;
+	// For now, just carelessly replace everything. Future: do something smarter.
+	$title = GenerateRandomPostTitle();
+	$body = GenerateRandomPostText();
+	ModifyGame($user, $title, $body);
+	return true;
 }
 // Can only be called once. If the game is not published, publish it.
 function CompoPublishGame(&$user, $phase)
 {
+	// Need to ensure there is something good before publish.
+	$title = GenerateRandomPostTitle();
+	$body = GenerateRandomPostText();
+	ModifyGame($user, $title, $body);
+
+	PublishGame($user);
 	return false;
 }
 
@@ -651,6 +681,10 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 }
 Message("All Stages Complete!");
 
+	Verbose("Kickoff cron magic.php task one last time to update necessary values in the db.");
+	exec("php ~/www/private/magic.php");
+
+
 $currentstageactions = null;
 
 function PrepareStageActions($stage, $phase)
@@ -658,7 +692,7 @@ function PrepareStageActions($stage, $phase)
 	global $event_users;
 	global $event_user_lookup;
 	global $currentstageactions;
-	$currentstageactions = [ "Allowed" => [], "Required" => [], "Users" => [], "ActiveUsernames" => [] ];
+	$currentstageactions = [ "Allowed" => [], "Required" => [], "Users" => [], "ActiveUsernames" => [], "ActionCount" => [] ];
 	
 	// Extract actions out from stage	
 	// Always => List of functions (actions) to be called by all simulated users in this phase
@@ -708,6 +742,9 @@ function PrepareStageActions($stage, $phase)
 			}
 		}	
 	}	
+
+	$eventsperuser = -1;
+	if(key_exists("MaxEventsPerUser",$stage)) { $eventsperuser = $stage["MaxEventsPerUser"]; } 
 	
 	// Compute ActiveUsernames from users that have actions still.
 	foreach($event_users as $u)
@@ -717,7 +754,9 @@ function PrepareStageActions($stage, $phase)
 		{
 			$currentstageactions["ActiveUsernames"][] = $n;
 		}
+		$currentstageactions["ActionCount"][$n] = $eventsperuser;
 	}
+	
 }
 
 function PickRandomSubset($objects, $count)
@@ -792,6 +831,13 @@ function ExecuteStageAction($stage, $phase)
 		{
 			RemoveElement($currentstageactions["ActiveUsernames"], $username);
 		}
+	}
+	
+	// Decrement action count & disable username if it hits zero.
+	$currentstageactions["ActionCount"][$username]--;
+	if($currentstageactions["ActionCount"][$username] == 0)
+	{
+		RemoveElement($currentstageactions["ActiveUsernames"], $username);
 	}
 	
 	return true;
@@ -916,14 +962,42 @@ function GetRandomRecentPost(&$user)
 	return $data[0];
 }
 
-function WalkFeedId(&$feed, $key) { $feed = $feed["id"]; }
+function GetRandomTopGame(&$user)
+{
+	Verbose("Fetching a random game...");
+	$nodes = GetTopEventGameNodes($user);
+	if(count($nodes) == 0) return null;
+	$i = random_int(1,count($nodes))-1;
+	$data = ApiNodeGet($user, $nodes[$i]["id"]);
+	if($data == null)
+	{
+		ReportError("Error fetching node " . $nodes[$i]);
+		return null;
+	}
+	return $data[0];
+}
+
+function GetTopGames(&$user)
+{
+	Verbose("Reading over the top games...");
+	$nodes = GetTopEventGameNodes($user);
+	return GetNodesForFeed($user, $nodes);
+}
 
 function GetRecentEventPosts(&$user)
 {
 	Verbose("Reading over the recent posts...");
 	$nodes = GetRecentEventPostNodes($user);
+	return GetNodesForFeed($user, $nodes);
+}
+
+function WalkFeedId(&$feed, $key) { $feed = $feed["id"]; }
+
+function GetNodesForFeed(&$user, $feed)
+{
+	if(count($feed) == 0) return [];
 	$fullnodes = [];
-	$chunks = array_chunk($nodes, 30);
+	$chunks = array_chunk($feed, 30);
 	foreach($chunks as $c)
 	{
 		array_walk($c, "WalkFeedId");
@@ -938,7 +1012,7 @@ function GetRecentEventPosts(&$user)
 		}
 	}
 	$outdata = [];
-	foreach($nodes as $n)
+	foreach($feed as $n)
 	{
 		$data = $fullnodes[$n["id"]];
 		if($data != null) { $outdata[] = $data; }
@@ -959,6 +1033,33 @@ function GetRecentEventPostNodes(&$user, $count = 60)
 		if($fetch > $maxpage) $fetch = $maxpage;
 		
 		$newdata = ApiNodeFeed($user, $event_nodeid, "all", "post", $fetch, $have);
+		if($newdata === null)
+		{
+			ReportError("Error getting feed.");
+		}
+		else
+		{
+			$out = array_merge($out, $newdata);
+		}
+		$have += $fetch;
+	}
+	
+	if(count($out) == 0) return null;
+	return $out;
+}
+
+function GetTopEventGameNodes(&$user, $count = 60)
+{
+	global $event_nodeid;
+	$maxpage = 30;
+	$have = 0;
+	$out = [];
+	while($have < $count)
+	{
+		$fetch = $count - $have;
+		if($fetch > $maxpage) $fetch = $maxpage;
+		
+		$newdata = ApiNodeFeed($user, $event_nodeid, "smart+parent", "item/game/compo+jam", $fetch, $have);
 		if($newdata === null)
 		{
 			ReportError("Error getting feed.");
@@ -1050,10 +1151,81 @@ function LikeComment(&$user, $commentid)
 	$user["love"][] = -$commentid;
 }
 
+function UnlikeRandom(&$user)
+{
+	$count = count($user["love"]);
+	if($count < 1) return;
+	
+	$item = random_int(1,$count)-1;
+	$remove = $user["love"][$item];
+	if($item != ($count-1)) $user["love"][$item] = $user["love"][$count-1];
+	unset($user["love"][$count-1]);
+	
+	RemoveLike($user, $remove);
+}
+
 function RemoveLike(&$user, $thing)
 {
 	// Positive numbers = node love, Negative numbers = note love
+	if($thing < 0)
+	{
+		$thing = -$thing;
+		Verbose("Remove note love ". $thing);
+		if(!ApiNoteLoveRemove($user, $thing))
+		{
+			ReportError("Failed to remove note love for ". $thing);
+		}
+	}
+	else
+	{
+		Verbose("Remove node love ". $thing);
+		if(!ApiNodeLoveRemove($user, $thing))
+		{
+			ReportError("Failed to remove node love for ". $thing);
+		}		
+	}
+}
+
+function ModifyGame(&$user, $newTitle, $newBody)
+{
+	User_EnsureJoined($user);
+	Verbose("Modifying game node information...");
 	
+	if(!ApiNodeUpdate($user, $user["game_node"], $newTitle, $newBody))
+	{
+		ReportError("Failure to update game.");
+		return;
+	}
+}
+
+function PublishGame(&$user)
+{
+	User_EnsureJoined($user);
+	// Bail early if user already published game.
+	if($user["publishedgame"]) return;
+	
+	Verbose("Publishing game node ".$user["game_node"]);
+	
+	// Transform game into compo or jam game
+	$newtype = ["item/game/compo","item/game/jam"][random_int(0,1)];
+	if(!ApiNodeTransform($user, $user["game_node"], $newtype))
+	{
+		ReportError("Failed to transform game node to " . $newtype);
+	}
+	
+	// other stuff (future: enable opt-outs and stuff)
+	
+	
+	// Publish!
+	if(!ApiNodePublish($user, $user["game_node"]))
+	{
+		ReportError("Failed to publish game!");
+	}
+	
+	$user["publishedgame"] = true;
+	
+	Verbose("Kickoff cron magic.php task to update necessary scores in the db.");
+	exec("php ~/www/private/magic.php");
 }
 
 

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -1,0 +1,234 @@
+#!/usr/bin/env php
+<?php 
+
+const CONFIG_PATH = "../src/shrub/";
+const SHRUB_PATH = "../src/shrub/src/";
+
+# Use shrub wrapper for db access
+include_once __DIR__."/".CONFIG_PATH."config.php";
+require_once __DIR__."/".SHRUB_PATH."constants.php";
+require_once __DIR__."/".SHRUB_PATH."core/db.php";
+require_once __DIR__."/".SHRUB_PATH."node/node.php";
+require_once __DIR__."/".SHRUB_PATH."user/user.php";
+
+/*
+	Summary of this program and its intent:
+	
+This is an API test for the ludumdare website. It's goal is to interact with all API functionality by simulating a ludumdare.
+Users will be created, an event will be created, users will post, read other users posts, post comments, like, etc.
+Users will interact with the theme creation process stages, will publish games, will rate each other's games, and will observe the results.
+The script will keep track of (some/much of) the data it generates, and will verify that what it sees is what it expects.
+(Future) Users will maliciously interact with the API to verify that things cannot be changed (e.g. votes, theme creation) outside of the time when they are enabled to be changed.
+
+The exact flow will be documented in the data structures that guide the process, below.
+
+*/
+
+if ( count($argv) < 3  || ($argv[2] != "actions" && $argv[2] != "minutes")) {
+	print "LudumDare Event simulator. Quick summary:\n";
+	print "  Creates a new event, and simulates a number of users interacting with it.\n";
+	print "  This is an API test, and does not aim to test the website's rendering.\n";
+	print "  (It does however provide a good way to generate data to test the website)\n";
+	print "\n";
+	print "Run simulation for 1000 actions per stage: ".$argv[0]." 1000 actions\n";
+	print "Run simulation for 5 minutes per stage: ".$argv[0]." 5 minutes\n";
+	print "\n";
+	exit(1);
+}
+
+
+$runminutes = null;
+$runactions = null;
+if($argv[2] == "minutes")
+{
+	$runminutes = intval($argv[1]);
+} 
+else 
+{
+	$runactions = intval($argv[1]);
+}
+
+
+////////////////////////////////
+// Some global settings
+$usercount = 40;
+$keepallposts = true;
+$keeppostcount = 100; // Number of posts per user to keep, when keep all posts is false (which it should be for high user counts or long runtimes / stress environments.)
+$verbose = true; // Display all of the details about what's going on?
+$verboselog = true; // Keep all details about what's going on in a log.
+$useprevioususers = false; // (not implemented) Load the set of users from the previous test event, instead of creating new users.
+
+
+
+/*
+	Stages definition:
+Each stage is a hashtable with a number of properties that are used to determine the behavior in that stage.
+Properties:
+	Name => Name to display for the stage
+	Phases => if present, number indicating how many phases there are to the stage (otherwise just one)
+	MaxMinutes => if present, override the time for each phase in this stage to avoid spending a lot of time on it.
+	MaxEventsPerUser => if present, impose a hard limit on events per user for each phase in this stage to avoid spending a lot of time on this section.
+	StageStart => Function that is called when the stage starts
+	StageEnd => Function that is called when the stage ends
+	PhaseStart => Function to be called when a phase starts
+	PhaseEnd => Function to be called when a phase ends
+	
+	Always => List of functions (actions) to be called by all simulated users in this phase
+	LowChance => List of functions (actions) to be called by a few (at least one, but less than half) of the simulated users in this phase. Each function gets its own list of users
+	HighChance => list of functions (actions) to be called by most (not all, but at least half) of the simulated users in this phase. Each function gets its own list of users
+	
+	UserVerify => Function that is called arbitrarily to ask the system to verify that the data it receives from the website for a specific user is consistent with what it expects.
+	
+About start/end functions:
+	Stage start and end have no argument
+	Phase start and end are passed the current phase index as an argument.
+	
+About actions:
+	The action function is always called to ask a specific user to take action.
+	The action function is passed a user array, and the phase index.
+	if the action function returns false, it will not be called again for that user in that phase. Otherwise it may be called multiple times.
+	
+About reporting errors:
+	TBD
+	
+*/
+$stages = array(
+	// First stage, create users and generate the event
+	array(
+		"Name" => "Setup",
+		"Setup" => SetupEvent,
+		"MaxMinutes" => 1,
+		"MaxEventsPerUser" => 15,
+		"LowChance" => array(PostImIn, CommentOnPost) // Early "I'm In" posts
+	),
+	// Second stage, Theme voting
+	array(
+		"Name" => "Theme Voting",
+		"Phases" => 7, // Theme suggestion + theme slaughter + 4 rounds of voting + theme selection
+		"MaxMinutes" => 1, // This is per phase
+		"MaxEventsPerUser" => 200,
+		"PhaseStart" => SetupThemePhase,
+		"HighChance" => UserVoteOnTheme,
+		"LowChance" => array(PostImIn, CommentOnPost)  // More various "I'm In" posts will trickle in
+	),
+	// Third stage, LD Starts!
+	array(
+		"Name" => "Compo Running",
+		"Setup" => StartCompo,
+		"HighChance" => array(CompoPostUpdate, CompoEditGame, CommentOnPost),
+		"LowChance" => array(CommentOnGame, CompoPublishGame, CommentUnlike)
+	),
+	// Fourth stage, Submission deadline
+	array(
+		"Name" => "Compo Submission Period",
+		"Setup" => SetupSubmission,
+		"MaxMinutes" => 2,
+		"MaxEventsPerUser" => 20,
+		"HighChance" => array(CommentOnGame, CompoPublishGame),
+		"LowChance" => array(CompoPostUpdate, CompoEditGame, CommentOnPost, CommentUnlike),
+	),
+	// Fifth stage, Voting
+	array(
+		"Name" => "Compo Voting",
+		"Setup" => SetupVoting,
+		"MaxEventsPerUser" => 300,
+		"HighChance" => array(CommentOnGame, VoteOnGame),
+		"LowChance" => array(CommentOnPost, CompoEditGame, CompoPostUpdate, CommentUnlike)
+	),
+	// Sixth stage - Closed / resuts
+	array(
+		"Name" => "Compo Results",
+		"Setup" => EndCompo,
+		LowChance => array(CommentOnGame, CommentOnPost, CompoEditGame, CompoPostUpdate, CommentUnlike, CompoPostResults)
+	)
+);
+
+
+// Prepare the event. Create an admin superuser. Create all the compo users. Create the new LudumDare event. Publish the event node.
+// Some of this has to be done through the database directly (finding the email verification links, and creating the ludumdare event and setting it up)
+// We'll also use some data from the database to make the naming a bit more friendly.
+function SetupEvent()
+{
+
+}
+
+// Set up for each of the phases of the theme selection, in sequence.
+function SetupThemePhase($phase)
+{
+}
+
+// The compo has now started, the theme voting is now locked and a theme is selected. The users will be sure to mention the theme in some of their posts.
+function StartCompo()
+{
+}
+
+// The compo has now stopped and will only accept submissions for a limited amount of time. Configure the event to this mode.
+function SetupSubmission()
+{
+}
+
+// User should discover and interact with the available options in the current theme voting phase.
+function UserVoteOnTheme($user, $phase)
+{
+
+}
+
+
+// Post a very simple "I'm In" post. Only do this once per event.
+function PostImIn($user, $phase)
+{
+
+}
+
+// Find a recent post in the feed, and post a comment - and optionally give it or one of its comments a like.
+function CommentOnPost($user, $phase)
+{
+}
+// Find a game through one of the game lists, and give it a comment, and optionally give it or one of its comments a like.
+function CommentOnGame($user, $phase)
+{
+}
+
+// Remove a like from some post/comment/game that was liked previously. The simulated user revisits the node and comments, and removes the like.
+function CommentUnlike($user, $phase)
+{
+}
+
+// Generate and post a new item to the compo feed
+function CompoPostUpdate($user, $phase)
+{
+}
+
+// And this is the part of the game where some users wish to parade their stats into the news feed, or complain about PoV :)
+function CompoPostResults($user, $phase)
+{
+}
+
+// Modify the record for the current user's game and submit an update.
+function CompoEditGame($user, $phase)
+{
+
+}
+// Can only be called once. If the game is not published, publish it.
+function CompoPublishGame($user, $phase)
+{
+
+}
+
+////
+//// Code to drive the stage progression based on the $stages variable defined above.
+////
+
+
+
+
+////
+//// Now that we're far enough down in the file that nobody will ever see it, it's time to unleash the true dark magic
+//// Below is code to greatly simplify the process of poking the LD API from the script. Its features will be summarized above for mere mortals.
+////
+
+
+
+
+print "test\n";
+exit(0);

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -52,8 +52,15 @@ else
 ////////////////////////////////
 // Some global settings
 
+$enable_file_logs = true;
+$logbase = "/tmp/ld_event"; // Logs will be put in /tmp
+// Generate 3 kinds of log. 
+//   <name>.<eventIndex>.event (Event information, user/password list)
+//   <name>.<eventIndex>.log (Full Detail Verbose log)
+//   <name>.<eventIndex>.err (Summary log and errors)
+
 $apibase = "http://api.ludumdare.org/";
-$usercount = 40;
+$usercount = 3; // Something like 40-50 is good for reasonable size tests.
 $keepallposts = true;
 $keeppostcount = 100; // Number of posts per user to keep, when keep all posts is false (which it should be for high user counts or long runtimes / stress environments.)
 $verbose = true; // Display all of the details about what's going on?
@@ -72,13 +79,97 @@ function ReportError($text)
 {
 	global $errorcount;
 	$errorcount++;
-	print("[" . TimeString() . "] Error: " . $text . "\n");
+	$text = "[" . TimeString() . "] Error: " . $text . "\n";
+	print($text);
+	LogFull($text);
+	LogErr($text);
 }
 function Verbose($text)
 {
-	print("[" . TimeString() . "] Verbose: " . $text . "\n");
+	$text = "[" . TimeString() . "] Verbose: " . $text . "\n";
+	print($text);
+	LogFull($text);
+}
+function Message($text)
+{
+	$text = "[" . TimeString() . "] " . $text . "\n";
+	print($text);
+	LogFull($text);
+	LogErr($text);
 }
 
+
+$flogfull = null;
+$flogerr = null;
+
+function LogFull($text)
+{
+	global $flogfull;
+	if($flogfull != null)
+	{
+		fwrite($flogfull, $text);
+		fflush($flogfull);
+	}
+}
+function LogErr($text)
+{
+	global $flogerr;
+	if($flogerr != null)
+	{
+		fwrite($flogerr, $text);
+		fflush($flogerr);
+	}
+}
+
+function OpenLogs($index)
+{
+	global $logbase;
+	global $flogfull;
+	global $flogerr;
+	$fulllog = $logbase . "." . $index . ".log";
+	$errlog = $logbase . "." . $index . ".err";
+	$flogfull = fopen($fulllog, "a");
+	$flogerr = fopen($errlog, "a");
+}
+
+function CloseLogs()
+{
+	global $flogfull;
+	global $flogerr;
+	fclose($flogfull);
+	fclose($flogerr);
+	$flogfull = null;
+	$flogerr = null;
+}
+
+function OpenEventFile()
+{
+	global $logbase;
+	global $eventindex;
+	$log = $logbase . "." . $eventindex . ".event";
+	return fopen($log, "a");
+}
+
+// Figure out event index to use for this run, and start loggers.
+
+$events = db_QueryFetch(
+		"SELECT
+			n.id, n.name, n.slug, 
+			".DB_FIELD_DATE('n.modified', 'modified')."
+		FROM
+			".SH_TABLE_PREFIX.SH_TABLE_NODE." AS n
+		WHERE n.type = 'event'
+		ORDER BY n.id
+		LIMIT 500
+		;"
+	);
+
+$eventindex = count($events) + 1;
+
+if($enable_file_logs)
+{
+	OpenLogs($eventindex);
+}
 
 
 /*
@@ -168,6 +259,7 @@ $stages = array(
 $event_admin_user = null;
 $event_users = array();
 
+$event_nodeid = null;
 
 // Prepare the event. Create an admin superuser. Create all the compo users. Create the new LudumDare event. Publish the event node.
 // Some of this has to be done through the database directly (finding the email verification links, and creating the ludumdare event and setting it up)
@@ -178,13 +270,78 @@ function SetupEvent()
 	
 	$event_admin_user = User_Create();
 	
+	// Now create the normal users
+	global $usercount;
+	for($i=0;$i < $usercount; $i++)
+	{
+		$event_users[] = User_Create();
+	}
 	
-	exit(0);
+	// Now generate an event
+	global $event_nodeid;
+	global $eventindex;
+	$parentnode = 1; // Future: build out a more complex structure for this test.
+	$author = $event_admin_user["id"];
+	$eventname = "Testumdare " . ($eventindex);  
+	
+	$starttime = time();
+	$endtime = $starttime + 48*60*60;
+	$formatStart = gmdate("Y-m-d\TH:i:s\Z", $starttime);
+	$formatEnd = gmdate("Y-m-d\TH:i:s\Z", $endtime);
+	
+	$event_nodeid = node_Add( $parentnode, $author, "event", "", "", null, $cmdname, "");
+
+	// Add metadata
+	nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'can-create', 'item/game');
+
+	nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'event-start', $formatStart);
+	nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'event-end', $formatEnd);
+
+	// Also publish the event
+
+	// (soon)
+
+
+	// Make featured
+	nodeMeta_AddByNode(1, SH_NODE_META_PUBLIC, 'featured', "$event_nodeid");
+	
+	
+	// Save information about the users into a file
+	$f = OpenEventFile();
+	fwrite($f, "# For now, just spitting out event data in a semi human readable form.\n");
+	fwrite($f, "# First line is Admin, rest of the lines are normal users.\n");
+	fwrite($f, "# Each line is Username:Password\n");
+	
+	fwrite($f, $event_admin_user["username"] . ":" . $event_admin_user["password"] . "\n");
+
+	foreach($event_users as $u)
+	{
+		fwrite($f, $u["username"] . ":" . $u["password"] . "\n");	
+	}
+
+	fclose($f);
 }
 
 // Set up for each of the phases of the theme selection, in sequence.
 function SetupThemePhase($phase)
 {
+	global $event_nodeid;
+	
+	switch($phase)
+	{
+	case 0: // Theme Suggestion
+		nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'can-theme', 1);
+		nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'theme-mode', 1);
+		break;
+		
+	case 1: // Theme Slaughter
+	case 2: // Theme voting
+	case 3:
+	case 4:
+	case 5:
+	case 6: // Final theme selection
+		break;
+	}
 }
 
 // The compo has now started, the theme voting is now locked and a theme is selected. The users will be sure to mention the theme in some of their posts.
@@ -269,7 +426,7 @@ $stagecount = count($stages);
 for($curStage = 0; $curStage < $stagecount; $curStage++)
 {
 	$stage = $stages[$curStage];
-	Verbose("Starting stage " . $curStage . " - " . $stage["Name"]);
+	Message("Starting stage " . $curStage . " - " . $stage["Name"]);
 
 	// Start stage function
 	if(key_exists("StageStart",$stage)) { $stage["StageStart"](); }
@@ -283,6 +440,10 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 
 	for($phase = 0; $phase < $phasecount; $phase++)
 	{
+		if($hasPhases)
+		{
+			Message("Beginning Phase ".$phase);
+		}
 		if($hasPhases && key_exists("PhaseStart",$stage)) { $stage["PhaseStart"]($phase); }
 
 		PrepareStageActions($stage, $phase);
@@ -564,16 +725,22 @@ class LdApi
 		
 		$c = curl_init($url);
 		
+		curl_setopt($c, CURLOPT_HEADER, true);		
 		curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($c, CURLOPT_HTTPGET, true);
 		
 		LdApi::SetRequestUser($c, $user);
 		
+		$content = "";
 		$result = curl_exec($c);
 		$success = !($result === false);
 		if($success)
 		{
-			$outputObject = json_decode($result, true);
+			$parts = explode("\r\n\r\n",$result);
+			$headers = $parts[0];
+			$content = $parts[1];
+		
+			$outputObject = json_decode($content, true);
 			$httpcode = curl_getinfo($c, CURLINFO_HTTP_CODE);
 			$outputObject["response_httpcode"] = $httpcode;			
 			LdApi::UpdateUserCookie($c, $user);
@@ -585,7 +752,7 @@ class LdApi
 		
 		if(LdApi::$debug_api)
 		{
-			Verbose("Response '" . $result . "'");
+			Verbose("Response '" . $content . "'");
 		}
 		curl_close($c);
 		
@@ -642,5 +809,5 @@ class LdApi
 }
 
 
-
+CloseLogs();
 exit(0);

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -1158,8 +1158,10 @@ function UnlikeRandom(&$user)
 	
 	$item = random_int(1,$count)-1;
 	$remove = $user["love"][$item];
+	if($remove == null) { print_r($user); }
 	if($item != ($count-1)) $user["love"][$item] = $user["love"][$count-1];
 	unset($user["love"][$count-1]);
+	$user["love"] = array_values($user["love"]); // Reindex for good measure.
 	
 	RemoveLike($user, $remove);
 }
@@ -1473,6 +1475,11 @@ class LdApi
 		print( "\x1b[31mLast Request/Response:\x1b[m\n"); 
 		print( "\x1b[31m" . LdApi::$lastRequestLog . "\x1b[m\n"); 
 		print( "\x1b[31m" . LdApi::$lastResponseLog . "\x1b[m\n"); 
+		
+		// Also put these in the error log for easier reference.
+		LogErr("Last Request/Response:\n");
+		LogErr(LdApi::$lastRequestLog . "\n");
+		LogErr(LdApi::$lastResponseLog . "\n");
 	}
 
 	static function DebugRequestLog($log)

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -93,7 +93,7 @@ function Verbose($text)
 function VerboseAction($text)
 {
 	$text = "[" . TimeString() . "] Verbose: " . $text . "\n";
-	print( "\x1b[1,34m" . $text . "\x1b[m"); // Draw in blue with intensity
+	print( "\x1b[1;34m" . $text . "\x1b[m"); // Draw in blue with intensity
 	LogFull($text);
 }
 function Message($text)
@@ -226,7 +226,7 @@ $stages = array(
 		"MaxMinutes" => 1, // This is per phase
 		"MaxEventsPerUser" => 200,
 		"PhaseStart" => 'SetupThemePhase',
-		"HighChance" => 'UserVoteOnTheme',
+		"HighChance" => ['UserVoteOnTheme'],
 		"LowChance" => array('PostImIn', 'CommentOnPost')  // More various "I'm In" posts will trickle in
 	),
 	// Third stage, LD Starts!
@@ -274,7 +274,7 @@ function SetupEvent()
 {
 	global $event_admin_user, $event_users;
 	
-	$event_admin_user = User_Create();
+	$event_admin_user = &User_Create();
 	
 	// Now create the normal users
 	global $usercount;
@@ -377,7 +377,7 @@ function EndCompo()
 }
 
 // User should discover and interact with the available options in the current theme voting phase.
-function UserVoteOnTheme($user, $phase)
+function UserVoteOnTheme(&$user, $phase)
 {
 	switch($phase)
 	{
@@ -401,50 +401,102 @@ function UserVoteOnTheme($user, $phase)
 
 
 // Post a very simple "I'm In" post. Only do this once per event.
-function PostImIn($user, $phase)
+function PostImIn(&$user, $phase)
 {
+	if($user["postedimin"]) return false;
+	
+	$title = "I'm In";
+	$body = "I'm In " . GenerateRandomPostText();
+	CreatePost($user, $title, $body);
+	
+	$user["postedimin"] = true;
 	return false;
 }
 
 // Find a recent post in the feed, and post a comment - and optionally give it or one of its comments a like.
-function CommentOnPost($user, $phase)
+function CommentOnPost(&$user, $phase)
 {
 	return false;
 }
 // Find a game through one of the game lists, and give it a comment, and optionally give it or one of its comments a like.
-function CommentOnGame($user, $phase)
+function CommentOnGame(&$user, $phase)
+{
+	return false;
+}
+// Find a game through one of the game lists, and vote on it. Or change the votes to something else.
+function VoteOnGame(&$user, $phase)
 {
 	return false;
 }
 
 // Remove a like from some post/comment/game that was liked previously. The simulated user revisits the node and comments, and removes the like.
-function CommentUnlike($user, $phase)
+function CommentUnlike(&$user, $phase)
 {
 	return false;
 }
 
 // Generate and post a new item to the compo feed
-function CompoPostUpdate($user, $phase)
+function CompoPostUpdate(&$user, $phase)
 {
-	return false;
+	$title = GenerateRandomPostTitle();
+	$body = GenerateRandomPostText();
+	CreatePost($user, $title, $body);
+	return true;
 }
 
 // And this is the part of the game where some users wish to parade their stats into the news feed, or complain about PoV :)
-function CompoPostResults($user, $phase)
+function CompoPostResults(&$user, $phase)
 {
 	return false;
 }
 
 // Modify the record for the current user's game and submit an update.
-function CompoEditGame($user, $phase)
+function CompoEditGame(&$user, $phase)
 {
 	return false;
 }
 // Can only be called once. If the game is not published, publish it.
-function CompoPublishGame($user, $phase)
+function CompoPublishGame(&$user, $phase)
 {
 	return false;
 }
+
+
+////
+//// Quickly sanity check that all functions referenced in the above state system actually exist.
+//// 
+function EnsureFunction($funcname)
+{
+	if(!function_exists($funcname))
+	{
+		ReportError("Fatal error - Function ".$funcname.' referenced in the $stages array does not exist.');
+		exit(1);
+	}
+}
+function EnsureFunctionKey(&$stage, $keyname)
+{
+	if(key_exists($keyname, $stage)) { EnsureFunction($stage[$keyname]); }
+}
+function EnsureFunctionArray(&$stage, $keyname)
+{
+	if(key_exists($keyname, $stage)) 
+	{
+		foreach($stage[$keyname] as $f) EnsureFunction($f);
+	}
+}
+
+foreach($stages as $stage)
+{
+	EnsureFunctionKey($stage, "StageStart");
+	EnsureFunctionKey($stage, "StageEnd");
+	EnsureFunctionKey($stage, "PhaseStart");
+	EnsureFunctionKey($stage, "PhaseEnd");
+	EnsureFunctionKey($stage, "UserVerify");
+	EnsureFunctionArray($stage, "Always");
+	EnsureFunctionArray($stage, "LowChance");
+	EnsureFunctionArray($stage, "HighChance");
+}
+
 
 ////
 //// Code to drive the stage progression based on the $stages variable defined above.
@@ -522,20 +574,169 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
   
 }
 
+$currentstageactions = null;
+
 function PrepareStageActions($stage, $phase)
 {
+	global $event_users;
+	global $currentstageactions;
+	$currentstageactions = [ "Allowed" => [], "Required" => [], "Users" => [], "ActiveUsernames" => [] ];
+	
+	// Generate a reference list of users for the current stage
+	foreach($event_users as $u)
+	{
+		$currentstageactions["Users"][$u["username"]] = &$u;
+	}
+	
+	// Extract actions out from stage	
+	// Always => List of functions (actions) to be called by all simulated users in this phase
+	// LowChance => List of functions (actions) to be called by a few (at least one, but less than half) of the simulated users in this phase. Each function gets its own list of users
+	// HighChance => list of functions (actions) to be called by most (not all, but at least half) of the simulated users in this phase. Each function gets its own list of users
+	
+	if(key_exists("Always",$stage))
+	{
+		foreach($stage["Always"] as $action)
+		{
+			foreach($currentstageactions["Users"] as $u)
+			{	
+				$currentstageactions["Allowed"][$u["username"]][] = $action;
+				$currentstageactions["Required"][$u["username"]][] = $action;
+			}
+		}
+	}
+	$usercount = count($currentstageactions["Users"]);
+	$halflow = floor($usercount/2);
+	$halfhigh = ceil($usercount/2);
+	
+	if(key_exists("LowChance",$stage))
+	{
+		foreach($stage["LowChance"] as $action)
+		{
+			$users = random_int(1, $halfhigh);
+			$randomusers = PickRandomSubset($event_users, $users);
+			
+			foreach($randomusers as $u)
+			{	
+				$currentstageactions["Allowed"][$u["username"]][] = $action;
+				$currentstageactions["Required"][$u["username"]][] = $action;
+			}
+		}	
+	}
+	if(key_exists("HighChance",$stage))
+	{
+		foreach($stage["HighChance"] as $action)
+		{
+			$users = random_int($halflow, $usercount);
+			$randomusers = PickRandomSubset($event_users, $users);
+			
+			foreach($randomusers as $u)
+			{	
+				$currentstageactions["Allowed"][$u["username"]][] = $action;
+				$currentstageactions["Required"][$u["username"]][] = $action;
+			}
+		}	
+	}	
+	
+	// Compute ActiveUsernames from users that have actions still.
+	foreach($event_users as $u)
+	{
+		$n = $u["username"];
+		if(count($currentstageactions["Allowed"][$n]) > 0)
+		{
+			$currentstageactions["ActiveUsernames"][] = $n;
+		}
+	}
+}
 
+function PickRandomSubset($objects, $count)
+{
+	$subset = [];
+	for($i = 0;$i < $count && count($objects) > 0; $i++)
+	{
+		$pick = random_int(1,count($objects))-1;
+		$subset[] = $objects[$pick];
+		if($pick < (count($objects)-1)) { $objects[$pick] = $objects[count($objects)-1]; }
+		unset($objects[count($objects)-1]);
+	}
+	return $subset;
+}
+
+function RemoveElement(&$location, $action)
+{
+	$index = array_search($action, $location);
+	if($index === false) return;
+	
+	$last = count($location)-1;
+	if($index != $last)
+	{
+		$location[$index] = $location[$last];
+	}
+	unset($location[$last]);
+}
+
+function ExecuteAction(&$user, $action, $phase)
+{
+	$username = $user["username"];
+	
+	VerboseAction("Running action ".$action." with user ".$username);
+
+	return $action($user,$phase);
 }
 
 function ExecuteStageAction($stage, $phase)
 {
+	global $currentstageactions;	
+	if(count($currentstageactions["ActiveUsernames"]) == 0) return false; // Nothing to do!
 	
-	return false;
+	// Pick a random user from the active usernames
+	$userindex = random_int(1,count($currentstageactions["ActiveUsernames"]))-1;
+	$username = $currentstageactions["ActiveUsernames"][$userindex];
+	$user = $currentstageactions["Users"][$username];
+	
+	// Pick a random action from the available actions
+	$actions = $currentstageactions["Allowed"][$username];
+	if(count($actions) < 1)
+	{
+		ReportError("Debug - something has gone wrong.");
+		print_r($username);
+		print_r($currentstageactions);
+		return true;
+	}
+	$actionindex = random_int(1, count($actions)) - 1;
+	$action = $actions[$actionindex];
+	
+	// Execute the action
+	$result = ExecuteAction($user, $action, $phase);
+	
+	// Unmark the action from the Required list if present
+	RemoveElement($currentstageactions["Required"][$username], $action);
+	
+	// If the action has requested a stop, remove this action from the Allowed list, and possibly remove this username from the active usernames list.
+	if($result === false)
+	{
+		RemoveElement($currentstageactions["Allowed"][$username], $action);
+		if(count($currentstageactions["Allowed"][$username]) == 0)
+		{
+			RemoveElement($currentstageactions["ActiveUsernames"], $username);
+		}
+	}
+	
+	return true;
 }
 
 function CompleteMandatoryStageActions($stage, $phase)
 {
-
+	// Complete any remaining Required actions that we didn't get to already (and remove from the list).
+	global $currentstageactions;	
+	foreach($currentstageactions["Required"] as $u => $actions)
+	{
+		$user = $currentstageactions["Users"][$u];
+		
+		foreach($actions as $action)
+		{
+			ExecuteAction($user, $action, $phase);
+		}
+	}
 }
 
 
@@ -555,8 +756,11 @@ function User_Create()
 		"cookies" => array(),
 		
 		// Further info for tracking data this user has posted and interacted with.
+		"joinedevent" => false,
+		"game_node" => 0,
 		"posts" => array(),
-		"publishedgame" => "false"
+		"postedimin" => false,
+		"publishedgame" => false,
 	];
 	
 	// Determine if username is in use
@@ -608,10 +812,49 @@ function User_Create()
 	return $user;
 }
 
+function User_EnsureJoined(&$user)
+{
+	global $event_nodeid;
+	if(!$user["joinedevent"])
+	{
+		$user["game_node"] = ApiNodeAdd($user, $event_nodeid, "item/game");
+		$user["joinedevent"] = true;
+	}
+}
+
 
 function GetRecentEventPosts($count = 30)
 {
 	
+}
+
+function CreatePost(&$user, $title, $body)
+{
+	User_EnsureJoined($user);
+	
+	$nodeid = ApiNodeAdd($user, $user["game_node"], "post");
+	if($nodeid == null)
+	{
+		ReportError("Failure to add new post!");
+		return;
+	}	
+	if(!ApiNodeUpdate($user, $nodeid, $title, $body))
+	{
+		ReportError("Failure to update post being created.");
+		return;
+	}
+	if(!ApiNodePublish($user, $nodeid))
+	{
+		ReportError("Failure to publish post being created.");
+		return;
+	}
+	$user["posts"][] = $nodeid; // Track post for later use.
+}
+
+function CreateComment(&$user, $nodeid, $body)
+{
+	User_EnsureJoined($user);
+
 }
 
 
@@ -647,8 +890,8 @@ function ApiNodeFeed(&$user, $parentid, $methods, $type, $count, $offset = 0)
 // Pass type,subtype,subsubtype together as $type.
 function ApiNodeAdd(&$user, $parentid, $type)
 {  // POST node/add/:parent/:type/:subtype/:subsubtype
-	$value = LdApi::Post("vx/node/add/" . $nodeid , "", $user);
-	if($value != null)
+	$value = LdApi::Post("vx/node/add/" . $parentid . "/" . $type , "", $user);
+	if($value != null && key_exists("id",$value))
 	{
 		return $value["id"];
 	}
@@ -865,7 +1108,7 @@ class LdApi
 			curl_setopt($curl, CURLOPT_COOKIE, $cookiestring);
 			if($cookiestring != "")
 			{
-				Verbose("Sending Cookie: ".$cookiestring);
+				// debug debug Verbose("Sending Cookie: ".$cookiestring);
 			}
 		}
 	}
@@ -879,7 +1122,8 @@ class LdApi
 				$parts = explode(": ",$v, 2);
 				if($parts[0] == "Set-Cookie")
 				{
-					Verbose("Receive Set-Cookie: ".$parts[1]);
+					// debug debug Verbose("Receive Set-Cookie: ".$parts[1]);
+					
 					$c = explode(";", $parts[1]);
 					$cookiedata = explode("=",$c[0],2);
 					// interpret "=deleted" as the condition to delete a cookie, as the code to check the expires time is annoying in php.

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -80,7 +80,7 @@ function ReportError($text)
 	global $errorcount;
 	$errorcount++;
 	$text = "[" . TimeString() . "] Error: " . $text . "\n";
-	print($text);
+	print( "\x1b[1;31m" . $text . "\x1b[m"); // Draw with intense red color
 	LogFull($text);
 	LogErr($text);
 }
@@ -90,10 +90,16 @@ function Verbose($text)
 	print($text);
 	LogFull($text);
 }
+function VerboseAction($text)
+{
+	$text = "[" . TimeString() . "] Verbose: " . $text . "\n";
+	print( "\x1b[1,34m" . $text . "\x1b[m"); // Draw in blue with intensity
+	LogFull($text);
+}
 function Message($text)
 {
 	$text = "[" . TimeString() . "] " . $text . "\n";
-	print($text);
+	print( "\x1b[1m" . $text . "\x1b[m"); // Draw with greater intensity.
 	LogFull($text);
 	LogErr($text);
 }
@@ -283,13 +289,14 @@ function SetupEvent()
 	$parentnode = 1; // Future: build out a more complex structure for this test.
 	$author = $event_admin_user["id"];
 	$eventname = "Testumdare " . ($eventindex);  
+	$eventbody = GenerateRandomPostText();
 	
 	$starttime = time();
 	$endtime = $starttime + 48*60*60;
 	$formatStart = gmdate("Y-m-d\TH:i:s\Z", $starttime);
 	$formatEnd = gmdate("Y-m-d\TH:i:s\Z", $endtime);
 	
-	$event_nodeid = node_Add( $parentnode, $author, "event", "", "", null, $cmdname, "");
+	$event_nodeid = node_Add( $parentnode, $author, "event", "", "", null, $eventname, $eventbody);
 
 	// Add metadata
 	nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'can-create', 'item/game');
@@ -298,9 +305,10 @@ function SetupEvent()
 	nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'event-end', $formatEnd);
 
 	// Also publish the event
-
-	// (soon)
-
+	if(!ApiNodePublish($event_admin_user, $event_nodeid))
+	{
+		ReportError("Failed to publish the event node.");
+	}
 
 	// Make featured
 	nodeMeta_AddByNode(1, SH_NODE_META_PUBLIC, 'featured', "$event_nodeid");
@@ -335,6 +343,10 @@ function SetupThemePhase($phase)
 		break;
 		
 	case 1: // Theme Slaughter
+		nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'can-theme', 1);
+		nodeMeta_AddByNode($event_nodeid, SH_NODE_META_PUBLIC, 'theme-mode', 2);
+		break;
+	
 	case 2: // Theme voting
 	case 3:
 	case 4:
@@ -367,6 +379,23 @@ function EndCompo()
 // User should discover and interact with the available options in the current theme voting phase.
 function UserVoteOnTheme($user, $phase)
 {
+	switch($phase)
+	{
+	case 0: // Theme Suggestion
+		break;
+		
+	case 1: // Theme Slaughter
+	
+		break;
+		
+	case 2: // Theme voting
+	case 3:
+	case 4:
+	case 5:
+	case 6: // Final theme selection	
+	
+	}
+	
 	return false;
 }
 
@@ -458,10 +487,15 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 				$minutes = Math.min($minutes, $stage["MaxMinutes"]);
 			}
 			$end = (new DateTime()).Add(new DateInterval("PT".$minutes."M"));
+			Message("Running for ".$minutes." minute".($minutes == 1?"":"s"));
 			
 			while($end > new DateTime())
 			{
-				ExecuteStageAction($stage, $phase);
+				if(!ExecuteStageAction($stage, $phase))
+				{
+					// Still wait for the period to complete before continuing
+					usleep(10000); // Delay 10ms
+				}
 			}
 		}
 		else
@@ -469,7 +503,10 @@ for($curStage = 0; $curStage < $stagecount; $curStage++)
 			// Use event count limiting
 			for($action = 0; $action < $runactions; $action++)
 			{
-				ExecuteStageAction($stage, $phase);
+				if(!ExecuteStageAction($stage, $phase))
+				{
+					break;
+				}
 			}
 		}
 		
@@ -492,7 +529,8 @@ function PrepareStageActions($stage, $phase)
 
 function ExecuteStageAction($stage, $phase)
 {
-	usleep(1000); // Delay 1ms
+	
+	return false;
 }
 
 function CompleteMandatoryStageActions($stage, $phase)
@@ -556,20 +594,165 @@ function User_Create()
 		return null;
 	}
 	
-	$user["id"] = $id;
-	
+		
 	// Login the user
-	if(!ApiUserLogin($user))
+	$userid = ApiUserLogin($user);
+	if(!$userid)
 	{
 		ReportError("Unable to login new user.");
 		return null;	
 	}
 	
+	$user["id"] = $userid;
+	
 	return $user;
 }
 
 
+function GetRecentEventPosts($count = 30)
+{
+	
+}
 
+
+
+////
+//// API Interface wrapper functions
+////
+
+// Get one or more nodes
+function ApiNodeGet(&$user, $nodeidlist)
+{
+	$value = LdApi::Post("vx/node/get/".$nodeidlist, $user);
+	if($value != null)
+	{
+		return $value["node"];
+	}
+	return null; 
+}
+
+// Enumerate nodes related to an event
+function ApiNodeFeed(&$user, $parentid, $methods, $type, $count, $offset = 0)
+{ // GET node/feed/:node_id/:methods[]/:type/[:subtype]/[:subsubtype] ?offset= ?limit=
+
+	$value = LdApi::Post("vx/node/feed/" . $methods . "/" . $type . "?offset=" . $offset . "&limit=" . $count, $user);
+	if($value != null)
+	{
+		return $value["feed"];
+	}
+	return null;
+}
+
+// Add item(/game[/compo, /jam]) or post (typically)
+// Pass type,subtype,subsubtype together as $type.
+function ApiNodeAdd(&$user, $parentid, $type)
+{  // POST node/add/:parent/:type/:subtype/:subsubtype
+	$value = LdApi::Post("vx/node/add/" . $nodeid , "", $user);
+	if($value != null)
+	{
+		return $value["id"];
+	}
+	return null;
+}
+
+// Edit name and body of a node (either can be skipped with null) (tag is also an option, but overlooking that for now)
+function ApiNodeUpdate(&$user, $nodeid, $newname = null, $newbody = null)
+{ // POST node/update/:node_id
+	$poststring = "";
+	if($newname != null) { $poststring = "name=".$newname; }
+	if($newbody != null)
+	{
+		if($poststring != "") { $poststring .= "&"; }
+		$poststring .= "body=".$newbody;
+	}
+
+	$value = LdApi::Post("vx/node/update/" . $nodeid , $poststring, $user);
+	return ResponseIs200($value);
+}
+
+// Change the type of a node (e.g. change item/game to item/game/compo, item/game/jam)
+function ApiNodeTransform(&$user, $nodeid, $newtype)
+{ // POST node/transform/:node_id/:type/[:subtype]/[:subsubtype]
+	$value = LdApi::Post("vx/node/transform/" . $nodeid . "/" . $newtype, "", $user);
+	return ResponseIs200($value);
+}
+
+// Just publish the node.
+function ApiNodePublish(&$user, $nodeid)
+{ // POST node/publish/:node_id
+	$value = LdApi::Post("vx/node/publish/" . $nodeid, "", $user);
+	return ResponseIs200($value);
+}
+
+function ApiNodeLoveAdd(&$user, $nodeid) //GET node/love/add/:node_id
+{
+	$value = LdApi::Get("vx/node/love/add" . $nodeid, $user);
+	return ResponseIs200($value);
+}
+
+function ApiNodeLoveRemove(&$user, $nodeid) //GET node/love/remove/:node_id
+{
+	$value = LdApi::Get("vx/node/love/add" . $nodeid, $user);
+	return ResponseIs200($value);
+}
+
+function ApiNodeMetaAdd(&$user, $nodeid, $key, $value) // POST node/meta/add/:node_id
+{
+	$value = LdApi::Post("vx/node/meta/add/".$nodeid, $key."=".$value, $user);
+	return ResponseIs200($value);
+}
+
+function ApiNodeMetaRemove(&$user, $nodeid, $key) // POST node/meta/remove/:node_id
+{
+	$value = LdApi::Post("vx/node/meta/remove/".$nodeid, $key."=", $user);
+	return ResponseIs200($value);
+}
+
+
+function ApiNoteAdd(&$user, $parentid, $body) // POST note/add
+{
+	$value = LdApi::Post("vx/note/add","parent=".$parentid."&body=".$body, $user);
+	if($value) { return $value["note"]; }
+	return null;
+}
+
+function ApiNoteUpdate(&$user, $parentid, $noteid, $newbody)
+{
+	$value = LdApi::Post("vx/note/update/".$noteid,"node=".$parentid."&body=".$body, $user);
+	return ResponseIs200($value);
+}
+
+// Get all notes for a node
+function ApiNoteGet(&$user, $nodeId)
+{
+	$value = LdApi::Get("vx/note/get/" + $nodeid, $user);
+	if($value)
+	{
+		return $value["note"];
+	}
+	return null;
+}
+
+function ApiNoteLoveAdd(&$user, $noteid)
+{
+	$value = LdApi::Get("vx/note/love/add" . $noteid, $user);
+	return ResponseIs200($value);
+}
+
+function ApiNoteLoveRemove(&$user, $noteid)
+{
+	$value = LdApi::Get("vx/note/love/remove" . $noteid, $user);
+	return ResponseIs200($value);
+}
+
+function ResponseIs200($response)
+{
+	if($response != null)
+	{
+		return $response["response_httpcode"] == "200"; 
+	}
+	return false;
+}
 
 // Does the site have this username already?
 function ApiUserHave($username)
@@ -617,9 +800,12 @@ function ApiUserLogin(&$user)
 	
 	if($value != null)
 	{
-		return $value["response_httpcode"] == "200"; 
+		if($value["response_httpcode"] == "200")
+		{
+			return $value["id"];
+		} 
 	}
-	return $false;
+	return 0;
 }
 
 ////
@@ -636,6 +822,11 @@ function GenerateRandomPassword()
 {
   $length = random_int(5, 10);
   return bin2hex(random_bytes($length));
+}
+
+function GenerateRandomPostTitle()
+{
+	return GenerateRandomPostText(3,12);
 }
 
 // Future: something much more meaningful. Also figure out how to include image uploads, links, other fun feathres.

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -1,16 +1,5 @@
 #!/usr/bin/env php
 <?php 
-
-const CONFIG_PATH = "../src/shrub/";
-const SHRUB_PATH = "../src/shrub/src/";
-
-# Use shrub wrapper for db access
-include_once __DIR__."/".CONFIG_PATH."config.php";
-require_once __DIR__."/".SHRUB_PATH."constants.php";
-require_once __DIR__."/".SHRUB_PATH."core/db.php";
-require_once __DIR__."/".SHRUB_PATH."node/node.php";
-require_once __DIR__."/".SHRUB_PATH."user/user.php";
-
 /*
 	Summary of this program and its intent:
 	
@@ -23,6 +12,17 @@ The script will keep track of (some/much of) the data it generates, and will ver
 The exact flow will be documented in the data structures that guide the process, below.
 
 */
+
+const CONFIG_PATH = "../src/shrub/";
+const SHRUB_PATH = "../src/shrub/src/";
+
+# Use shrub wrapper for db access
+include_once __DIR__."/".CONFIG_PATH."config.php";
+require_once __DIR__."/".SHRUB_PATH."constants.php";
+require_once __DIR__."/".SHRUB_PATH."core/db.php";
+require_once __DIR__."/".SHRUB_PATH."node/node.php";
+require_once __DIR__."/".SHRUB_PATH."user/user.php";
+
 
 if ( count($argv) < 3  || ($argv[2] != "actions" && $argv[2] != "minutes")) {
 	print "LudumDare Event simulator. Quick summary:\n";
@@ -96,10 +96,10 @@ $stages = array(
 	// First stage, create users and generate the event
 	array(
 		"Name" => "Setup",
-		"Setup" => SetupEvent,
+		"StageStart" => 'SetupEvent',
 		"MaxMinutes" => 1,
 		"MaxEventsPerUser" => 15,
-		"LowChance" => array(PostImIn, CommentOnPost) // Early "I'm In" posts
+		"LowChance" => array('PostImIn', 'CommentOnPost') // Early "I'm In" posts
 	),
 	// Second stage, Theme voting
 	array(
@@ -107,39 +107,39 @@ $stages = array(
 		"Phases" => 7, // Theme suggestion + theme slaughter + 4 rounds of voting + theme selection
 		"MaxMinutes" => 1, // This is per phase
 		"MaxEventsPerUser" => 200,
-		"PhaseStart" => SetupThemePhase,
-		"HighChance" => UserVoteOnTheme,
-		"LowChance" => array(PostImIn, CommentOnPost)  // More various "I'm In" posts will trickle in
+		"PhaseStart" => 'SetupThemePhase',
+		"HighChance" => 'UserVoteOnTheme',
+		"LowChance" => array('PostImIn', 'CommentOnPost')  // More various "I'm In" posts will trickle in
 	),
 	// Third stage, LD Starts!
 	array(
 		"Name" => "Compo Running",
-		"Setup" => StartCompo,
-		"HighChance" => array(CompoPostUpdate, CompoEditGame, CommentOnPost),
-		"LowChance" => array(CommentOnGame, CompoPublishGame, CommentUnlike)
+		"StageStart" => 'StartCompo',
+		"HighChance" => array('CompoPostUpdate', 'CompoEditGame', 'CommentOnPost'),
+		"LowChance" => array('CommentOnGame', 'CompoPublishGame', 'CommentUnlike')
 	),
 	// Fourth stage, Submission deadline
 	array(
 		"Name" => "Compo Submission Period",
-		"Setup" => SetupSubmission,
+		"StageStart" => 'SetupSubmission',
 		"MaxMinutes" => 2,
 		"MaxEventsPerUser" => 20,
-		"HighChance" => array(CommentOnGame, CompoPublishGame),
-		"LowChance" => array(CompoPostUpdate, CompoEditGame, CommentOnPost, CommentUnlike),
+		"HighChance" => array('CommentOnGame', 'CompoPublishGame'),
+		"LowChance" => array('CompoPostUpdate', 'CompoEditGame', 'CommentOnPost', 'CommentUnlike'),
 	),
 	// Fifth stage, Voting
 	array(
 		"Name" => "Compo Voting",
-		"Setup" => SetupVoting,
+		"StageStart" => 'SetupVoting',
 		"MaxEventsPerUser" => 300,
-		"HighChance" => array(CommentOnGame, VoteOnGame),
-		"LowChance" => array(CommentOnPost, CompoEditGame, CompoPostUpdate, CommentUnlike)
+		"HighChance" => array('CommentOnGame', 'VoteOnGame'),
+		"LowChance" => array('CommentOnPost', 'CompoEditGame', 'CompoPostUpdate', 'CommentUnlike')
 	),
 	// Sixth stage - Closed / resuts
 	array(
 		"Name" => "Compo Results",
-		"Setup" => EndCompo,
-		LowChance => array(CommentOnGame, CommentOnPost, CompoEditGame, CompoPostUpdate, CommentUnlike, CompoPostResults)
+		"StageStart" => 'EndCompo',
+		"LowChance" => array('CommentOnGame', 'CommentOnPost', 'CompoEditGame', 'CompoPostUpdate', 'CommentUnlike', 'CompoPostResults')
 	)
 );
 
@@ -167,56 +167,157 @@ function SetupSubmission()
 {
 }
 
+// Submission is over, and now the voting period begins
+function SetupVoting()
+{
+}
+
+// Voting is over, close out the compo.
+function EndCompo()
+{
+}
+
 // User should discover and interact with the available options in the current theme voting phase.
 function UserVoteOnTheme($user, $phase)
 {
-
+	return false;
 }
 
 
 // Post a very simple "I'm In" post. Only do this once per event.
 function PostImIn($user, $phase)
 {
-
+	return false;
 }
 
 // Find a recent post in the feed, and post a comment - and optionally give it or one of its comments a like.
 function CommentOnPost($user, $phase)
 {
+	return false;
 }
 // Find a game through one of the game lists, and give it a comment, and optionally give it or one of its comments a like.
 function CommentOnGame($user, $phase)
 {
+	return false;
 }
 
 // Remove a like from some post/comment/game that was liked previously. The simulated user revisits the node and comments, and removes the like.
 function CommentUnlike($user, $phase)
 {
+	return false;
 }
 
 // Generate and post a new item to the compo feed
 function CompoPostUpdate($user, $phase)
 {
+	return false;
 }
 
 // And this is the part of the game where some users wish to parade their stats into the news feed, or complain about PoV :)
 function CompoPostResults($user, $phase)
 {
+	return false;
 }
 
 // Modify the record for the current user's game and submit an update.
 function CompoEditGame($user, $phase)
 {
-
+	return false;
 }
 // Can only be called once. If the game is not published, publish it.
 function CompoPublishGame($user, $phase)
 {
-
+	return false;
 }
 
 ////
 //// Code to drive the stage progression based on the $stages variable defined above.
+////
+$stagecount = count($stages);
+
+function Verbose($text)
+{
+	print($text . "\n");
+}
+
+for($curStage = 0; $curStage < $stagecount; $curStage++)
+{
+	$stage = $stages[$curStage];
+	Verbose("Starting stage " . $curStage . " - " . $stage["Name"]);
+
+	// Start stage function
+	if(key_exists("StageStart",$stage)) { $stage["StageStart"](); }
+
+	$phasecount = 1;
+	$hasPhases = false;
+	if(key_exists("Phases", $stage)) { 
+		$hasPhases = true;
+		$phasecount = $stage["Phases"];
+	}
+
+	for($phase = 0; $phase < $phasecount; $phase++)
+	{
+		if($hasPhases && key_exists("PhaseStart",$stage)) { $stage["PhaseStart"]($phase); }
+
+		PrepareStageActions($stage, $phase);
+
+		// Determine proper action limiting mechanism
+		if($runminutes)
+		{
+			// Use temporal limiting
+			$minutes = $runminutes;
+			if($stage["MaxMinutes"])
+			{
+				$minutes = Math.min($minutes, $stage["MaxMinutes"]);
+			}
+			$end = (new DateTime()).Add(new DateInterval("PT".$minutes."M"));
+			
+			while($end < new DateTime())
+			{
+				ExecuteStageAction($stage, $phase);
+			}
+		}
+		else
+		{
+			// Use event count limiting
+			for($action = 0; $action < $runactions; $action++)
+			{
+				ExecuteStageAction($stage, $phase);
+			}
+		}
+
+		// Excecute actions as available until limit is hit
+
+		// Ensure promised conditions about mandatory actions hold
+		CompleteMandatoryStageActions($stage, $phase);
+
+		if($hasPhases && key_exists("PhaseEnd",$stage)) { $stage["PhaseEnd"]($phase); }
+
+	}
+
+	// End stage function
+	if(key_exists("StageEnd",$stage)) { $stage["StageEnd"](); }
+  
+}
+
+function PrepareStageActions($stage, $phase)
+{
+
+}
+
+function ExecuteStageAction($stage, $phase)
+{
+	usleep(1000); // Delay 1ms
+}
+
+function CompleteMandatoryStageActions($stage, $phase)
+{
+
+}
+
+
+////
+//// Common functions to assist in doing normal tasks in the site
 ////
 
 
@@ -230,5 +331,5 @@ function CompoPublishGame($user, $phase)
 
 
 
-print "test\n";
+
 exit(0);


### PR DESCRIPTION
Early event simulation code in sandbox.

Usage: Navigate to www/sandbox in the dairybox ssh
`./simulate_ld_event 50 actions`

This will churn for a while (~5 minutes), create a bunch of (11) bot accounts on your local instance, and they will post a few dozen posts, many comments and likes, and most will submit games.

Saves detailed logs to /tmp including account user/password pairs and  all request/response data, which is unnecessary but not too much space (few 10s of MBs with the above settings). Current logging should do a good job of surfacing the relevant API request details when there's a failure, but if it fails to, that's where to dig.

There's more work to be done in automating the event through all its stages and having the bots interact with theme selection and voting, but this should be a useful resource for testing even without those things.