### PR TITLE
Perf measurement

### DIFF
--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -54,6 +54,7 @@ else
 
 $enable_file_logs = true;
 $logbase = "/tmp/ld_event"; // Logs will be put in /tmp
+$htmlbase = "ld_event"; // Put html report in current directory.
 // Generate 3 kinds of log. 
 //   <name>.<eventIndex>.event (Event information, user/password list)
 //   <name>.<eventIndex>.log (Full Detail Verbose log)
@@ -175,6 +176,14 @@ function OpenStatsFile()
 	return fopen($log, "a");
 }
 
+function OpenHtmlStatsFile()
+{
+	global $htmlbase;
+	global $eventindex;
+	$log = $htmlbase . "." . $eventindex . ".stats.html";
+	return fopen($log, "a");
+}
+
 
 // Figure out event index to use for this run, and start loggers.
 
@@ -288,13 +297,14 @@ $event_users = array(); // Only use for reference (e.g. getting usernames)
 $event_user_lookup = array(); // Only use this as a source for user objects, and get them by reference.
 
 $event_nodeid = null;
+$event_name = null;
 
 // Prepare the event. Create an admin superuser. Create all the compo users. Create the new LudumDare event. Publish the event node.
 // Some of this has to be done through the database directly (finding the email verification links, and creating the ludumdare event and setting it up)
 // We'll also use some data from the database to make the naming a bit more friendly.
 function SetupEvent()
 {
-	global $event_admin_user, $event_users, $event_user_lookup;
+	global $event_admin_user, $event_users, $event_user_lookup, $event_name;
 	
 	$event_admin_user = User_Create();
 	
@@ -315,6 +325,7 @@ function SetupEvent()
 	$parentnode = 1; // Future: build out a more complex structure for this test.
 	$author = $event_admin_user["id"];
 	$eventname = "Testumdare " . ($eventindex);  
+	$event_name = $eventname;
 	$eventbody = GenerateRandomPostText();
 	
 	$starttime = time();
@@ -1809,6 +1820,46 @@ function dump_stat_var(&$f, $var)
 	dump_stat_node($f, $GLOBALS[$var]);
 }
 
+
+function dump_stat_html_node(&$f, &$node, $prefix="root")
+{
+	$count = $node["count"];
+	$time = $node["time"];
+	$min = $node["mintime"];
+	$max = $node["maxtime"];
+	$avg = 0;
+	if($count > 0) { $avg = $time / $count; }
+
+	$summary = "$prefix - Count: $count, Total Time: $time, Min $min s / Avg $avg s / Max $max s";
+	
+	$html = <<<HTMLCHUNK
+<div class="hierarchy">
+  <div class="container">
+  <div class="summary" onclick="ShowHideElement(this.parentElement)">$summary</div>
+  <div class="collapse" style="display:none">
+  <div class="longcontent">
+  <pre>	
+HTMLCHUNK;
+	fwrite($f, $html);
+
+	foreach($node["top"] as $topobj)
+	{
+		fwrite($f, print_r($topobj,true) . "\n\n");
+	}
+	fwrite($f, "  </pre></div></div></div>\n");
+	
+	foreach($node["children"] as $key => $child)
+	{
+		dump_stat_html_node( $f, $child, $prefix . " / " . $key );
+	}
+	fwrite($f, "</div>\n");	
+}
+
+function dump_stat_html_var(&$f, $var)
+{
+	dump_stat_html_node($f, $GLOBALS[$var]);
+}
+
 function dump_stats()
 {
 	$f = OpenStatsFile();
@@ -1821,6 +1872,56 @@ function dump_stats()
 	fwrite($f, "\n\n####################\nDB Query stats:\n");
 	dump_stat_var($f, "stats_db");
 	
+	fclose($f);
+	
+	
+	
+	// Also generate HTML report
+	
+	global $event_name;
+	
+	$f = OpenHtmlStatsFile();
+	$html = <<<HTMLSTART
+<html>
+<head><title>Performance stats for $event_name</title></head>
+<body>
+<script>
+function ShowHideElement(value)
+{
+	var children = value.getElementsByClassName('collapse');
+	var element = children[0];
+	if(element.style.display == 'none')
+	{
+		element.style.display = 'inline';
+	}
+	else
+	{
+		element.style.display = 'none';
+	}
+}
+</script>
+<style>
+div.hierarchy { padding-left:20px; }
+div.container { }
+div.summary { margin:5px; padding:10px; background-color:#CCC }
+div.longcontent { margin:5px; padding:10px; background-color:#aaa }
+</style>
+
+HTMLSTART;
+
+	fwrite($f,  $html);
+
+	fwrite($f, "\n<h1>DB Connect stats:</h1>\n");
+	dump_stat_html_var($f, "stats_dbconnect");
+
+	fwrite($f, "\n<h1>API Access stats:</h1>\n");
+	dump_stat_html_var($f, "stats_api");
+
+	fwrite($f, "\n<h1>DB Query stats:</h1>\n");
+	dump_stat_html_var($f, "stats_db");
+
+
+	fwrite($f, "</body></html>\n");
 	fclose($f);
 }
 

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -67,6 +67,8 @@ $verbose = true; // Display all of the details about what's going on?
 $verboselog = true; // Keep all details about what's going on in a log.
 $useprevioususers = false; // (not implemented) Load the set of users from the previous test event, instead of creating new users.
 
+define("TOP_STATS",10); // keep top 10 stats
+
 $errorcount = 0;
 
 function TimeString()
@@ -165,6 +167,15 @@ function OpenEventFile()
 	return fopen($log, "a");
 }
 
+function OpenStatsFile()
+{
+	global $logbase;
+	global $eventindex;
+	$log = $logbase . "." . $eventindex . ".stats";
+	return fopen($log, "a");
+}
+
+
 // Figure out event index to use for this run, and start loggers.
 
 $events = db_QueryFetch(
@@ -186,6 +197,7 @@ if($enable_file_logs)
 	OpenLogs($eventindex);
 }
 
+stats_init();
 
 /*
 	Stages definition:
@@ -785,11 +797,14 @@ function RemoveElement(&$location, $action)
 	unset($location[$last]);
 }
 
+$ActionContext = [];
+
 function ExecuteAction(&$user, $action, $phase)
 {
 	$username = $user["username"];
 	
 	VerboseAction("Running action ".$action." with user ".$username);
+	$GLOBALS["ActionContext"] = ["action" => $action];
 
 	return $action($user,$phase);
 }
@@ -1565,9 +1580,13 @@ class LdApi
 	{
 		global $apibase;
 		$outputObject = NULL;
+		$urlpath = $url;
 		$url = $apibase . $url;
 		
 		LdApi::DebugRequestLog("GET '".$url."'".LdApi::ForUser($user));
+		
+		// Add "debug" get request
+		if(false === strpos($url,"?")) { $url .= "?debug"; } else { $url .= "&debug"; }		
 		
 		$c = curl_init($url);
 		
@@ -1590,6 +1609,9 @@ class LdApi
 			$outputObject = json_decode($content, true);
 			$httpcode = curl_getinfo($c, CURLINFO_HTTP_CODE);
 			$outputObject["response_httpcode"] = $httpcode;			
+			
+			stats_accumulate("GET", $urlpath, null, $outputObject, $user);
+			
 			LdApi::UpdateUserCookie($headers, $user);
 		}
 		if(!$success && $report_error)
@@ -1612,9 +1634,13 @@ class LdApi
 		global $apibase;
 
 		$outputObject = NULL;
+		$urlpath = $url;
 		$url = $apibase . $url;		
-
+		
 		LdApi::DebugRequestLog("POST '".$url."' with data '".$postdata."'".LdApi::ForUser($user));
+		
+		// Add "debug" get request
+		if(false === strpos($url,"?")) { $url .= "?debug"; } else { $url .= "&debug"; }		
 		
 		$c = curl_init($url);
 		
@@ -1639,6 +1665,8 @@ class LdApi
 			$httpcode = curl_getinfo($c, CURLINFO_HTTP_CODE);
 			$outputObject["response_httpcode"] = $httpcode;
 			
+			stats_accumulate("POST",$urlpath, $postdata, $outputObject, $user);
+			
 			LdApi::UpdateUserCookie($headers, $user);
 		}
 		if(!$success && $report_error)
@@ -1658,6 +1686,145 @@ class LdApi
 	}
 }
 
+////
+//// Statistical tracking for API information
+//// * Keep track of most expensive API requests overall and by type of API request. (to granularity of 2 levels, /vx/aaa/bbb)
+//// * Keep track of most expensive DB queries overall and by type of API request.
+////
+
+
+
+function stats_init()
+{
+	$GLOBALS["stats_api"] = stats_makenode();
+	$GLOBALS["stats_db"] = stats_makenode();
+	$GLOBALS["stats_dbconnect"] = stats_makenode();
+}
+
+function stats_accumulate($type, $url, $postdata, &$response, &$user)
+{
+	$statsobj = ["type"=>$type, "path"=>$url, "response"=> $response, "username" => $user["username"], "time" => $response["debug"]["request_time"] ];
+
+	$url = substr($url, 3); // skip vx/ prefix
+	$parts = explode("/",$url,3);
+	$statspath = array_merge([$type], array_slice($parts,0,2));
+
+	stats_accumulateobject("stats_api", $statsobj, $statspath);
+
+	// For each DB request in the response, also make an entry
+
+	unset($statsobj["response"]["debug"]); // Avoid storing / printing out entire DB debug path for every DB response.
+	
+	foreach($response["debug"]["db_details"] as $detail)
+	{
+		if($detail["action"] == "query")
+		{
+			$detail["context"] = $statsobj;
+			stats_accumulateobject("stats_db", $detail, $statspath);
+		}
+		if($detail["action"] == "connect")
+		{
+			// Also track DB connect stats, but only in a root node. It's not going to be affected by other factors.
+			stats_accumulateobject("stats_dbconnect",$detail,[]);
+		}
+	}
+
+}
+
+function stats_makenode()
+{
+	return [ "count"=>0, "time"=>0.0, "maxtime" => null, "mintime" => null, "top"=>[], "children" => [] ];
+}
+// Stats $obj will have at least a "time" element, which will be used to keep track of top stats objects and 
+function stats_accumulateobject($var, &$obj, $path)
+{
+	$target = &$GLOBALS[$var];
+	stats_adddata($target, $obj);
+	foreach($path as $pathelement)
+	{
+		if(!key_exists($pathelement, $target["children"]))
+		{
+			$target["children"][$pathelement] = stats_makenode();
+		}
+		$target = &$target["children"][$pathelement];
+		stats_adddata($target, $obj);
+	}
+}
+function stats_adddata(&$target, &$obj)
+{
+	$target["count"]++;
+	$target["time"] += $obj["time"];
+	if($target["maxtime"] === null) $target["maxtime"] = $obj["time"]; else $target["maxtime"] = max($target["maxtime"],$obj["time"]);
+	if($target["mintime"] === null) $target["mintime"] = $obj["time"]; else $target["mintime"] = min($target["mintime"],$obj["time"]);
+	
+	if(count($target["top"]) < TOP_STATS || end($target["top"])["time"] < $obj["time"])
+	{
+		// Merge new object into the array
+		$target["top"][] = $obj;
+		usort($target["top"], "statobj_sortfunc");
+		if(count($target["top"]) > TOP_STATS)
+		{
+			array_pop($target["top"]);
+		}
+	}
+}
+
+function sign($n)
+{
+	return $n>0?1:($n<0?-1:0);
+}
+function statobj_sortfunc($a, $b) // Sort by time descending.
+{
+	return sign($b["time"]-$a["time"]);
+}	
+
+function dump_stat_node(&$f, &$node, $prefix="root")
+{
+	$count = $node["count"];
+	$time = $node["time"];
+	$min = $node["mintime"];
+	$max = $node["maxtime"];
+	$avg = 0;
+	if($count > 0) { $avg = $time / $count; }
+
+	fwrite($f, ">>>> Stats ($prefix)\n");
+	fwrite($f, "  Request count: $count\n");
+	fwrite($f, "  Total time on requests: $time s\n");
+	fwrite($f, "  Min time: $min s / Avg time: $avg s / Max time: $max s\n");
+	fwrite($f, "  Top time-consumers:\n");
+	foreach($node["top"] as $topobj)
+	{
+		fwrite($f, print_r($topobj,true) . "\n\n");
+	}
+	fwrite($f, "\n");
+	
+	foreach($node["children"] as $key => $child)
+	{
+		dump_stat_node( $f, $child, $prefix . " / " . $key );
+	}
+}
+
+function dump_stat_var(&$f, $var)
+{
+	dump_stat_node($f, $GLOBALS[$var]);
+}
+
+function dump_stats()
+{
+	$f = OpenStatsFile();
+	fwrite($f, "\nDB Connect stats:\n");
+	dump_stat_var($f, "stats_dbconnect");
+
+	fwrite($f, "\n\n####################\nAPI Access stats:\n");
+	dump_stat_var($f, "stats_api");
+
+	fwrite($f, "\n\n####################\nDB Query stats:\n");
+	dump_stat_var($f, "stats_db");
+	
+	fclose($f);
+}
+
+dump_stats();
 
 CloseLogs();
 exit(0);

--- a/src/shrub/src/core/db_mysql.php
+++ b/src/shrub/src/core/db_mysql.php
@@ -386,10 +386,8 @@ function _db_DebugEndQuery(&$st, &$result)
 		
 		global $DB_DEBUG_DATA;
 		$newdata = ['action'=>'query', 'time'=>($end-$start), 'query' => $GLOBALS['DB_LAST_QUERY']];
-		if($num_rows > 0) {
-			$newdata['num_rows'] = $num_rows;
-		}
-		if($st->affected_rows > 0) {
+		$newdata['num_rows'] = $num_rows;
+		if($st->affected_rows > 0 && $st->affected_rows != $num_rows) {
 			$newdata['affected_rows'] = $st->affected_rows;
 		}
 		if($st->insert_id > 0) {

--- a/src/shrub/src/core/db_mysql.php
+++ b/src/shrub/src/core/db_mysql.php
@@ -90,6 +90,8 @@ const SH_FIELD_TYPE_JSON = 5;			///< JSON encoded strings
 /// @{
 $db = null;				///< The global database object
 $DB_QUERY_COUNT = 0;	///< How many queries have been run
+$DB_ENABLE_DEBUG = 0;	///< Collect additional data about queries being run for debugging purposes
+$DB_DEBUG_DATA = [];	///< Store structured data about each individual query performed, if debugging is enabled.
 /// @}
 
 /// @name Internal: Error Logging
@@ -174,6 +176,10 @@ function _db_Connect(
 {
 	// Safely call this multiple times, only the first time has any effect //
 	if ( !_db_IsConnected() ) {
+		if($GLOBALS['DB_ENABLE_DEBUG']) {
+			$start = microtime(true);
+		}
+		
 		global $db;
 		$db = mysqli_init();
 		
@@ -198,6 +204,12 @@ function _db_Connect(
     	// Set character set to utf8mb4 mode (default is utf8mb3 (utf8). mb4 is required for Emoji)
     	mysqli_set_charset($db, 'utf8mb4');
     	// More info: http://stackoverflow.com/questions/279170/utf-8-all-the-way-through
+		
+		if($GLOBALS['DB_ENABLE_DEBUG']) {
+			$end = microtime(true);
+			global $DB_DEBUG_DATA;
+			$DB_DEBUG_DATA[] = ['action'=>'connect', 'time'=>($end-$start)];
+		}
 	}
 }
 
@@ -353,10 +365,49 @@ function _db_BindExecute( &$st, $args ) {
 
 /* *********************************************************************************************** */
 
+function _db_DebugStartQuery($query)
+{
+	if($GLOBALS['DB_ENABLE_DEBUG']) {
+		$GLOBALS['DB_LAST_QUERY'] = $query;
+		$GLOBALS['DB_LAST_QUERY_START'] = microtime(true);
+	}
+}
+
+function _db_DebugEndQuery(&$st, &$result)
+{
+	if($GLOBALS['DB_ENABLE_DEBUG'])
+	{
+		$start = $GLOBALS['DB_LAST_QUERY_START'];
+		$end = microtime(true);
+		$num_rows = $st->num_rows;
+		if($result != null) {
+			$num_rows = $result->num_rows;
+		}
+		
+		global $DB_DEBUG_DATA;
+		$newdata = ['action'=>'query', 'time'=>($end-$start), 'query' => $GLOBALS['DB_LAST_QUERY']];
+		if($num_rows > 0) {
+			$newdata['num_rows'] = $num_rows;
+		}
+		if($st->affected_rows > 0) {
+			$newdata['affected_rows'] = $st->affected_rows;
+		}
+		if($st->insert_id > 0) {
+			$newdata['insert_id'] = $st->insert_id;
+		}	
+		
+		$DB_DEBUG_DATA[] = $newdata;
+	}
+}
+
+/* *********************************************************************************************** */
+
 /// This, the underscore version doesn't close $st; It returns it instead
 function _db_Query( $query, $args ) {
 	_db_Connect();
 
+	_db_DebugStartQuery($query);
+		
 	$st = _db_Prepare($query);
 	if ( $st && _db_BindExecute($st, $args) ) {
 		return $st;
@@ -372,6 +423,7 @@ function _db_Query( $query, $args ) {
 /// @{
 function _db_GetAssoc( &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_ASSOC /*MYSQLI_NUM*/)) {
 		$ret[] = $row;
@@ -381,6 +433,7 @@ function _db_GetAssoc( &$st ) {
 /// Given a key (field name), populate an array using the value of the key as the index
 function _db_GetAssocStringKey( $key, &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_ASSOC /*MYSQLI_NUM*/)) {
 		$ret[$row[$key]] = $row;
@@ -390,6 +443,7 @@ function _db_GetAssocStringKey( $key, &$st ) {
 /// Same as _db_GetAssocStringKey, but assume the key is an integer, not a string
 function _db_GetAssocIntKey( $key, &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);	
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_ASSOC /*MYSQLI_NUM*/)) {
 		$ret[intval($row[$key])] = $row;
@@ -399,6 +453,7 @@ function _db_GetAssocIntKey( $key, &$st ) {
 /// Same as _db_GetAssocStringKey, but assume the key is a float, not a string
 function _db_GetAssocFloatKey( $key, &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);	
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_ASSOC /*MYSQLI_NUM*/)) {
 		$ret[floatval($row[$key])] = $row;
@@ -408,6 +463,7 @@ function _db_GetAssocFloatKey( $key, &$st ) {
 /// Get an array of arrays of elements (without names)
 function _db_GetArray( &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);	
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_NUM)) {
 		$ret[] = $row;
@@ -417,6 +473,7 @@ function _db_GetArray( &$st ) {
 /// Get an array of just the first element
 function _db_GetFirst( &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);	
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_NUM)) {
 		$ret[] = $row[0];
@@ -426,6 +483,7 @@ function _db_GetFirst( &$st ) {
 /// Make a key=value pair array, where 0 is the key, and 1 is the value 
 function _db_GetPair( &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);	
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_NUM)) {
 		$ret[$row[0]] = $row[1];
@@ -435,6 +493,7 @@ function _db_GetPair( &$st ) {
 /// Same as _db_GetPair, but make sure the key is an integer
 function _db_GetIntPair( &$st ) {
 	$result = $st->get_result();
+	_db_DebugEndQuery($st, $result);	
 	$ret = [];
 	while ($row = $result->fetch_array(MYSQLI_NUM)) {
 		$ret[intval($row[0])] = $row[1];
@@ -460,6 +519,7 @@ function _db_GetIntPair( &$st ) {
 function db_Query( $query, ...$args ) {
 	$st = _db_Query($query, $args);
 	if ( $st ) {
+		_db_DebugEndQuery($st, $null);		
 		return $st->close();
 	}
 	return false;
@@ -472,6 +532,7 @@ function db_Query( $query, ...$args ) {
 function db_QueryInsert( $query, ...$args ) {
 	$st = _db_Query($query, $args);
 	if ( $st ) {
+		_db_DebugEndQuery($st, $null);		
 		$index = $st->insert_id;
 		$st->close();
 		return $index;
@@ -486,6 +547,7 @@ function db_QueryInsert( $query, ...$args ) {
 function db_QueryDelete( $query, ...$args ) {
 	$st = _db_Query($query, $args);
 	if ( $st ) {
+		_db_DebugEndQuery($st, $null);		
 		$index = $st->affected_rows;
 		$st->close();
 		return $index;
@@ -505,6 +567,7 @@ function db_QueryUpdate( $query, ...$args ) {
 function db_QueryNumRows( $query, ...$args ) {
 	$st = _db_Query($query, $args);
 	if ( $st ) {
+		_db_DebugEndQuery($st, $null);			
 		print_r($query);
 		print_r($st);
 		$rows = $st->num_rows;

--- a/src/shrub/src/core/json.php
+++ b/src/shrub/src/core/json.php
@@ -248,6 +248,15 @@ function json_Emit( $out, $allow_jsonp = true ) {
 		if ( getenv('REDIRECT_QUERY_STRING') ) {
 			$out['debug']['redirect_query'] = getenv('REDIRECT_QUERY_STRING');
 		}
+		
+		global $json_starttime;
+		$json_endtime = microtime(true);
+		$totaltime = $json_endtime - $json_starttime;
+		
+		$out['debug']['request_time'] = $totaltime;
+		
+		global $DB_DEBUG_DATA;
+		$out['debug']['db_details'] = $DB_DEBUG_DATA;
 	}
 	
 	// Output the Page
@@ -319,6 +328,16 @@ function json_ArgCount() {
 
 function json_Begin() {
 	global $RESPONSE, $REQUEST;
+	
+	// Track starting time
+	global $json_starttime;
+	$json_starttime = microtime(true);
+	
+	if ( defined('SH_PHP_DEBUG') && isset($_GET['debug']) ) {
+		// If debugging enabled, tell the system to track additional data.
+		global $DB_ENABLE_DEBUG;
+		$DB_ENABLE_DEBUG = true;
+	}
 	
 	// Begin
 	$RESPONSE = json_NewResponse();


### PR DESCRIPTION
Early useful performance measurement.
* Added further details including detailed query information when ?debug is present
* event simulator consumes this data, and produces a (minimal but useful) HTML report in the current directory when running it.
* This data highlights slow API calls and DB queries individually as well as statistics about all calls in a "tree" based on the http request type and path to the API being used..
* In the report website, click on a node in the tree to display the most expensive API requests or DB queries for that node