### PR TITLE
Anonymous comments

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -38,7 +38,7 @@ export default class ContentCommentsComment extends Component {
 		this.onSave = this.onSave.bind(this);
 		this.onCancel = this.onCancel.bind(this);
 		this.onPublish = this.onPublish.bind(this);
-
+		this.onPublishAnon = this.onPublishAnon.bind(this);
 		this.onLove = this.onLove.bind(this);
 		this.onReply = this.onReply.bind(this);
 	}
@@ -79,6 +79,14 @@ export default class ContentCommentsComment extends Component {
 		.catch(err => {
 			this.setState({ 'error': err });
 		});
+	}
+
+	onPublishAnon( e ) {
+		if (this.canSave() ) {
+			if ( this.props.onpublish ) {
+				this.props.onpublish(e, true);
+			}
+		}
 	}
 
 	onPublish( e ) {
@@ -225,6 +233,9 @@ export default class ContentCommentsComment extends Component {
 
 				var ShowRight = [];
 				if ( props.publish ) {
+					if (props.allowAnonymous) {
+						ShowRight.push(<div class={"-button -publish"+(state.modified?" -modified":"")} onclick={this.onPublishAnon}><SVGIcon>publish</SVGIcon><div>Publish Anonymously</div></div>);
+					}
 					ShowRight.push(<div class={"-button -publish"+(state.modified?" -modified":"")} onclick={this.onPublish}><SVGIcon>publish</SVGIcon><div>Publish</div></div>);
 				}
 				else {

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -6,8 +6,6 @@ import NavLink 							from 'com/nav-link/link';
 import SVGIcon 							from 'com/svg-icon/icon';
 import IMG2 							from 'com/img2/img2';
 
-import ContentFooterButtonComments		from 'com/content-footer/footer-button-comments';
-
 import ContentCommentsMarkup			from 'comments-markup';
 
 import $Note							from '../../shrub/js/note/note';
@@ -29,7 +27,6 @@ export default class ContentCommentsComment extends Component {
 			'lovecount': props.comment.love,
 		};
 
-//		console.log('C '+props.comment.id+": ", this.state.editing,this.state.preview);
 
 		this.onEditing = this.onEditing.bind(this);
 		this.onPreview = this.onPreview.bind(this);
@@ -95,7 +92,6 @@ export default class ContentCommentsComment extends Component {
 	}
 
 	onEdit( e ) {
-		console.log('edit');
 		this.setState({'editing': true, 'preview': false});
 	}
 
@@ -130,8 +126,6 @@ export default class ContentCommentsComment extends Component {
 		var user = props.user;
 		var comment = props.comment;
 		var author = props.author;
-
-//		console.log('R '+comment.id+": ", state.editing, state.preview);
 
 		if ( author || comment.author == 0 ) {
 			var Name = "Anonymous";

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -183,11 +183,12 @@ export default class ContentComments extends Component {
 			if ( r.note ) {
 				var Now = new Date();
 				var comment = Object.assign({
-					'id': r.note,
-					'created': Now.toISOString(),
-					'modified': Now.toISOString()
+					id: r.note,
+					created: Now.toISOString(),
+					modified: Now.toISOString(),
+					anonymous: publishAnon,
 				}, newcomment);
-				
+
 				// TODO: insert properly
 				this.state.comments.push(comment);
 

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -1,14 +1,6 @@
 import { h, Component } 				from 'preact/preact';
-//import ShallowCompare	 				from 'shallow-compare/index';
 
 import NavSpinner						from 'com/nav-spinner/spinner';
-import NavLink 							from 'com/nav-link/link';
-import SVGIcon 							from 'com/svg-icon/icon';
-import IMG2 							from 'com/img2/img2';
-
-import ContentFooterButtonComments		from 'com/content-footer/footer-button-comments';
-
-import ContentCommentsMarkup			from 'comments-markup';
 
 import ContentCommentsComment			from 'comments-comment';
 
@@ -24,7 +16,6 @@ export default class ContentComments extends Component {
 			'comments': null,
 			'tree': null,
 			'authors': null,
-
 			'newcomment': null,
 		};
 
@@ -143,7 +134,7 @@ export default class ContentComments extends Component {
 
 		var lovedComments = this.state.lovedComments;
 		var actualLove = [];
-		for (var item in lovedComments) {
+		for ( var item in lovedComments ) {
 			actualLove.push(lovedComments[item]['note']);
 		}
 
@@ -183,10 +174,10 @@ export default class ContentComments extends Component {
 			if ( r.note ) {
 				var Now = new Date();
 				var comment = Object.assign({
-					id: r.note,
-					created: Now.toISOString(),
-					modified: Now.toISOString(),
-					anonymous: publishAnon,
+					'id': r.note,
+					'created': Now.toISOString(),
+					'modified': Now.toISOString(),
+					'anonymous': publishAnon,
 				}, newcomment);
 
 				// TODO: insert properly
@@ -199,19 +190,16 @@ export default class ContentComments extends Component {
 				this.setState({'tree': this.buildTree()});
 			}
 			else {
-				this.setState({ 'error': err });
+				this.setState({'error': err});
 			}
 		})
 		.catch(err => {
-			this.setState({ 'error': err });
+			this.setState({'error': err});
 		});
 	}
 
 	render( props, {comments, tree, authors, newcomment} ) {
-		var node = props.node;
-		var user = props.user;
-		var path = props.path;
-		var extra = props.extra;
+		let {node, user, path, extra} = props;
 
 		var ShowComments = <NavSpinner />;
 		if ( comments && tree && authors ) {

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -40,7 +40,6 @@ export default class ContentComments extends Component {
 			'parent': 0,
 			'node': this.props.node.id,
 			'author': this.props.user.id,
-			'allowAnonymous': this.props.node.meta['allow-anonymous-comments'] ? true : false,
 			'body': '',
 			'love': 0,
 			'loved': false
@@ -166,12 +165,13 @@ export default class ContentComments extends Component {
 	}
 
 	renderPostNew() {
-		var user = this.props.user;
-		var authors = this.state.authors;
-		var comment = this.state.newcomment;
-		var author = authors[comment.author];
+		const user = this.props.user;
+		const authors = this.state.authors;
+		const comment = this.state.newcomment;
+		const author = authors[comment.author];
+		const allowAnonymous = this.props.node.meta['allow-anonymous-comments'] ? true : false;
 
-		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove /></div>;
+		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} /></div>;
 	}
 
 	onPublish( e, publishAnon ) {
@@ -187,7 +187,7 @@ export default class ContentComments extends Component {
 					'created': Now.toISOString(),
 					'modified': Now.toISOString()
 				}, newcomment);
-
+				
 				// TODO: insert properly
 				this.state.comments.push(comment);
 

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -212,10 +212,6 @@ export default class ContentComments extends Component {
 		var path = props.path;
 		var extra = props.extra;
 
-//		var FooterItems = [];
-//		if ( !props['no_comments'] )
-//			FooterItems.push(<ContentFooterButtonComments href={path} node={node} wedge_left_bottom />);
-
 		var ShowComments = <NavSpinner />;
 		if ( comments && tree && authors ) {
 			if ( comments.length )
@@ -242,11 +238,4 @@ export default class ContentComments extends Component {
 		);
 	}
 
-//				<div class="content-footer content-footer-common -footer">
-//					<div class="-left">
-//					</div>
-//					<div class="-right">
-//			  			{FooterItems}
-//			  		</div>
-//				</div>
 }

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -40,6 +40,7 @@ export default class ContentComments extends Component {
 			'parent': 0,
 			'node': this.props.node.id,
 			'author': this.props.user.id,
+			'allowAnonymous': this.props.node.meta['allow-anonymous-comments'] ? true : false,
 			'body': '',
 			'love': 0,
 			'loved': false
@@ -173,11 +174,11 @@ export default class ContentComments extends Component {
 		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove /></div>;
 	}
 
-	onPublish( e ) {
-		var node = this.props.node;
-		var newcomment = this.state.newcomment;
+	onPublish( e, publishAnon ) {
+		const node = this.props.node;
+		const newcomment = this.state.newcomment;
 
-		$Note.Add( newcomment.parent, newcomment.node, newcomment.body )
+		$Note.Add( newcomment.parent, newcomment.node, newcomment.body, null, publishAnon )
 		.then(r => {
 			if ( r.note ) {
 				var Now = new Date();

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -169,7 +169,7 @@ export default class ContentComments extends Component {
 		const authors = this.state.authors;
 		const comment = this.state.newcomment;
 		const author = authors[comment.author];
-		const allowAnonymous = this.props.node.meta['allow-anonymous-comments'] ? true : false;
+		const allowAnonymous = parseInt(this.props.node.meta['allow-anonymous-comments']);
 
 		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} /></div>;
 	}

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -37,8 +37,7 @@ export default class ContentItem extends Component {
 
 			'linksShown': 1,
 
-//			'platforms': [],
-//			'tags': [],
+			'allowAnonymous': node.meta['allow-anonymous-comments'] ? true : false,
 		};
 
 		for ( let i = 0; i < 9; i++ ) {
@@ -54,6 +53,7 @@ export default class ContentItem extends Component {
 		this.onSetJam = this.onSetJam.bind(this);
 		this.onSetCompo = this.onSetCompo.bind(this);
 		this.onSetUnfinished = this.onSetUnfinished.bind(this);
+		this.onAnonymousComments = this.onAnonymousComments.bind(this);
 	}
 
 	componentDidMount() {
@@ -204,6 +204,18 @@ export default class ContentItem extends Component {
 					this.setState({ 'error': err });
 				});
 		}
+	}
+
+	onAnonymousComments () {
+		const anon = this.state.allowAnonymous;
+		const node = this.props.node;
+
+		return $NodeMeta.Add(node.id, {'allow-anonymous-comments': anon ? 1 : 0})
+			.then(r => {
+				if ( r && r.changed ) {
+					this.setState({allowAnonymous: !anon});
+				}
+			});
 	}
 
 	onModifyLinkName( Index, e ) {
@@ -714,6 +726,13 @@ export default class ContentItem extends Component {
 			ShowLinkEntry = this.makeLinks(true /* editing */);
 		}
 
+		let ShowAnonymousComments = null;
+		if ( true ) {
+			ShowAnonymousComments = (
+				<ContentCommonNavButton onclick={this.onAnonymousComments} class={state.allowAnonymous ? "-selected" : ""}><SVGIcon>warning</SVGIcon><div>Allow anonymous comments</div></ContentCommonNavButton>);
+
+		}
+
 		var ShowUploadTips = null;
 		if ( true ) {
 			ShowUploadTips = (
@@ -744,7 +763,6 @@ export default class ContentItem extends Component {
 			);
 		}
 
-
 		props.editonly = (
 			<div>
 				{ShowEventPicker}
@@ -753,6 +771,7 @@ export default class ContentItem extends Component {
 				{ShowLinkEntry}
 				{ShowUploadTips}
 				{ShowUnfinished}
+				{ShowAnonymousComments}
 			</div>
 		);
 		props.onSave = this.onSave.bind(this);

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -728,7 +728,14 @@ export default class ContentItem extends Component {
 		let ShowAnonymousComments = null;
 		if ( true ) {
 			ShowAnonymousComments = (
-				<ContentCommonNavButton onclick={this.onAnonymousComments} class={state.allowAnonymous ? "-selected" : ""}><SVGIcon>warning</SVGIcon><div>Allow anonymous comments</div></ContentCommonNavButton>);
+				<ContentCommonBody>
+					<ContentCommonNavButton onclick={this.onAnonymousComments} class={state.allowAnonymous ? "-selected" : ""}>
+						<SVGIcon>warning</SVGIcon>
+						<div>Allow anonymous comments</div>
+					</ContentCommonNavButton>
+					<br />
+					Click to <em>{state.allowAnonymous ? "deactivate" : "activate"}</em> anonymous comments.
+				</ContentCommonBody>);
 
 		}
 

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -211,7 +211,8 @@ export default class ContentItem extends Component {
 		let update = null;
 		if (anon) {
 			update = $NodeMeta.Remove(node.id, {'allow-anonymous-comments': 0});
-		} else {
+		}
+		else {
 			update = $NodeMeta.Add(node.id, {'allow-anonymous-comments': 1});
 		}
 

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -218,7 +218,7 @@ export default class ContentItem extends Component {
 
 		return update.then(r => {
 				if ( r && r.changed ) {
-					this.setState({allowAnonymous: !anon});
+					this.setState({'allowAnonymous': !anon});
 				}
 			});
 	}

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -15,7 +15,6 @@ import ContentCommonNavButton			from 'com/content-common/common-nav-button';
 
 import ContentSimple					from 'com/content-simple/simple';
 
-
 import $Node							from '../../shrub/js/node/node';
 import $NodeMeta						from '../../shrub/js/node/node_meta';
 import $Grade							from '../../shrub/js/grade/grade';

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -208,9 +208,14 @@ export default class ContentItem extends Component {
 	onAnonymousComments () {
 		const anon = this.state.allowAnonymous;
 		const node = this.props.node;
+		let update = null;
+		if (anon) {
+			update = $NodeMeta.Remove(node.id, {'allow-anonymous-comments': 0});
+		} else {
+			update = $NodeMeta.Add(node.id, {'allow-anonymous-comments': 1});
+		}
 
-		return $NodeMeta.Add(node.id, {'allow-anonymous-comments': anon ? 1 : 0})
-			.then(r => {
+		return update.then(r => {
 				if ( r && r.changed ) {
 					this.setState({allowAnonymous: !anon});
 				}

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -36,7 +36,7 @@ export default class ContentItem extends Component {
 
 			'linksShown': 1,
 
-			'allowAnonymous': node.meta['allow-anonymous-comments'] ? true : false,
+			'allowAnonymous': parseInt(node.meta['allow-anonymous-comments']),
 		};
 
 		for ( let i = 0; i < 9; i++ ) {

--- a/src/com/content-notifications/notification.js
+++ b/src/com/content-notifications/notification.js
@@ -116,7 +116,12 @@ export default class NotificationItem extends Component {
 
 		} else if(notification.notification.note) {
 			const note = notification.note[0];
-			const NoteAuthor = <NavLink class='-at-name'>@{notification.users.get(note.author).name}</NavLink>;
+			let NoteAuthor = null;
+			if (note.author > 0) {
+				NoteAuthor = <NavLink class='-at-name'>@{notification.users.get(note.author).name}</NavLink>;
+			} else {
+				NoteAuthor = <NavLink class='-at-name -anonymous'>An anonymous user</NavLink>;
+			}
 
 			if (!node.selfauthored && !note.selfauthored) {
 

--- a/src/shrub/js/node/node.js
+++ b/src/shrub/js/node/node.js
@@ -22,7 +22,9 @@ export default {
 	AddMeta,
 	RemoveMeta,
 	AddLink,
-	RemoveLink
+	RemoveLink,
+
+	InvalidateNodeCache,
 };
 
 var NODE_CACHE = {};
@@ -38,6 +40,9 @@ function _Get( node_id ) {
 	return NODE_CACHE[node_id];
 }
 
+export function InvalidateNodeCache( node_id ) {
+	NODE_CACHE[node_id] = undefined;
+}
 
 // http://stackoverflow.com/a/4026828/5678759
 function ArrayDiff(a, b) {

--- a/src/shrub/js/node/node.js
+++ b/src/shrub/js/node/node.js
@@ -41,7 +41,7 @@ function _Get( node_id ) {
 }
 
 export function InvalidateNodeCache( node_id ) {
-	NODE_CACHE[node_id] = undefined;
+	NODE_CACHE[node_id] = null;
 }
 
 // http://stackoverflow.com/a/4026828/5678759

--- a/src/shrub/js/node/node_meta.js
+++ b/src/shrub/js/node/node_meta.js
@@ -1,4 +1,5 @@
 import Fetch	 				from '../internal/fetch';
+import { InvalidateNodeCache } from './node';
 
 export default {
 	Add,
@@ -6,8 +7,10 @@ export default {
 };
 
 export function Add( node, data ) {
+	InvalidateNodeCache(node);
 	return Fetch.Post(API_ENDPOINT+'/vx/node/meta/add/'+node, data);
 }
 export function Remove( node, data ) {
+	InvalidateNodeCache(node);
 	return Fetch.Post(API_ENDPOINT+'/vx/node/meta/remove/'+node, data);
 }

--- a/src/shrub/js/note/note.js
+++ b/src/shrub/js/note/note.js
@@ -20,7 +20,7 @@ export function Pick( notes ) {
 	return Fetch.Get(API_ENDPOINT+'/vx/note/getnote/'+notes.join('+'), true);
 }
 
-export function Add( parent, node, body, tag ) {
+export function Add( parent, node, body, tag, anonymous ) {
 	var Data = {};
 
 	if ( Number.isInteger(parent) )
@@ -29,6 +29,10 @@ export function Add( parent, node, body, tag ) {
 		Data.body = body;
 	if ( tag )
 		Data.tag = tag;
+
+	if ( anonymous ) {
+		Data.anonymous = anonymous;
+	}
 
 	return Fetch.Post(API_ENDPOINT+'/vx/note/add/'+node, Data);
 }


### PR DESCRIPTION
Continuing on #1247 with full UI implementation.

Node author on games (only games) can opt-in for anonymous comments.

Everyone can then choose to publish or publish anonymously. Still requires logged in. 

For mobile the comment button `bar` isn't really mobile friendly. Wasn't either before. Mainly because there's no collapsing the to icon only for either publish icon. Now it would also be good to have a new svg for the rocket with some mask.