### PR TITLE
Anonymous comments

### DIFF
--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -42,6 +42,7 @@ const VALID_META = [
 		'grade-06-out' => ['length' => 1],
 		'grade-07-out' => ['length' => 1],
 		'grade-08-out' => ['length' => 1],
+		'allow-anonymous-comments' => ['length' => 1],
 		
 		'link-01' => ['length' => 512, 'url' => true],
 		'link-02' => ['length' => 512, 'url' => true],

--- a/public-api/vx/note.php
+++ b/public-api/vx/note.php
@@ -80,9 +80,9 @@ switch ( $action ) {
 
 
 			if ( isset($_POST['anonymous']) && $_POST['anonymous'] ) {
-				// Only allow anonymous comments to be posted if the node has "allow_anonymous_comments" meta set.
+				// Only allow anonymous comments to be posted if the node has "allow-anonymous-comments" meta set.
 				
-				$meta = nodeMeta_GetByKeyNode('allow_anonymous_comments',$node_id);
+				$meta = nodeMeta_GetByKeyNode('allow-anonymous-comments',$node_id);
 				if ( count($meta) == 0 || !$meta[0]['value'] ) {
 					json_EmitFatalError_BadRequest("Cannot post anonymous comment: Node doesn't allow anonymous comments.", $RESPONSE);
 				}

--- a/public-api/vx/note.php
+++ b/public-api/vx/note.php
@@ -32,9 +32,23 @@ switch ( $action ) {
 			json_EmitFatalError_BadRequest(null, $RESPONSE);
 		}
 
-		$RESPONSE['note'] = noteComplete_GetByNode($ids[0]);
+		$RESPONSE['note'] = noteFlags_Filter(noteComplete_GetByNode($ids[0]), userAuth_GetID());
 
-		break; //case 'get': //note/get
+		break; //case 'get': //note/get		
+	case 'getnote': //note/getnote
+		// Temporary "Get note by note ID" call. To be renamed when the renaming time comes.
+		json_ValidateHTTPMethod('GET');
+
+		$ids = explode('+', json_ArgGet(0));
+
+		// Limit number of notes
+		if ( count($ids) > 250 ) {
+			json_EmitFatalError_BadRequest("Too many notes", $RESPONSE);
+		}
+		
+		$RESPONSE['notes'] = noteFlags_Filter(noteComplete_Get($ids), userAuth_GetID());
+
+		break; //case 'getnote': //note/getnote
 	case 'add': //note/add
 		json_ValidateHTTPMethod('POST');
 
@@ -45,6 +59,7 @@ switch ( $action ) {
 			}
 
 			$author = $user_id;
+			$flags = 0;
 
 			if ( !isset($_POST['parent']) )
 				json_EmitFatalError_BadRequest("No parent", $RESPONSE);
@@ -58,8 +73,22 @@ switch ( $action ) {
 			if ( isset($_POST['tag']) )
 				$version_tag = coreSlugify_Name($_POST['tag']);
 
+			$parent = intval($_POST['parent']);
+
 			// Load Node
 			$node = node_GetById($node_id);
+
+
+			if ( isset($_POST['anonymous']) && $_POST['anonymous'] ) {
+				// Only allow anonymous comments to be posted if the node has "allow_anonymous_comments" meta set.
+				
+				$meta = nodeMeta_GetByKeyNode('allow_anonymous_comments',$node_id);
+				if ( count($meta) == 0 || !$meta[0]['value'] ) {
+					json_EmitFatalError_BadRequest("Cannot post anonymous comment: Node doesn't allow anonymous comments.", $RESPONSE);
+				}
+				
+				$flags |= SH_NOTE_FLAG_ANONYMOUS;
+			}
 
 			// Check if you have permission to add comment to node
 			if ( note_IsNotePublicByNode($node) ) {
@@ -67,7 +96,7 @@ switch ( $action ) {
 				if ( $parent !== 0 )
 					json_EmitFatalError_Permission("Temporary: No children", $RESPONSE);
 
-				$RESPONSE['note'] = note_AddByNode($node['id'], $node['parent'], $author, $parent, $body, $version_tag);
+				$RESPONSE['note'] = note_AddByNode($node['id'], $node['parent'], $author, $parent, $body, $version_tag, $flags);
 				
 				// Add notifications for users watching this thread
 				if ( $RESPONSE['note'] ) {
@@ -115,6 +144,10 @@ switch ( $action ) {
 			if ( $note['node'] !== $node_id )
 				json_EmitFatalError_Permission("Invalid node", $RESPONSE);
 
+			if ( $note['author'] !== $author )
+				json_EmitFatalError_Permission("Not allowed to edit other people's comments.", $RESPONSE);
+
+
 			// Are bodies different?
 			if ( $body !== $note['body'] ) {
 				// Load Node
@@ -122,7 +155,7 @@ switch ( $action ) {
 
 				// Check if you have permission to add comment to node
 				if ( note_IsNotePublicByNode($node) ) {
-					$RESPONSE['updated'] = note_SafeEdit($note_id, $author, $body, $version_tag);
+					$RESPONSE['updated'] = note_SafeEdit($note_id, $author, $body, $version_tag, $note.flags);
 				}
 				else {
 					json_EmitFatalError_Forbidden("This node type does now allow notes (yet)", $RESPONSE);

--- a/public-api/vx/note.php
+++ b/public-api/vx/note.php
@@ -155,7 +155,7 @@ switch ( $action ) {
 
 				// Check if you have permission to add comment to node
 				if ( note_IsNotePublicByNode($node) ) {
-					$RESPONSE['updated'] = note_SafeEdit($note_id, $author, $body, $version_tag, $note.flags);
+					$RESPONSE['updated'] = note_SafeEdit($note_id, $author, $body, $version_tag, $note['flags']);
 				}
 				else {
 					json_EmitFatalError_Forbidden("This node type does now allow notes (yet)", $RESPONSE);

--- a/sandbox/simulate_ld_event
+++ b/sandbox/simulate_ld_event
@@ -814,7 +814,8 @@ function PostImIn(&$user, $phase)
 	
 	$title = "I'm In";
 	$body = "I'm In " . GenerateRandomPostText();
-	CreatePost($user, $title, $body);
+	$nodeid = CreatePost($user, $title, $body);
+	MaybeReactToPost($user, $nodeid);
 	
 	$user["postedimin"] = true;
 	return false;
@@ -865,6 +866,57 @@ function LikeFeed(&$user, $nodes)
 	}	
 }
 
+function MaybeReactToPost(&$user, $nodeid)
+{
+	// Don't react to every post.
+	if(random_int(1,3) == 1)
+	{
+		$nodes = ApiNodeGet($user, $nodeid);
+		if($nodes == null) 
+		{
+			ReportError("Could not get post to react to.");
+			return;
+		}
+		ReactToPost($user, $nodes[0]);
+	}
+}
+
+// Grab a subset of users in the system and ask them to look at this newly generated post. They may like, comment.
+function ReactToPost(&$user, $node)
+{
+	global $event_user_lookup;
+	$usernames = array_keys($event_user_lookup);
+	
+	$min_users = count($usernames)/10;
+	$max_users = count($usernames)/3;
+	$react_count = random_int($min_users, $max_users);
+	
+	for($i=0; $i<$react_count; $i++)
+	{
+		$random_user = random_int(1,count($usernames))-1;
+		$username = $usernames[$random_user];
+		$reactuser = &$event_user_lookup[$username];
+		
+		Verbose("User " . $username . " reacting to post...");
+		
+		if(random_int(1,3) == 1)
+		{
+			LikeNode($reactuser, $node["id"]);
+		}
+		
+		// Add likes to the comments on the node
+		LikeCommentsNode($reactuser, $node);
+		
+		if(random_int(1,5) == 1)
+		{
+			// Maybe comment on the post.
+			$body = GenerateRandomPostText();
+			CreateComment($reactuser, $node["id"], $body);
+		}
+		
+	}
+}
+
 // Helper: fetch a node's comments, and maybe like some of them.
 function LikeCommentsNode(&$user, $node)
 {
@@ -873,7 +925,7 @@ function LikeCommentsNode(&$user, $node)
 	{
 		foreach($comments as $c)
 		{
-			if(random_int(1,20) == 1) LikeComment($user, $c["id"]);
+			if(random_int(1,10) == 1) LikeComment($user, $c["id"]);
 		}
 	}
 }
@@ -903,8 +955,15 @@ function CommentOnGame(&$user, $phase)
 		$post = GetRandomTopGame($user);
 		if($post != null)
 		{
+			$anonymous = null;
+			// If Anonymous comments are enabled, we might generate an anonymous comment.
+			if( isset($post['meta']['allow-anonymous-comments']) && $post['meta']['allow-anonymous-comments'] )
+			{
+				$anonymous = random_int(1,5) == 1;
+			}
+		
 			$body = GenerateRandomPostText();
-			CreateComment($user, $post["id"], $body);
+			CreateComment($user, $post["id"], $body, $anonymous);
 		}
 	}
 	return true;
@@ -979,7 +1038,8 @@ function CompoPostUpdate(&$user, $phase)
 {
 	$title = GenerateRandomPostTitle();
 	$body = GenerateRandomPostText(5);
-	CreatePost($user, $title, $body);
+	$nodeid = CreatePost($user, $title, $body);
+	MaybeReactToPost($user, $nodeid);
 	
 	// There's a limit to how many posts a user should make. Try not to make too many more.
 	return count($user["posts"]) < 3;
@@ -1627,13 +1687,15 @@ function CreatePost(&$user, $title, $body)
 		return;
 	}
 	$user["posts"][] = $nodeid; // Track post for later use.
+	return $nodeid;
 }
 
-function CreateComment(&$user, $nodeid, $body)
+function CreateComment(&$user, $nodeid, $body, $anonymous = null)
 {
 	User_EnsureJoined($user);
-	Verbose("Posting a comment to node " . $nodeid);
-	$id = ApiNoteAdd($user, $nodeid, $body);
+	$anon = $anonymous ? "n anonymous": "";
+	Verbose("Posting a" . $anon. " comment to node " . $nodeid);
+	$id = ApiNoteAdd($user, $nodeid, $body, $anonymous);
 	if(!$id)
 	{
 		ReportError("Failed to add comment");
@@ -1734,7 +1796,19 @@ function PublishGame(&$user)
 		ReportError("Failed to transform game node to " . $newtype);
 	}
 	
-	// other stuff (future: enable opt-outs and stuff)
+	// Enable opt-outs
+	if(random_int(1,3) == 1) 
+	{
+		// Future: Determine possible opt-outs and opt out of one or more of them.
+	}
+	
+	// Enable anonymous comments
+	if(random_int(1,3) == 1) 
+	{	
+		Verbose("Enabling anonymous comments");
+		if(!ApiNodeMetaAdd($user, $user["game_node"], 'allow-anonymous-comments', '1')) ReportError("Unable to enable anonymous comments meta.");
+	}	
+	
 	
 	
 	// Publish!
@@ -1899,9 +1973,14 @@ function ApiNodeLinkRemove(&$user, $node_a, $node_b, $key) // POST node/link/rem
 	return ResponseIs200($value);
 }
 
-function ApiNoteAdd(&$user, $nodeid, $body) // POST note/add
+function ApiNoteAdd(&$user, $nodeid, $body, $anonymous) // POST note/add
 {
-	$value = LdApi::Post("vx/note/add/".$nodeid,"parent=0&body=".urlencode($body), $user);
+	$anon = "";
+	if($anonymous !== null)
+	{
+		$anon = "&anonymous=".$anonymous;
+	}
+	$value = LdApi::Post("vx/note/add/".$nodeid,"parent=0&body=".urlencode($body).$anon, $user);
 	if($value) { return $value["note"]; }
 	return null;
 }

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -132,14 +132,18 @@ export default class ContentCommentsComment extends Component {
 		var author = props.author;
 		
 //		console.log('R '+comment.id+": ", state.editing, state.preview);
-		if ( author ) {
-			var Name = author.name;
-			if ( author.meta['real-name'] )
-				Name = author.meta['real-name'];
 
+		if ( author || comment.author == 0 ) {
+			var Name = "Anonymous";
 			var Avatar = "///other/dummy/user64.png";
-			if ( author.meta['avatar'] )
-				Avatar = author.meta['avatar'] + ".64x64.fit.png";;
+			if ( author ) {
+				Name = author.name;
+				if ( author.meta['real-name'] )
+					Name = author.meta['real-name'];
+
+				if ( author.meta['avatar'] )
+					Avatar = author.meta['avatar'] + ".64x64.fit.png";;
+			}
 
 			var ShowTitle = null;
 			if ( !state.editing || state.preview ) {
@@ -152,12 +156,20 @@ export default class ContentCommentsComment extends Component {
 				// 1 minute leeway on edits
 				var HasEdited = ModDiff > (60*1000);
 
-				ShowTitle = [
-					<div class="-title">
-						<span class="-author">{Name}</span> (<NavLink class="-atname" href={"/users/"+author.slug}>{"@"+author.slug}</NavLink>)
-					</div>,
-				];
-
+				if ( author ) {
+					ShowTitle = [
+						<div class="-title">
+							<span class="-author">{Name}</span> (<NavLink class="-atname" href={"/users/"+author.slug}>{"@"+author.slug}</NavLink>){comment.anonymous?" (Posted Anonymously)":""}
+						</div>,
+					];
+				}
+				else {
+					ShowTitle = [
+						<div class="-title">
+							<span class="-author">{Name}</span>
+						</div>,
+					];				
+				}
 				if ( comment.created ) {
 					ShowTitle.push(<div class="-date">posted <span title={getLocaleTimeStamp(Created)}>{getRoughAge(DateDiff)}</span><span title={getLocaleDate(Modified)}>{HasEdited?" (edited)":""}</span></div>);
 				}

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -113,7 +113,9 @@ export default class ContentComments extends Component {
 			var Authors = [];
 			// Extract a list of all authors from comments
 			for ( var idx = 0; idx < comments.length; idx++ ) {
-				Authors.push(comments[idx].author);
+				if ( comments[idx].author != 0  ) {
+					Authors.push(comments[idx].author);
+				}
 			}
 			// Add self (in case we start making comments
 			if ( user && user.id ) {

--- a/src/shrub/src/note/constants.php
+++ b/src/shrub/src/note/constants.php
@@ -11,6 +11,12 @@ const SH_TABLE_NOTE_VERSION =		"note_version";		// History
 const SH_TABLE_NOTE_LOVE =			"note_love";
 /// @}
 
+///	@addtogroup NoteFlags
+/// @{
+const SH_NOTE_FLAG_HIDDEN = 			1;	///< Comment has been hidden by default by a moderation action
+const SH_NOTE_FLAG_ANONYMOUS = 			2;	///< Comment is anonymous and author will be redacted for everyone but the actual author.
+/// @}
+
 global_AddTableConstant( 
 	'SH_TABLE_NOTE',
 	'SH_TABLE_NOTE_TREE',

--- a/src/shrub/src/note/note.php
+++ b/src/shrub/src/note/note.php
@@ -1,6 +1,7 @@
 <?php
 // Tables and Features
 require_once __DIR__."/note_core.php";
+require_once __DIR__."/note_flags.php";
 require_once __DIR__."/note_tree.php";
 require_once __DIR__."/note_love.php";
 require_once __DIR__."/note_version.php";

--- a/src/shrub/src/note/note_complete.php
+++ b/src/shrub/src/note/note_complete.php
@@ -20,3 +20,32 @@ function noteComplete_GetByNode( $node ) {
 	// it's a shame to do this, but this is how I need the data client side :(
 	return array_values($notes);
 }
+
+function noteComplete_Get( $ids ) {
+	$multi = is_array($ids);
+	if ( !$multi )
+		$ids = [$ids];
+		
+	$notes = note_GetById($ids);
+	if ( $notes ) {
+		$loves = noteLove_GetByNote($ids);
+	
+		// Populate Love
+		foreach ( $notes as &$note ) {
+			$note['love'] = 0;
+
+			foreach ( $loves as $love ) {
+				if ( $note['id'] === $love['note'] ) {
+					$note['love'] = $love['count'];
+					$note['love-timestamp'] = $love['timestamp'];
+				}
+			}
+		}
+		
+		if ( $multi )
+			return array_values($notes);
+		else
+			return $notes ? $notes[0] : null;		
+	}
+	return null;
+}

--- a/src/shrub/src/note/note_core.php
+++ b/src/shrub/src/note/note_core.php
@@ -137,7 +137,7 @@ function _note_GetByNode( $ids ) {
 				author, 
 				".DB_FIELD_DATE('created').",
 				".DB_FIELD_DATE('modified').",
-				version,
+				version, flags,
 				body
 			FROM ".SH_TABLE_PREFIX.SH_TABLE_NOTE." 
 			WHERE node IN ($ids_string)
@@ -206,7 +206,7 @@ function note_GetById( $ids ) {
 				author, 
 				".DB_FIELD_DATE('created').",
 				".DB_FIELD_DATE('modified').",
-				version,
+				version, flags,
 				body
 			FROM ".SH_TABLE_PREFIX.SH_TABLE_NOTE." 
 			WHERE id IN ($ids_string)
@@ -223,33 +223,33 @@ function note_GetById( $ids ) {
 }
 
 
-function _note_AddByNode( $node, $supernode, $author, $parent, $body, $version_tag ) {
+function _note_AddByNode( $node, $supernode, $author, $parent, $body, $version_tag, $flags ) {
 	// Insert Proxy
 	$note_id = db_QueryInsert(
 		"INSERT IGNORE INTO ".SH_TABLE_PREFIX.SH_TABLE_NOTE." (
 			parent,
 			node, supernode,
-			author,
+			author, flags,
 			created
 		)
 		VALUES (
 			?,
 			?, ?,
-			?,
+			?, ?,
 			NOW()
 		)",
 		$parent,
 		$node, $supernode,
-		$author
+		$author, $flags
 	);
 
-	$edit = note_SafeEdit( $note_id, $author, $body, $version_tag );
+	$edit = note_SafeEdit( $note_id, $author, $body, $version_tag, $flags );
 	
 	return $note_id;
 }
 
-function note_AddByNode( $node, $supernode, $author, $parent, $body, $version_tag ) {
-	$note_id = _note_AddByNode($node, $supernode, $author, $parent, $body, $version_tag);
+function note_AddByNode( $node, $supernode, $author, $parent, $body, $version_tag, $flags = 0 ) {
+	$note_id = _note_AddByNode($node, $supernode, $author, $parent, $body, $version_tag, $flags);
 	
 	// Hack: Adding just the root entry to the tree
 	$tree = noteTree_Add($node, $note_id, 0, 1);
@@ -257,18 +257,20 @@ function note_AddByNode( $node, $supernode, $author, $parent, $body, $version_ta
 	return $note_id;
 }
 
-function note_SafeEdit( $note_id, $author, $body, $version_tag ) {
-	$version_id = noteVersion_Add($note_id, $author, $body, $version_tag);
+function note_SafeEdit( $note_id, $author, $body, $version_tag, $flags ) {
+	$version_id = noteVersion_Add($note_id, $author, $body, $version_tag, $flags);
 
 	return db_QueryUpdate(
 		"UPDATE ".SH_TABLE_PREFIX.SH_TABLE_NOTE."
 		SET
 			modified=NOW(),
 			version=?,
+			flags=?,
 			body=?
 		WHERE
 			id=?;",
 		$version_id,
+		$flags,
 		$body,
 	
 		$note_id

--- a/src/shrub/src/note/note_flags.php
+++ b/src/shrub/src/note/note_flags.php
@@ -1,0 +1,26 @@
+<?php
+
+function noteFlags_Filter( $notes, $current_user_id ) {
+	$multi = is_array($notes);
+	if ( !$multi )
+		$notes = [$notes];
+		
+	foreach ( $notes as &$note ) {
+		if ( $note['flags'] & SH_NOTE_FLAG_ANONYMOUS ) {
+			if ( $note['author'] != $current_user_id ) {
+				$note['author'] = 0;
+				$note['anonymous'] = true;
+			}
+		}
+		if ( $note['flags'] & SH_NOTE_FLAG_HIDDEN ) {
+			$note['hidden'] = true;
+		}
+	}
+
+	if ( $multi )
+		return array_values($notes);
+	else
+		return $notes ? $notes[0] : null;	
+}
+
+

--- a/src/shrub/src/note/note_flags.php
+++ b/src/shrub/src/note/note_flags.php
@@ -1,5 +1,7 @@
 <?php
 
+// Filter notes through this function before returning to a user.
+// Rewrites comments to add some convenience fields based on flags, and mask anonymous commentors.
 function noteFlags_Filter( $notes, $current_user_id ) {
 	$multi = is_array($notes);
 	if ( !$multi )
@@ -9,8 +11,8 @@ function noteFlags_Filter( $notes, $current_user_id ) {
 		if ( $note['flags'] & SH_NOTE_FLAG_ANONYMOUS ) {
 			if ( $note['author'] != $current_user_id ) {
 				$note['author'] = 0;
-				$note['anonymous'] = true;
 			}
+			$note['anonymous'] = true;
 		}
 		if ( $note['flags'] & SH_NOTE_FLAG_HIDDEN ) {
 			$note['hidden'] = true;

--- a/src/shrub/src/note/note_version.php
+++ b/src/shrub/src/note/note_version.php
@@ -1,25 +1,28 @@
 <?php
 
-function noteVersion_Add( $note, $author, $body, $tag = "" ) {
+function noteVersion_Add( $note, $author, $body, $tag = "", $flags = 0 ) {
 	$ret = db_QueryInsert(
 		"INSERT IGNORE INTO ".SH_TABLE_PREFIX.SH_TABLE_NOTE_VERSION." (
 			note,
 			author,
 			timestamp,
 			body,
-			tag
+			tag,
+			flags
 		)
 		VALUES (
 			?,
 			?,
 			NOW(),
 			?,
+			?,
 			?
 		)",
 		$note,
 		$author,
 		$body,
-		$tag
+		$tag,
+		$flags
 	);
 	
 	return $ret;

--- a/src/shrub/src/note/table_create.php
+++ b/src/shrub/src/note/table_create.php
@@ -28,6 +28,13 @@ if ( in_array($table, $TABLE_LIST) ) {
 			)".DB_CREATE_SUFFIX);
 		$created = true;
 		if (!$ok) break; $TABLE_VERSION++;
+	case 1:
+		$ok = table_Update( $table,
+			"ALTER TABLE ".SH_TABLE_PREFIX.constant($table)."
+				ADD COLUMN flags ".DB_TYPE_INT32."
+					AFTER timestamp;"
+			);
+		if (!$ok) break; $TABLE_VERSION++;			
 	};
 	table_Exit($table);
 }
@@ -101,6 +108,13 @@ if ( in_array($table, $TABLE_LIST) ) {
 					AFTER id;"
 			);
 		if (!$ok) break; $TABLE_VERSION++;
+	case 4:
+		$ok = table_Update( $table,
+			"ALTER TABLE ".SH_TABLE_PREFIX.constant($table)."
+				ADD COLUMN flags ".DB_TYPE_INT32."
+					AFTER version;"
+			);
+		if (!$ok) break; $TABLE_VERSION++;		
 	};
 
 	table_Exit($table);

--- a/src/shrub/src/notification/notification_core.php
+++ b/src/shrub/src/notification/notification_core.php
@@ -184,6 +184,6 @@ function notification_GetLastReadNotification( $node ) {
 }
 
 function notification_SetLastReadNotification( $node, $notification ) {
-	nodeMeta_AddByNode($node, SH_SCOPE_SERVER, 'last_read_notification', $notification);
+	return nodeMeta_AddByNode($node, SH_SCOPE_SERVER, 'last_read_notification', $notification);
 }
 


### PR DESCRIPTION
This is the backend work to enable anonymous comments.  
Following are the major changes:
* Add `flags` to note and note version tables. Define two flags (hidden and anonymous)
* Add `allow-anonymous-comments` metadata that can be applied to an 'item' node - The expected value for "enabled" is `1`
* Add `anonymous` optional parameter to `/note/add`, posting anonymously will only succeed if `allow-anonymous-comments` is present and resolves to a nonzero / true value.
* `flags` as well as boolean convenience variables `anonymous` and `hidden` are returned to the client with notes
* Minor site JS changes to not get stuck when anonymous comments are returned, and to render them appropriately.
* Event simulator now marks some games with `allow-anonymous-comments`, and sometimes comments anonymously on them.

Unrelated to anonymous comments:
* Fixed bug causing 500 server error on `notification/markread`
* Add `note/getnote` for fetching one or more notes by ID (Mainly for notifications). It's expected that this will be renamed in the future with a reorganization.
* Add event simulator concept of 'reaction' - Newly posted posts may cause a collection of users to interact with the new node - this will make the simulated dataset look more like actual data with many consecutive notifications on the same thread (to assist with development of comment merging in notifications / etc)