### PR TITLE
Shrub tags

### DIFF
--- a/src/shrub/js/tag/tag.js
+++ b/src/shrub/js/tag/tag.js
@@ -22,7 +22,7 @@ function _Get( filter ) {
 
 export function GetContains( subString ) {
 	pattern = new RegExp(subString.match(/^#?(.+)/)[1], 'i');
-	GetAll()
+	return GetAll()
 		.then( (r) => {
 			const newResponse = Object.assign({}, r);
 			newResponse.tag = [];

--- a/src/shrub/js/tag/tag.js
+++ b/src/shrub/js/tag/tag.js
@@ -2,7 +2,9 @@ import Fetch	 				from '../internal/fetch';
 
 export default {
 	Get,
-	GetFresh
+	GetFresh,
+	GetAll,
+	GetContains,
 };
 
 var TAG_CACHE = {};
@@ -18,6 +20,24 @@ function _Get( filter ) {
 	return TAG_CACHE['_'+filter];
 }
 
+export function GetContains( subString ) {
+	pattern = new RegExp(subString.match(/^#?(.+)/)[1], 'i');
+	GetAll()
+		.then( (r) => {
+			const newResponse = Object.assign({}, r);
+			newResponse.tag = [];
+			r.tag.forEach((tag) => {
+				if (tag.name.match(pattern)) {
+					newResponse.tag.push(tag);
+				}
+			});
+			return Promise.resolve(newResponse);
+		});
+}
+
+export function GetAll() {
+		return Get('all');
+}
 
 export function Get( filter ) {
 	if ( _Exists(filter) ) {
@@ -26,6 +46,7 @@ export function Get( filter ) {
 
 	return GetFresh(filter);
 }
+
 export function GetFresh( filter ) {
 	return Fetch.Get(API_ENDPOINT+'/vx/tag/get/'+filter)
 		.then( r => {


### PR DESCRIPTION
Idea is to allow UI to query tags based on their names.
Matching is done in case independent and any initial `#` is removed from input.
All tags containing pattern are returned.
Uses existing cache.

Example REPL use:
```
IN:> $Tag.GetContains('y').then(r=>console.log(r.tag.map(t=>t.name)));
OUT:> Array [ "kitty", "Gameboy" ]
```