### PR TITLE
Notify on at-mention

### DIFF
--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -672,8 +672,8 @@ switch ( $action ) {
 
 					nodeCache_InvalidateById($node_id);
 					
-					if ( $node['published'] ) {
-						// Add mention notifications for at-mentions of users that were added in this edit.
+					if ( $node['published'] && notification_EnabledForNodeType($node['type']) ) {
+						// Add mention notifications for at-mentions of users that were added in this edit, if this node is published and of a type that supports notifications.
 						$newmentions = notification_GetMentionedUsers($body, $node['body']);
 						notification_AddForEdit($node_id, 0, $user_id, $newmentions);
 					}

--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -671,6 +671,12 @@ switch ( $action ) {
 					);
 
 					nodeCache_InvalidateById($node_id);
+					
+					if ( $node['published'] ) {
+						// Add mention notifications for at-mentions of users that were added in this edit.
+						$newmentions = notification_GetMentionedUsers($body, $node['body']);
+						notification_AddForEdit($node_id, 0, $user_id, $newmentions);
+					}
 				}
 			}
 			else {
@@ -800,7 +806,8 @@ switch ( $action ) {
 					$RESPONSE['path'] = node_GetPathById($node_id, 1)['path']; // Root node
 					
 					// notify users watching the author of the published node
-					notification_AddForPublishedNode($node_id, $node['author'], $node['type']);
+					$mentions = notification_GetMentionedUsers($node['body']);
+					notification_AddForPublishedNode($node_id, $node['author'], $node['type'], $mentions);
 				}
 			}
 			else {

--- a/public-api/vx/note.php
+++ b/public-api/vx/note.php
@@ -100,7 +100,8 @@ switch ( $action ) {
 				
 				// Add notifications for users watching this thread
 				if ( $RESPONSE['note'] ) {
-					notification_AddForNote($node['id'], $RESPONSE['note'], $author);
+					$mentions = notification_GetMentionedUsers($body);
+					notification_AddForNote($node['id'], $RESPONSE['note'], $author, $mentions);
 				}
 			}
 			else {
@@ -156,6 +157,10 @@ switch ( $action ) {
 				// Check if you have permission to add comment to node
 				if ( note_IsNotePublicByNode($node) ) {
 					$RESPONSE['updated'] = note_SafeEdit($note_id, $author, $body, $version_tag, $note['flags']);
+					
+					// Add mention notifications for at-mentions of users that were added in this edit.
+					$newmentions = notification_GetMentionedUsers($body, $note['body']);
+					notification_AddForEdit($node_id, $note_id, $author, $newmentions);
 				}
 				else {
 					json_EmitFatalError_Forbidden("This node type does now allow notes (yet)", $RESPONSE);

--- a/sandbox/simulator/model_default
+++ b/sandbox/simulator/model_default
@@ -87,13 +87,20 @@ $stages = array(
 	)
 );
 
-
+// Future: move user creation out of the model and make it smarter.
 $event_admin_user = null;
 $event_users = array(); // Only use for reference (e.g. getting usernames)
 $event_user_lookup = array(); // Only use this as a source for user objects, and get them by reference.
 
 $event_nodeid = null;
 $event_name = null;
+
+function RandomUserName()
+{
+	global $event_users;
+	$i = random_int(1, count($event_users)) - 1;
+	return $event_users[$i]["username"];
+}
 
 
 function LoadPreviousUsers()

--- a/sandbox/simulator/randomtext
+++ b/sandbox/simulator/randomtext
@@ -73,6 +73,8 @@ function GenerateRandomPostText($maxParagraphs = 8)
 			{
 				$markdown = "";
 				if(random_int(1,6) == 1) {	$markdown = ["*","**","`","~~"][random_int(0,3)]; }
+				// Occasionally mention another user
+				if(random_int(1,50) == 1) { $output .= "@" . RandomUserName() . " "; }
 				$output .= $markdown.GenerateRandomPhrase(3,17).$markdown . ". ";
 			}
 			$output .= "\n";

--- a/src/shrub/src/node/node_core.php
+++ b/src/shrub/src/node/node_core.php
@@ -73,6 +73,28 @@ function node_GetIdByParentTypePublished( $parent, $type, $subtype = null, $subs
 }
 
 
+// Used to find multiple user node IDs quickly for a list of slugs
+// Returns a map with the slug as a key and id as value.
+function node_GetUserIdBySlug( $slugs ) {
+	if ( !count($slugs) ) {
+		return [];
+	}
+	
+	$safeslugs = [];
+	foreach( $slugs as $s ) {
+		// single quote should not exist in the dataset this is called with, but be extra safe.
+		$safeslugs[] = "'" . str_replace("'", "''", $s) . "'";
+	}
+	$sluglist = implode(",", $safeslugs);
+	
+	return db_QueryFetchPair(
+		"SELECT slug, id
+		FROM ".SH_TABLE_PREFIX.SH_TABLE_NODE." 
+		WHERE type='user' AND slug IN (" . $sluglist . ");"
+	);
+}
+
+
 
 function _node_GetPathById( $id, $top = 0, $timeout = 10 ) {
 	if ( !$id )

--- a/src/shrub/src/notification/constants.php
+++ b/src/shrub/src/notification/constants.php
@@ -7,6 +7,7 @@
 /// @name Notification Types
 /// @{
 const SH_NOTIFICATION_NOTE =			'note';
+const SH_NOTIFICATION_MENTION =			'mention';
 /// @}
 
 

--- a/src/shrub/src/notification/notification_core.php
+++ b/src/shrub/src/notification/notification_core.php
@@ -193,6 +193,19 @@ function notification_AddForNote( $node, $note, $author, $mentions = [] ) {
 	notification_AddMultiple($notifications);	
 }
 
+function notification_AddForEdit($node, $note, $author, $mentions = []) {
+
+	$notifications = [];
+	foreach($mentions as $uid)	{
+		if ( $uid == $author )
+			continue; // Don't bother sending the author of the note a notification for their own note.
+			
+		$notifications[] = ['user' => $uid, 'node' => $node, 'note' => $note, 'type' => SH_NOTIFICATION_MENTION];
+	}	
+	
+	notification_AddMultiple($notifications);	
+}
+
 
 /// @retval Integer Id of highest read notification.
 function notification_GetLastReadNotification( $node ) {

--- a/src/shrub/src/notification/notification_core.php
+++ b/src/shrub/src/notification/notification_core.php
@@ -121,9 +121,12 @@ function notification_Get( $user, $limit = 20, $offset = 0 ) {
 	);
 }
 
+function notification_EnabledForNodeType( $type ) {
+	return in_array($type, NOTIFY_ON_NODE_TYPE);
+}
 
 function notification_AddForPublishedNode( $node, $author, $type, $mentions = [] ) {
-	if ( in_array($type, NOTIFY_ON_NODE_TYPE) ) {
+	if ( notification_EnabledForNodeType($type) ) {
 		// Identify users following the author and push notifications.
 		$notifications = [];
 		// "Following" is a "star" link between a=user id, and b=starred node id. Find the stars on the author's node.

--- a/src/shrub/src/notification/notification_core.php
+++ b/src/shrub/src/notification/notification_core.php
@@ -251,7 +251,7 @@ function notification_GetMentionedUsers($text, $previoustext = null) {
 function notification_AtTokens($text) {
 	$text = strip_tags($text);
 	$text = strtolower($text);	
-	if ( preg_match_all("/(?:^|[^a-z0-9_.\-])@([a-z0-9_.\-])+/", $text, $matches) ) {
+	if ( preg_match_all("/(?:^|[^a-z0-9_.\-])@([a-z0-9_.\-]+)/", $text, $matches) ) {
 		return array_unique($matches[1]);
 	}
 	return [];


### PR DESCRIPTION
Now notifications are generated when users are at-mentioned in node / note content.
* `mention` notification is generated if the user was mentioned - and is preferred if there are multiple applicable notification types. If the user would have otherwise received a notification, the user will only receive a `mention`
* list of users mentioned is discovered by regex parsing body in node publish and note add. see `notification_AtTokens` at the end of `notification_core.php`
* List of users is diffed with the previous contents in published node edit and note edit
* In all cases, the list of mentioned users is used to push out notifications.
* Simulator now at-mentions random users to help build data. But this has otherwise been manually tested to work correctly.
* Note: an at-mention does not add you to the thread, you only get notification for that directed response, unless you then post to the thread.