### PR TITLE
Fixing specific columns and large game

### DIFF
--- a/src/com/content-box/box.js
+++ b/src/com/content-box/box.js
@@ -153,7 +153,8 @@ export default class ContentBox extends Component {
 					</div>
 				</ButtonLink>
 			);
-		} else if (props.placeHolder) {
+		}
+		else if (props.placeHolder) {
 			return <div class={cN(Class, props.class, '-place-holder')} />;
 		}
 		else {

--- a/src/com/content-box/box.js
+++ b/src/com/content-box/box.js
@@ -50,11 +50,7 @@ export default class ContentBox extends Component {
 
 	render( props, state ) {
 		props = Object.assign({}, props);
-
-		var node = props.node;
-		var user = props.user;
-		var path = props.path;
-		var extra = props.extra;
+		const {node, user, path, extra} = props;
 
 		if ( node /* && state.authors */ ) {
 			var Class = ["content-box"];
@@ -133,7 +129,7 @@ export default class ContentBox extends Component {
 //				ShowTrophies.sort(function(a, b) {
 //					sortOrder = ['-first', '-second', '-third'];
 //					regexPattern = /class=\"([^\"]+)/;
-//					return sortOrder.indexOf(regexPattern.exec(a)[1]) - sortOrder.indexOf(regexPattern.exec(b)[1]); 
+//					return sortOrder.indexOf(regexPattern.exec(a)[1]) - sortOrder.indexOf(regexPattern.exec(b)[1]);
 //				});
 			}
 
@@ -157,6 +153,8 @@ export default class ContentBox extends Component {
 					</div>
 				</ButtonLink>
 			);
+		} else if (props.placeHolder) {
+			return <div class={cN(Class, props.class, '-place-holder')} />;
 		}
 		else {
 			return <ContentLoading />;

--- a/src/com/content-box/box.less
+++ b/src/com/content-box/box.less
@@ -8,7 +8,11 @@
 /*	height: 246px;	/* 5:4 */
 	
 	overflow: hidden;
-	
+
+	&.-place-holder {
+		visibility: hidden;
+	}
+
 	& > .-cover {
 		box-sizing: border-box;
 		

--- a/src/com/content-games/games.js
+++ b/src/com/content-games/games.js
@@ -1,5 +1,4 @@
 import { h, Component } 				from 'preact/preact';
-import NavSpinner						from 'com/nav-spinner/spinner';
 
 import ContentLoading					from 'com/content-loading/loading';
 import ContentError						from 'com/content-error/error';
@@ -12,8 +11,6 @@ import ContentCommonBodyTitle			from 'com/content-common/common-body-title';
 
 import GridSelector						from './grid-selector';
 
-//import ContentPost						from 'com/content-post/post';
-//import ContentUser						from 'com/content-user/user';
 import ContentMore						from 'com/content-more/more';
 
 import $Node							from '../../shrub/js/node/node';
@@ -24,13 +21,13 @@ export default class ContentGames extends Component {
 		super(props);
 
 		this.state = {
-			feed: [],
-			hash: {},
-			offset: 12-5, //10-5
-			added: null,
-			loaded: false,
-			defaultLayout: 3,
-			layout: 3,
+			'feed': [],
+			'hash': {},
+			'offset': 12-5, //10-5
+			'added': null,
+			'loaded': false,
+			'defaultLayout': 3,
+			'layout': 3,
 		};
 
 		this.fetchMore = this.fetchMore.bind(this);
@@ -147,10 +144,10 @@ export default class ContentGames extends Component {
 
 		var LoadMore = null;
 
-		if (error){
+		if ( error ) {
 			return <ContentError code="400">"Bad Request : Couldn't load games"</ContentError>;
 		}
-		else if(feed && feed.length > 0)
+		else if ( feed && feed.length > 0 )
 		{
 			var Games = feed.map(r => {
 				return <ContentItemBox node={r.node} user={props.user} path={props.path} noevent={props.noevent ? props.noevent : null} />;
@@ -162,7 +159,7 @@ export default class ContentGames extends Component {
 				keep adding placeholder elements so that the last
 				row looks nice
 			*/
-			while (Games.length % layout !== 0) {
+			while ( Games.length % layout !== 0 ) {
 				Games.push(<ContentItemBox placeHolder={true} />);
 			}
 

--- a/src/com/content-games/games.js
+++ b/src/com/content-games/games.js
@@ -10,6 +10,8 @@ import ContentItemBox					from 'com/content-item/item-box';
 import ContentCommonBody				from 'com/content-common/common-body';
 import ContentCommonBodyTitle			from 'com/content-common/common-body-title';
 
+import GridSelector						from './grid-selector';
+
 //import ContentPost						from 'com/content-post/post';
 //import ContentUser						from 'com/content-user/user';
 import ContentMore						from 'com/content-more/more';
@@ -26,7 +28,9 @@ export default class ContentGames extends Component {
 			hash: {},
 			offset: 12-5, //10-5
 			added: null,
-			loaded: false
+			loaded: false,
+			defaultLayout: 3,
+			layout: 3,
 		};
 
 		this.fetchMore = this.fetchMore.bind(this);
@@ -135,7 +139,7 @@ export default class ContentGames extends Component {
 		this.setState({'offset': offset + 12});
 	}
 
-	render( props, {feed, added, error, loaded} ) {
+	render( props, {feed, added, error, loaded, defaultLayout, layout} ) {
 		var Class = ['content-base'];
 //        props.class = typeof props.class == 'string' ? props.class.split(' ') : [];
 //        props.class.push("content-games");
@@ -152,14 +156,28 @@ export default class ContentGames extends Component {
 				return <ContentItemBox node={r.node} user={props.user} path={props.path} noevent={props.noevent ? props.noevent : null} />;
 			});
 
+			while (Games.length % layout !== 0) {
+				Games.push(<ContentItemBox placeHolder={true} />);
+			}
+
 			if ( !props.nomore /*|| added >= 10*/ ){
 				LoadMore = <ContentMore onclick={this.fetchMore} />;
 			}
 
+			const gridClass = `-columns-${layout}`;
+
 			return(
 				<div class={cN(Class, props.class)}>
 					{props.children}
-					<div class='content-boxes'>
+					<GridSelector
+						defaultLayout={defaultLayout}
+						onChangeLayout={
+							(gridLayout) => {
+								this.setState({layout: gridLayout,});
+							}
+						}
+					/>
+					<div class={cN('content-boxes', gridClass)}>
 						{Games}
 					</div>
 					{LoadMore}

--- a/src/com/content-games/games.js
+++ b/src/com/content-games/games.js
@@ -156,6 +156,12 @@ export default class ContentGames extends Component {
 				return <ContentItemBox node={r.node} user={props.user} path={props.path} noevent={props.noevent ? props.noevent : null} />;
 			});
 
+			/*
+				As long as the number of items in the Games array
+				doesn't evenly divide by the number of columns
+				keep adding placeholder elements so that the last
+				row looks nice
+			*/
 			while (Games.length % layout !== 0) {
 				Games.push(<ContentItemBox placeHolder={true} />);
 			}
@@ -173,7 +179,7 @@ export default class ContentGames extends Component {
 						defaultLayout={defaultLayout}
 						onChangeLayout={
 							(gridLayout) => {
-								this.setState({layout: gridLayout,});
+								this.setState({'layout': gridLayout,});
 							}
 						}
 					/>

--- a/src/com/content-games/games.js
+++ b/src/com/content-games/games.js
@@ -164,9 +164,9 @@ export default class ContentGames extends Component {
 				LoadMore = <ContentMore onclick={this.fetchMore} />;
 			}
 
-			const gridClass = `-columns-${layout}`;
+			const gridClass = '-columns-' + layout;
 
-			return(
+			return (
 				<div class={cN(Class, props.class)}>
 					{props.children}
 					<GridSelector

--- a/src/com/content-games/games.less
+++ b/src/com/content-games/games.less
@@ -4,8 +4,8 @@
 	flex-wrap: wrap;
 	justify-content: flex-start; /* space-between; */
 	align-items: flex-start;
-
 	margin: -0.5rem;	/* to undo the effect of the 0.5rem margin in items */
+	margin-top: 2.25rem !important;
 
 	& > * {
 		margin: 0.5rem;

--- a/src/com/content-games/games.less
+++ b/src/com/content-games/games.less
@@ -1,4 +1,3 @@
-
 #content .content-boxes {
 	display: flex;
 	flex-direction: row;
@@ -11,18 +10,7 @@
 	& > * {
 		margin: 0.5rem;
 	}
-/*
-	& when (@mobile = "mobile") {
-		& > * {
-			flex: 1 1 100%;
-		}
 
-	& when not (@mobile = "mobile") {
-		& > * {
-			flex: 1 1 30%;
-		}
-	}
-*/
 	&.-columns-1 {
 		& > * {
 			flex: 1 1 100% !important;
@@ -55,8 +43,7 @@
 
 	&.-columns-6 {
 		& > * {
-			flex: 1 1 12% !important;
+			flex: 1 1 13% !important;
 		}
 	}
-
 }

--- a/src/com/content-games/games.less
+++ b/src/com/content-games/games.less
@@ -5,14 +5,58 @@
 	flex-wrap: wrap;
 	justify-content: flex-start; /* space-between; */
 	align-items: flex-start;
-	
+
 	margin: -0.5rem;	/* to undo the effect of the 0.5rem margin in items */
-	
+
 	& > * {
-		flex: 1;
-		
-		min-width: 240px;
-		max-width: 640px;
 		margin: 0.5rem;
 	}
+/*
+	& when (@mobile = "mobile") {
+		& > * {
+			flex: 1 1 100%;
+		}
+
+	& when not (@mobile = "mobile") {
+		& > * {
+			flex: 1 1 30%;
+		}
+	}
+*/
+	&.-columns-1 {
+		& > * {
+			flex: 1 1 100% !important;
+		}
+	}
+
+	&.-columns-2 {
+		& > * {
+			flex: 1 1 45% !important;
+		}
+	}
+
+	&.-columns-3 {
+		& > * {
+			flex: 1 1 25% !important;
+		}
+	}
+
+	&.-columns-4 {
+		& > * {
+			flex: 1 1 20% !important;
+		}
+	}
+
+	&.-columns-5 {
+		& > * {
+			flex: 1 1 16% !important;
+		}
+	}
+
+	&.-columns-6 {
+		& > * {
+			flex: 1 1 12% !important;
+		}
+	}
+
 }

--- a/src/com/content-games/grid-selector.js
+++ b/src/com/content-games/grid-selector.js
@@ -1,0 +1,81 @@
+import { h, Component } 				from 'preact/preact';
+
+import Dropdown							from 'com/input-dropdown/dropdown';
+import ButtonBase						from '../button-base/base';
+import SVGIcon 							from 'com/svg-icon/icon';
+
+export default class GridSelector extends Component {
+    constructor( props ) {
+		super(props);
+        this.state = {
+            expanded: false,
+            selected: null,
+        };
+
+        this.onSelectLayout = this.onSelectLayout.bind(this);
+        this.onToggleDropDown = this.onToggleDropDown.bind(this);
+    }
+
+    componentDidMount() {
+       if (!this.state.selected) {
+          this.handleNewSelection(this.props.defaultLayout);
+       }
+    }
+
+    handleNewSelection(selected) {
+        const onChangeLayout = this.props.onChangeLayout;
+        this.setState({selected: selected});
+        if (onChangeLayout) {
+            onChangeLayout(selected);
+        }
+    }
+
+    onToggleDropDown() {
+        console.log('toggle dropdown', this.state);
+        this.setState({expanded: !this.state.expanded});
+    }
+
+    onSelectLayout(index) {
+        this.handleNewSelection(index);
+        this.setState({
+            expanded: false,
+            selected: index,
+        });
+    }
+
+    render( props, {expanded, selected} ) {
+       let ShowDropDown = null;
+
+       const ShowToggle = (
+            <ButtonBase onclick={this.onToggleDropDown}>
+                <SVGIcon>hammer</SVGIcon>
+            </ButtonBase>
+       );
+
+       if (expanded) {
+           const options = [
+               [1, '1 per line'],
+               [2, '2 per line'],
+               [3, '3 per line'],
+               [4, '4 per line'],
+               [5, '5 per line'],
+               [6, '6 per line'],
+           ];
+
+           ShowDropDown = (
+               <Dropdown
+                    items={options}
+                    onmodify={this.onSelectLayout}
+                    startExpanded={true}
+                />
+            );
+       }
+
+       return (
+           <div class={props.class ? props.class : 'grid-selector'}>
+                {ShowToggle}
+                {ShowDropDown}
+           </div>
+       );
+    }
+}

--- a/src/com/content-games/grid-selector.js
+++ b/src/com/content-games/grid-selector.js
@@ -8,8 +8,8 @@ export default class GridSelector extends Component {
     constructor( props ) {
 		super(props);
         this.state = {
-            expanded: false,
-            selected: null,
+            'expanded': false,
+            'selected': null,
         };
 
         this.onSelectLayout = this.onSelectLayout.bind(this);
@@ -24,7 +24,7 @@ export default class GridSelector extends Component {
 
     handleNewSelection(selected) {
         const onChangeLayout = this.props.onChangeLayout;
-        this.setState({selected: selected});
+        this.setState({'selected': selected});
         if (onChangeLayout) {
             onChangeLayout(selected);
         }
@@ -32,7 +32,7 @@ export default class GridSelector extends Component {
 
     onToggleDropDown() {
         console.log('toggle dropdown', this.state);
-        this.setState({expanded: !this.state.expanded});
+        this.setState({'expanded': !this.state.expanded});
     }
 
     onSelectLayout(index) {

--- a/src/com/content-games/grid-selector.js
+++ b/src/com/content-games/grid-selector.js
@@ -17,15 +17,15 @@ export default class GridSelector extends Component {
     }
 
     componentDidMount() {
-       if (!this.state.selected) {
+       if ( !this.state.selected ) {
           this.handleNewSelection(this.props.defaultLayout);
        }
     }
 
-    handleNewSelection(selected) {
+    handleNewSelection( selected ) {
         const onChangeLayout = this.props.onChangeLayout;
         this.setState({'selected': selected});
-        if (onChangeLayout) {
+        if ( onChangeLayout ) {
             onChangeLayout(selected);
         }
     }
@@ -35,7 +35,7 @@ export default class GridSelector extends Component {
         this.setState({'expanded': !this.state.expanded});
     }
 
-    onSelectLayout(index) {
+    onSelectLayout( index ) {
         this.handleNewSelection(index);
         this.setState({
             expanded: false,
@@ -52,7 +52,7 @@ export default class GridSelector extends Component {
             </ButtonBase>
        );
 
-       if (expanded) {
+       if ( expanded ) {
            const options = [
                [1, '1 per line'],
                [2, '2 per line'],

--- a/src/com/content-games/grid-selector.js
+++ b/src/com/content-games/grid-selector.js
@@ -48,7 +48,7 @@ export default class GridSelector extends Component {
 
        const ShowToggle = (
             <ButtonBase onclick={this.onToggleDropDown}>
-                <SVGIcon>hammer</SVGIcon>
+                <SVGIcon>cog</SVGIcon>
             </ButtonBase>
        );
 
@@ -72,7 +72,7 @@ export default class GridSelector extends Component {
        }
 
        return (
-           <div class={props.class ? props.class : 'grid-selector'}>
+           <div class={cN(props.class, 'grid-selector')}>
                 {ShowToggle}
                 {ShowDropDown}
            </div>

--- a/src/com/content-games/grid-selector.less
+++ b/src/com/content-games/grid-selector.less
@@ -1,0 +1,19 @@
+.grid-selector {
+    display: inline-block;
+    float: right;
+    width: 2rem;
+
+    & .input-dropdown {
+
+        & > button {
+            visibility: hidden;
+            height: 0;
+            width: 0;
+        }
+
+        & > .-items {
+            min-width: 10 rem;
+            right: 8rem;
+        }
+    }
+}

--- a/src/com/content-games/grid-selector.less
+++ b/src/com/content-games/grid-selector.less
@@ -2,6 +2,9 @@
     display: inline-block;
     float: right;
     width: 2rem;
+    margin-left: -2rem;
+    bottom: 1.5rem;
+    position: relative;
 
     & .input-dropdown {
 
@@ -13,7 +16,8 @@
 
         & > .-items {
             min-width: 8rem;
-            right: 1rem;
+            right: 0.25rem;
+            top: 0.45rem;
         }
     }
 }

--- a/src/com/content-games/grid-selector.less
+++ b/src/com/content-games/grid-selector.less
@@ -12,8 +12,8 @@
         }
 
         & > .-items {
-            min-width: 10 rem;
-            right: 8rem;
+            min-width: 8rem;
+            right: 1rem;
         }
     }
 }

--- a/src/com/content-item/item-box.js
+++ b/src/com/content-item/item-box.js
@@ -1,7 +1,5 @@
 import { h, Component } 				from 'preact/preact';
 
-import ContentLoading					from 'com/content-loading/loading';
-
 import ContentBox						from 'com/content-box/box';
 
 export default class ContentItemBox extends Component {
@@ -11,11 +9,6 @@ export default class ContentItemBox extends Component {
 
 	render( props, state ) {
 		props = Object.assign({}, props);
-
-		var node = props.node;
-		var user = props.user;
-		var path = props.path;
-		var extra = props.extra;
 
 		return <ContentBox {...props} />;
 	}


### PR DESCRIPTION
This introduces a hammer drop-down where number of columns to the games-grid can be selected.

At the moment the `<ContentsGames>` has a default layout of 3 columns for whatever platform in its state.
When there's a parameter for if on mobile, the `defaultLayout` should probably be moved to `props` or `props` should allow for a flag of default view-type to trigger different defaultLayout settings.

The hammer-button that triggers the layout should probably in the near future be placed inside the filter/search bar that most instances will have. That is for a future PR.

The PR also ensures that the number of boxes/cards produces a complete final row with invisible placeholders should need be. This fixes the bug of sometimes getting extra large boxes/cards on the final row.