### PR TITLE
Added tootips

### DIFF
--- a/src/com/tooltip/tooltip-text.js
+++ b/src/com/tooltip/tooltip-text.js
@@ -1,0 +1,31 @@
+import { h } 				from 'preact/preact';
+
+import ToolTip						from 'com/tooltip/tooltip';
+
+
+export default class ToolTipText extends ToolTip {
+	constructor( props ) {
+		if (!props.lineHeight) {
+			props.lineHeight = 18;
+		}
+		
+		this.textSpan = null;
+		props.PopUpContent = <div class='-tooltip-text' ref={(span) => this.textSpan = span}>{props.Text}</div>;
+		super(props);
+	}
+	
+	reshapeIfNeeded() {
+		if (this.textSpan && this.state.showPopUp) {
+			const docWidth = document.documentElement.clientWidth;
+			const maxWidth = docWidth * this.props.maxWidth;
+			const rect = this.textSpan.getBoundingClientRect();
+			if (rect.height > this.props.lineHeight) {
+				const bestWidth = Math.min(maxWidth, Math.floor(rect.height / this.props.lineHeight) * rect.width);
+				this.textSpan.style.width = bestWidth + 'px';
+			}
+		
+		} else {
+			this.textSpan = null;
+		}
+	}
+}

--- a/src/com/tooltip/tooltip.js
+++ b/src/com/tooltip/tooltip.js
@@ -1,0 +1,135 @@
+import { h, Component } 				from 'preact/preact';
+
+import SVGIcon 							from 'com/svg-icon/icon';
+
+import ButtonBase						from 'com/button-base/base';
+
+import ContentCommonBody				from 'com/content-common/common-body';
+
+
+export default class ToolTip extends Component {
+	
+	constructor( props ) {
+		if (!props.maxWidth) {
+			props.maxWidth = 0.5;
+		}
+		if (!props.horizontalPadding) {
+			props.horizontalPadding = 6;
+		}
+		if (!props.hideDelay) {
+			props.hideDelay = 500;
+		}
+		if (!props.touchNoDoubleClick) {
+			props.touchNoDoubleClick = 0.1;
+		}
+		
+		super(props);
+		
+		this.state = {			
+			showPopUp: false,			
+		};
+		
+		this.delayHideCounter = 0;
+		this.lastToggle = 0;
+		this.tooltipDiv = null;
+		this.tooltipContainerDiv = null;
+	}
+	
+	toggleShow(evt) {
+		const state = this.state;
+		const t = evt.timeStamp;
+		if (t - this.lastToggle < this.props.touchNoDoubleClick) {
+			return;
+		} 
+		this.lastToggle = t;
+		
+		if (state.showPopUp) {
+			this.delayHideCounter++;
+			this.setState({showPopUp: false});
+		} else {
+			this.showNow();
+		}
+	}
+	
+	showNow() {
+		this.delayHideCounter++;
+		this.setState({showPopUp: true});		
+	}
+	
+	delayHide() {
+		if (this.props.permaOn === true) {
+			return;
+		}
+		this.delayHideCounter++;
+		const myHide = this.delayHideCounter;
+		
+		setTimeout(
+			() => this.delayHideCounter == myHide ? this.setState({showPopUp: false}) : null
+			, this.props.hideDelay);
+	}
+	
+	render (props, state) {
+		
+		let popUp = null;
+		if (state.showPopUp && props.PopUpContent) {
+			popUp = (<div onmouseover={() => this.showNow()} onmouseout={() => this.delayHide()} class="-tooltip" ref={(div) => this.tooltipDiv = div}>{props.PopUpContent}</div>);
+		} else {
+			this.tooltipDiv	= null;
+		}
+		
+		let ToolTipButtonContent = null;
+		if (props.ToolTipButtonContent) {
+			ToolTipButtonContent = props.ToolTipButtonContent;
+		} else {
+			ToolTipButtonContent = (<SVGIcon small baseline gap>info</SVGIcon>);
+			
+		}
+
+		return (
+			<div class='tooltip-container'  ref={(div) => this.tooltipContainerDiv = div}>
+			{popUp}
+			<ButtonBase	class="-button -tooltip-icon" onclick={(evt) => this.toggleShow(evt)} hoverCallback={ (hover) => hover ? this.showNow() : this.delayHide() } >{ToolTipButtonContent}</ButtonBase>
+			</div>
+		);
+	}
+	
+	componentDidUpdate() {
+		this.reshapeIfNeeded();
+		this.alignTooltipHorizontallyIfNeeded();
+
+	}
+	
+	reshapeIfNeeded() {}
+		
+	alignTooltipHorizontallyIfNeeded() {
+		const props = this.props;
+		const docWidth = document.documentElement.clientWidth;
+		const maxWidth = docWidth * props.maxWidth;
+		const minLeft = props.horizontalPadding;
+		const maxRight = docWidth - props.horizontalPadding;
+		
+		if (this.tooltipDiv && this.state.showPopUp && this.tooltipContainerDiv) {
+			const rect = this.tooltipDiv.getBoundingClientRect();
+			const containerRect = this.tooltipContainerDiv.getBoundingClientRect();
+			
+			let width = rect.width;
+			if (width > maxWidth) {
+				this.tooltipDiv.style.maxWidth = maxWidth + 'px';
+				width = maxWidth;
+			}
+
+			if (rect.x < minLeft) {
+				
+				this.tooltipDiv.style.left = (minLeft - containerRect.x) + 'px';
+			}
+			
+			const right = rect.x + rect.width;
+			if (right > maxRight) {
+				const targetDeltaX = Math.floor(Math.max(props.horizontalPadding - containerRect.x, 0 - rect.width));
+				this.tooltipDiv.style.left = targetDeltaX + 'px';				
+			}
+			
+		}
+		
+	}
+}

--- a/src/com/tooltip/tooltip.less
+++ b/src/com/tooltip/tooltip.less
@@ -1,0 +1,26 @@
+@import 'defs.less';
+
+.-tooltip {
+	position: absolute;
+	z-index: 10000;
+	bottom: 20px;
+	left: -5px;
+	color: @COL_L;
+	background: @COL_NDDD;
+	border-radius: 4px;
+	padding: 2px 15px;
+	overflow-x: hidden;
+}
+
+.tooltip-container {
+	position: relative;	
+	display: inline;
+	margin: 0px;
+	padding: 0px;
+}
+	
+.button-base {
+	&.-tooltip-icon {
+		display: inline-block;
+	}
+}


### PR DESCRIPTION
## Features

```jsx
<ToolTip PopUpContent={<something />}  />
```

There are a bunch of optional properties to it:
* `ToolTipButtonContent` overrides the default SVG info-icon
* `maxWidth` (default 0.5) sets the maximum width as fraction of the width of the viewport
* `horizontalPadding` (default 6px) number of pixels padding to the edge of the viewport for the popup
* `hideDelay` (default 500ms) a time after mouse exits until toottip is hidden (this helps being able to move mouse from the icon that triggers the tooltip to the popup box. Which is useful if it contains buttons or such).
* `touchNoDoubleClick` (0.1s) a delay for when it isn't possible to hide the tooltip with a click after it has been shown. To counter touch causing flicker show-hide effects.

There's also a subclass for easier use if only text is intended (can be paragraphs and such too ofc) to be shown. This one will resize its width to minimize the number of lines in the tooltip while respecting the conditions set by above parameters.

```jsx
<ToolTipText Text={'My text is fine'} />
```

## Known issues
It is a bit weird that so much styling is done through the JS, but I found no way to make the content of the tooltip stretch out in a reliable way.

Therefore, the `ToolTipText` can sometimes give a bit strange padding on the right side.

I could also not reliably make the tooltip show on top of the right-side bar, so if the tooltip is triggered quite far to the right but isn't too wide to force it to shift alignment, it could be partially hidden.