### PR TITLE
Shelf and a game-shelf

### DIFF
--- a/src/com/content-box/box.js
+++ b/src/com/content-box/box.js
@@ -66,7 +66,7 @@ export default class ContentBox extends Component {
 			Cover += '.480x384.fit.jpg';
 
 			var ShowHoverCover = null;
-			if ( node.meta['cover-hover'] ) {
+			if ( node.meta && node.meta['cover-hover'] ) {
 				ShowHoverCover = <IMG2 class="-cover-hover" src={HoverCover} failsrc={CoverFail} />;
 			}
 

--- a/src/com/content-box/box.js
+++ b/src/com/content-box/box.js
@@ -1,4 +1,4 @@
-import { h, Component } 				from 'preact/preact';
+import {h, Component} 				from 'preact/preact';
 import Shallow							from 'shallow/shallow';
 
 import ContentLoading					from 'com/content-loading/loading';

--- a/src/com/content-shelf/game-shelf.js
+++ b/src/com/content-shelf/game-shelf.js
@@ -16,11 +16,25 @@ export default class GameShelf extends Component {
 		const subsubtypes = props.subsubtypes ? props.subsubtypes : null;
 		const more = null;
 		const limit = props.slots ? props.slots : 5;
+        const {expandable} = props;
 
 		$Node.GetFeed( id, methods, types, subtypes, subsubtypes, more, limit )
 		.then(r => {
 			if ( r.feed && r.feed.length ) {
-                this.setState({'games': r.feed});
+                const nodes = [];
+                r.feed.forEach( (node) => {
+                    if (expandable || nodes.length < limit) {
+                        nodes.push(node.id);
+                    }
+                });
+                return $Node.Get(nodes)
+                    .then( r => {
+                        console.log(r);
+                        this.setState({'games': r.node});
+                    })
+                    .catch(err => {
+                        this.setState({'error': err});
+                    });
 			}
 		})
 		.catch(err => {
@@ -29,8 +43,9 @@ export default class GameShelf extends Component {
     }
 
     getGameBoxes(games) {
+        const {user, path, noevent} = this.props;
         if ( games ) {
-            return games.map( ( node ) => <ContentBox node={node} /> );
+            return games.map( ( node ) => <ContentBox node={node} user={user} path={path} noevent={noevent ? noevent : null} /> );
         }
         else {
             return [];

--- a/src/com/content-shelf/game-shelf.js
+++ b/src/com/content-shelf/game-shelf.js
@@ -41,7 +41,6 @@ export default class GameShelf extends Component {
         let Games = this.getGameBoxes(games);
         let Props = Object.assign({}, props);
         delete Props.node;
-        console.log(Games, Props);
         return <Shelf {...Props}>{Games}</Shelf>;
     }
 }

--- a/src/com/content-shelf/game-shelf.js
+++ b/src/com/content-shelf/game-shelf.js
@@ -28,8 +28,17 @@ export default class GameShelf extends Component {
 		});
     }
 
+    getGameBoxes(games) {
+        if ( games ) {
+            return games.map( ( node ) => <ContentBox node={node} /> );
+        }
+        else {
+            return [];
+        }
+    }
+
     render ( props, {games} ) {
-        let Games = games.map( ( node ) => <ContentBox node={node} /> );
+        let Games = this.getGameBoxes(games);
         let Props = Object.assing({}, props);
         delete Props.node;
         return <Shelf {...Props}>{Games}</Shelf>;

--- a/src/com/content-shelf/game-shelf.js
+++ b/src/com/content-shelf/game-shelf.js
@@ -39,8 +39,9 @@ export default class GameShelf extends Component {
 
     render ( props, {games} ) {
         let Games = this.getGameBoxes(games);
-        let Props = Object.assing({}, props);
+        let Props = Object.assign({}, props);
         delete Props.node;
+        console.log(Games, Props);
         return <Shelf {...Props}>{Games}</Shelf>;
     }
 }

--- a/src/com/content-shelf/game-shelf.js
+++ b/src/com/content-shelf/game-shelf.js
@@ -1,0 +1,37 @@
+import {h, Component} from 'preact/preact';
+
+import Shelf from 'com/content-shelf/shelf';
+import ContentBox from 'com/content-box/box';
+
+import $Node from '../../shrub/js/node/node';
+
+export default class GameShelf extends Component {
+
+    componentDidMount() {
+        const props = this.props;
+        const {id} = props.node;
+		const methods = props.methods ? props.methods : ['parent', 'superparent'];
+		const types = ['item'];
+		const subtypes = ['game'];
+		const subsubtypes = props.subsubtypes ? props.subsubtypes : null;
+		const more = null;
+		const limit = props.slots ? props.slots : 5;
+
+		$Node.GetFeed( id, methods, types, subtypes, subsubtypes, more, limit )
+		.then(r => {
+			if ( r.feed && r.feed.length ) {
+                this.setState({'games': r.feed});
+			}
+		})
+		.catch(err => {
+			this.setState({'error': err});
+		});
+    }
+
+    render ( props, {games} ) {
+        let Games = games.map( ( node ) => <ContentBox node={node} /> );
+        let Props = Object.assing({}, props);
+        delete Props.node;
+        return <Shelf {...Props}>{Games}</Shelf>;
+    }
+}

--- a/src/com/content-shelf/shelf.js
+++ b/src/com/content-shelf/shelf.js
@@ -6,6 +6,10 @@ import SVGicon from 'com/svg-icon/icon';
 export default class Shelf extends Component {
 
     render ( {slots, children, expandable}, {expanded} ) {
+        if (!slots) {
+            slots = 5;
+        }
+
         const ExpandCollapseIcon = expandable ? (
             <SVGicon onclick={ () => this.setState({'expaned': !expaned}) } class="-shelf-tools">
                 {expaned ? 'arrow-up' : 'arrow-down'}
@@ -18,7 +22,7 @@ export default class Shelf extends Component {
         children.forEach( ( card ) => {
             Cards.push(card);
             if ( Cards.length == slots ) {
-                const invisible = expaned || Shelves.length == 0 ? '' : '-elf-shelf';
+                const invisible = expanded || Shelves.length == 0 ? '' : '-elf-shelf';
                 Shelves.push(
                     <div class={cN('-shelf', '-columns-' + slots, invisible)}>
                         {Cards}
@@ -31,13 +35,20 @@ export default class Shelf extends Component {
                 cardsOnShelf = false;
             }
         });
-        
+
         if (!cardsOnShelf && Cards.length > 0) {
+            console.log(Cards.length, slots);
             while ( Cards.length < slots ) {
                 Cards.push(<div class="-shelf-card -placeholder" />);
             }
+            const invisible = expanded || Shelves.length == 0 ? '' : '-elf-shelf';
+            Shelves.push(
+                <div class={cN('-shelf', '-columns-' + slots, invisible)}>
+                    {Cards}
+                </div>
+            );
         }
-
+        console.log(Shelves);
         return (
             <ContentCommon class={cN('content-shelf', this.props.class)}>
                 {ExpandCollapseIcon}

--- a/src/com/content-shelf/shelf.js
+++ b/src/com/content-shelf/shelf.js
@@ -5,6 +5,15 @@ import SVGicon from 'com/svg-icon/icon';
 
 export default class Shelf extends Component {
 
+    pushCardsAsNewShelf(Shelves, Cards, slots, expanded) {
+        const invisible = expanded || Shelves.length == 0 ? '' : '-elf-shelf';
+        Shelves.push(
+            <div class={cN('-shelf', '-columns-' + slots, invisible)}>
+                {Cards}
+            </div>
+        );
+    }
+
     render ( {slots, children, expandable}, {expanded} ) {
         if (!slots) {
             slots = 5;
@@ -22,12 +31,7 @@ export default class Shelf extends Component {
         children.forEach( ( card ) => {
             Cards.push(card);
             if ( Cards.length == slots ) {
-                const invisible = expanded || Shelves.length == 0 ? '' : '-elf-shelf';
-                Shelves.push(
-                    <div class={cN('-shelf', '-columns-' + slots, invisible)}>
-                        {Cards}
-                    </div>
-                );
+                this.pushCardsAsNewShelf(Shelves, Cards, slots, expanded);
                 cardsOnShelf = true;
                 Cards = [];
             }
@@ -37,23 +41,17 @@ export default class Shelf extends Component {
         });
 
         if (!cardsOnShelf && Cards.length > 0) {
-            console.log(Cards.length, slots);
             while ( Cards.length < slots ) {
                 Cards.push(<div class="-shelf-card -placeholder" />);
             }
-            const invisible = expanded || Shelves.length == 0 ? '' : '-elf-shelf';
-            Shelves.push(
-                <div class={cN('-shelf', '-columns-' + slots, invisible)}>
-                    {Cards}
-                </div>
-            );
+            this.pushCardsAsNewShelf(Shelves, Cards, slots, expanded);
         }
         console.log(Shelves);
         return (
-            <ContentCommon class={cN('content-shelf', this.props.class)}>
+            <div class={cN('content-shelf', expandable ? '-expandable' : '-in-expandable', this.props.class)}>
                 {ExpandCollapseIcon}
                 {Shelves}
-            </ContentCommon>
+            </div>
         );
     }
 }

--- a/src/com/content-shelf/shelf.js
+++ b/src/com/content-shelf/shelf.js
@@ -1,0 +1,41 @@
+import {h, Component} from 'preact/preact';
+
+import ContentCommon from 'com/content-common/common';
+import SVGicon from 'com/svg-icon/icon';
+
+export default class Shelf extends Component {
+
+    render ( {slots, children, expandable}, {expanded} ) {
+        const ExpandCollapseIcon = expandable ? (
+            <SVGicon onclick={ () => this.setState({'expaned': !expaned}) } class="-shelf-tools">
+                {expaned ? 'arrow-up' : 'arrow-down'}
+            </SVGicon>
+        ) : null;
+
+        const Shelves = [];
+        let Cards = [];
+        children.forEach( ( card ) => {
+            Cards.push(card);
+            if ( Cards.length == slots ) {
+                const invisible = expaned || Shelves.length == 0 ? '' : '-elf-shelf';
+                Shelves.push(
+                    <div class={cN('-shelf', '-columns-' + slots, invisible)}>
+                        {Cards}
+                    </div>
+                );
+                Cards = [];
+            }
+        });
+
+		while ( Cards.length % slots !== 0 ) {
+			Cards.push(<div class="-shelf-card -placeholder" />);
+		}
+
+        return (
+            <ContentCommon class={cN('content-shelf', this.props.class)}>
+                {ExpandCollapseIcon}
+                {Shelves}
+            </ContentCommon>
+        );
+    }
+}

--- a/src/com/content-shelf/shelf.js
+++ b/src/com/content-shelf/shelf.js
@@ -14,6 +14,7 @@ export default class Shelf extends Component {
 
         const Shelves = [];
         let Cards = [];
+        let cardsOnShelf = false;
         children.forEach( ( card ) => {
             Cards.push(card);
             if ( Cards.length == slots ) {
@@ -23,13 +24,20 @@ export default class Shelf extends Component {
                         {Cards}
                     </div>
                 );
+                cardsOnShelf = true;
                 Cards = [];
+            }
+            else {
+                cardsOnShelf = false;
             }
         });
 
-		while ( Cards.length % slots !== 0 ) {
-			Cards.push(<div class="-shelf-card -placeholder" />);
-		}
+        if (!cardsOnShelf && Cards.length > 0) {
+    		while ( Cards.length < slots ) {
+    			Cards.push(<div class="-shelf-card -placeholder" />);
+    		}
+        }
+
 
         return (
             <ContentCommon class={cN('content-shelf', this.props.class)}>

--- a/src/com/content-shelf/shelf.js
+++ b/src/com/content-shelf/shelf.js
@@ -19,6 +19,8 @@ export default class Shelf extends Component {
             slots = 5;
         }
 
+        expandable = expandable && (children.length > slots);
+
         const ExpandCollapseIcon = expandable ? (
             <SVGicon onclick={ () => this.setState({'expaned': !expaned}) } class="-shelf-tools">
                 {expaned ? 'arrow-up' : 'arrow-down'}
@@ -46,7 +48,6 @@ export default class Shelf extends Component {
             }
             this.pushCardsAsNewShelf(Shelves, Cards, slots, expanded);
         }
-        console.log(Shelves);
         return (
             <div class={cN('content-shelf', expandable ? '-expandable' : '-in-expandable', this.props.class)}>
                 {ExpandCollapseIcon}

--- a/src/com/content-shelf/shelf.js
+++ b/src/com/content-shelf/shelf.js
@@ -31,13 +31,12 @@ export default class Shelf extends Component {
                 cardsOnShelf = false;
             }
         });
-
+        
         if (!cardsOnShelf && Cards.length > 0) {
-    		while ( Cards.length < slots ) {
-    			Cards.push(<div class="-shelf-card -placeholder" />);
-    		}
+            while ( Cards.length < slots ) {
+                Cards.push(<div class="-shelf-card -placeholder" />);
+            }
         }
-
 
         return (
             <ContentCommon class={cN('content-shelf', this.props.class)}>

--- a/src/com/content-shelf/shelf.less
+++ b/src/com/content-shelf/shelf.less
@@ -1,0 +1,52 @@
+.content-shelf {
+    paddining: 1.5rem 1rem 0.5rem;
+    & > .-shelf-tools {
+        display: inline-block;
+        float: right;
+        width: 2rem;
+        margin-left: -2rem;
+        bottom: 1.5rem;
+        position: relative;
+    }
+
+    & > .-shelf {
+        display: flex;
+        width: 100%;
+        position: relative;
+        margin: -0.5rem;	/* to undo the effect of the 0.5rem margin in items */
+
+    	&.-placeholder {
+    		visibility: hidden;
+    	}
+
+    	&.-columns-2 {
+    		& > * {
+    			flex: 1 1 45% !important;
+    		}
+    	}
+
+    	&.-columns-3 {
+    		& > * {
+    			flex: 1 1 25% !important;
+    		}
+    	}
+
+    	&.-columns-4 {
+    		& > * {
+    			flex: 1 1 20% !important;
+    		}
+    	}
+
+    	&.-columns-5 {
+    		& > * {
+    			flex: 1 1 16% !important;
+    		}
+    	}
+
+    	&.-columns-6 {
+    		& > * {
+    			flex: 1 1 13% !important;
+    		}
+    	}
+    }
+}

--- a/src/com/content-shelf/shelf.less
+++ b/src/com/content-shelf/shelf.less
@@ -1,3 +1,5 @@
+@import 'defs.less';
+
 .content-shelf {
     paddining: 1.5rem 1rem 0.5rem;
     & > .-shelf-tools {
@@ -14,7 +16,7 @@
         width: 100%;
         position: relative;
         margin: -0.5rem;	/* to undo the effect of the 0.5rem margin in items */
-
+        box-shadow: 0 0 3px @COL_ND;
     	&.-placeholder {
     		visibility: hidden;
     	}

--- a/src/com/content-shelf/shelf.less
+++ b/src/com/content-shelf/shelf.less
@@ -1,6 +1,9 @@
 @import 'defs.less';
 
 .content-shelf {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    
     & >.-expandable {
         paddining: 1.5rem 1rem 0.5rem;
     }

--- a/src/com/content-shelf/shelf.less
+++ b/src/com/content-shelf/shelf.less
@@ -1,7 +1,13 @@
 @import 'defs.less';
 
 .content-shelf {
-    paddining: 1.5rem 1rem 0.5rem;
+    & >.-expandable {
+        paddining: 1.5rem 1rem 0.5rem;
+    }
+    & >.-in-expandable {
+        paddining: 0.5rem 1rem 0.5rem;
+    }
+
     & > .-shelf-tools {
         display: inline-block;
         float: right;

--- a/src/com/content-shelf/shelf.less
+++ b/src/com/content-shelf/shelf.less
@@ -21,40 +21,51 @@
         display: flex;
         width: 100%;
         position: relative;
-        margin: -0.5rem;	/* to undo the effect of the 0.5rem margin in items */
         box-shadow: 0 0 3px @COL_ND;
-    	&.-placeholder {
+
+    	& .-placeholder {
     		visibility: hidden;
+            display: inline-block;
     	}
 
     	&.-columns-2 {
     		& > * {
     			flex: 1 1 45% !important;
+    		    margin: 0.5rem;
     		}
+            margin: -0.5rem;	/* to undo the effect of the items */
     	}
 
     	&.-columns-3 {
     		& > * {
     			flex: 1 1 25% !important;
+    		    margin: 0.5rem;
     		}
+            margin: -0.5rem;	/* to undo the effect of the items */
     	}
 
     	&.-columns-4 {
     		& > * {
     			flex: 1 1 20% !important;
+    		    margin: 0.25rem;
     		}
+            margin: -0.25rem;	/* to undo the effect of the items */
     	}
 
     	&.-columns-5 {
     		& > * {
     			flex: 1 1 16% !important;
+    		    margin: 0.25rem;
     		}
+            margin: -0.25rem;	/* to undo the effect of the items */
     	}
 
     	&.-columns-6 {
     		& > * {
     			flex: 1 1 13% !important;
+    		    margin: 0.25rem;
     		}
+            margin: -0.25rem;	/* to undo the effect of the items */
     	}
     }
 }

--- a/src/com/view-content/content.js
+++ b/src/com/view-content/content.js
@@ -1,4 +1,4 @@
-import { h, Component }					from 'preact/preact';
+import {h, Component}					from 'preact/preact';
 
 import ContentPost						from 'com/content-post/post';
 
@@ -314,13 +314,13 @@ export default class ViewContent extends Component {
 						View.push(<ContentGames node={node} user={user} path={path} extra={extra} methods={['authors']} subsubtypes={SubSubType ? SubSubType : ""} />);
 					}
 					else if ( ViewType == 'article' ) {
-
+						//Remove??
 					}
-					else if ( ViewType == 'following'){
+					else if ( ViewType == 'following' ) {
 						View.push(<ContentNavUser node={node} user={user} path={path} extra={extra} featured={featured} />);
 						View.push(<ContentUserFollowing node={node} user={user} path={path} extra={extra} featured={featured} />);
 					}
-					else if ( ViewType == 'followers'){
+					else if ( ViewType == 'followers' ) {
 						View.push(<ContentNavUser node={node} user={user} path={path} extra={extra} featured={featured} />);
 						View.push(<ContentUserFollowers node={node} user={user} path={path} extra={extra} featured={featured} />);
 					}
@@ -367,7 +367,7 @@ export default class ViewContent extends Component {
 //							</Common>
 //						</div>
 //					);
-//					
+//
 //				}
 //				else {
 //					return (
@@ -379,7 +379,7 @@ export default class ViewContent extends Component {
 //					);
 //				}
 //			}
-			else if ( extra && extra.length && extra[0] == 'games' || extra[0] == 'results' ){
+			else if ( (extra && extra.length && extra[0] == 'games') || extra[0] == 'results' ) {
 				let DefaultSubFilter = 'all';
 				let DefaultFilter = 'smart';
 
@@ -438,11 +438,11 @@ export default class ViewContent extends Component {
 						case 'audio':
 						case 'humor':
 						case 'mood':
-							Methods = [EvalFilter2(Filter),'reverse'];
+							Methods = [EvalFilter2(Filter), 'reverse'];
 							break;
 
 						case 'zero':
-							Methods = ['grade','reverse'];
+							Methods = ['grade', 'reverse'];
 							break;
 
 						case 'jam':
@@ -652,7 +652,7 @@ export default class ViewContent extends Component {
 							break;
 
 						case 'zero':
-							Methods = ['grade','reverse'];
+							Methods = ['grade', 'reverse'];
 							break;
 
 						case 'jam':
@@ -747,7 +747,7 @@ export default class ViewContent extends Component {
 			}
 		}
 		else {
-			return <div id="content"><div class='content-base'>Unsupported Node Type: {""+node.type}</div></div>;
+			return <div id="content"><div class="content-base">Unsupported Node Type: {""+node.type}</div></div>;
 		}
 	}
 
@@ -760,4 +760,4 @@ export default class ViewContent extends Component {
 			return <div id="content">{this.props.children}</div>;
 		}
 	}
-};
+}


### PR DESCRIPTION
Currently the shelf is not in use anywhere on the site, but it allows for a limited (or extensive) collection of items to be viewed like `/games` are now but not limited to games.

My idea for use is to have a shelf of perhaps 4 games at the bottom of user pages for people logged in while the event is in rating mode and some title like: "Continue rating peoples' games".

We've also been talking about adding a new tab to the user-page with "Trohpies", having a shelf showing the trophies the user has been rewarded with the ability to reward them more new trophies of your own.