### PR TITLE
Improve feedback when comment post fails

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -134,6 +134,7 @@ export default class ContentCommentsComment extends Component {
 		var user = props.user;
 		var comment = props.comment;
 		var author = props.author;
+		var error = props.error;
 
 		if ( author || comment.author == 0 ) {
 			var Name = "Anonymous";
@@ -251,11 +252,19 @@ export default class ContentCommentsComment extends Component {
 				);
 			}
 
+			var ShowError = null;
+			if ( error ) {
+				ShowError = (
+					<div class="-error">{"Failed to post comment: " + error}</div>
+				);
+			}
+
 			return (
 				<div id={"comment-"+comment.id} class={"-item -comment -indent-"+props.indent}>
 					<div class="-avatar"><IMG2 src={Avatar} /></div>
 					<div class="-body">
 						{ShowTopNav}
+						{ShowError}
 						<div class="-text">
 							{ShowTitle}
 							<ContentCommentsMarkup user={user} editing={state.editing && !state.preview} onmodify={this.onModify} placeholder="type a comment here" limit={props.limit}>{comment.body}</ContentCommentsMarkup>

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -159,15 +159,17 @@ export default class ContentComments extends Component {
 		const user = this.props.user;
 		const authors = this.state.authors;
 		const comment = this.state.newcomment;
+		const error = this.state.error;
 		const author = authors[comment.author];
 		const allowAnonymous = parseInt(this.props.node.meta['allow-anonymous-comments']);
 
-		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} /></div>;
+		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} /></div>;
 	}
 
 	onPublish( e, publishAnon ) {
 		const node = this.props.node;
 		const newcomment = this.state.newcomment;
+		this.setState({'error': null });
 
 		$Note.Add( newcomment.parent, newcomment.node, newcomment.body, null, publishAnon )
 		.then(r => {
@@ -190,7 +192,7 @@ export default class ContentComments extends Component {
 				this.setState({'tree': this.buildTree()});
 			}
 			else {
-				this.setState({'error': err});
+				this.setState({'error': (r.message ? r.message : "Unknown error when posting comment")});
 			}
 		})
 		.catch(err => {


### PR DESCRIPTION
Previous behavior was to give no indication, just not add the comment + clear the comment field.

Tested:
* Can post comments normally
* Enable anonymous comments for node, refresh in another tab, disable anonymous comments, try to post anonymously, confirmed error message appears
* Enable chrome "offline" mode, confirm error message appears on post
* Confirm error message disappears when subsequently posting a comment successfully

![image](https://user-images.githubusercontent.com/620920/32352024-ac3a87fc-bfdc-11e7-9b18-975d0d6150f4.png)