### PR TITLE
WIP: Api stats

### DIFF
--- a/private/magic.php
+++ b/private/magic.php
@@ -241,7 +241,4 @@ if ( $featured_id ) {
 			$db->commit();
 		}
 	}
-	
-	// Invalidate cached object that selects random games based on smart ratings.
-	nodeRandomGames_InvalidateCache();
 }

--- a/private/magic.php
+++ b/private/magic.php
@@ -7,6 +7,7 @@ require_once __DIR__."/".SHRUB_PATH."/cron.php";
 require_once __DIR__."/".SHRUB_PATH."/node/node.php";
 require_once __DIR__."/".SHRUB_PATH."/note/note.php";
 require_once __DIR__."/".SHRUB_PATH."/grade/grade.php";
+require_once __DIR__."/".SHRUB_PATH."/perfstats/perfstats.php";
 
 // This is a CRON job that regularly updates magic
 const MAX_ITEMS_TO_ADD = 500;
@@ -51,6 +52,9 @@ function AddMagic( $name, $parent ) {
 		$db->commit();
 	}
 }
+
+// Store API performance statistics to DB if necessary (quick)
+perfstats_Cron();
 
 // Get the root node
 $root = nodeComplete_GetById(1);

--- a/public-api/vx/stats.php
+++ b/public-api/vx/stats.php
@@ -8,8 +8,10 @@ require_once __DIR__."/".SHRUB_PATH."node/node.php";
 const CACHE_TTL = 60+30;
 
 
-$node_id = intval(json_ArgShift());
 api_Exec([
+["stats/api/history", API_GET, API_CHARGE_1, function(&$RESPONSE) {
+	$RESPONSE['stats'] = perfstats_GetRecentStats();
+}],
 ["stats/api", API_GET, API_CHARGE_1, function(&$RESPONSE) {
 	$RESPONSE['stats'] = perfstats_GetCurrentPeriodStats();
 }],

--- a/public-api/vx/stats.php
+++ b/public-api/vx/stats.php
@@ -7,155 +7,167 @@ require_once __DIR__."/".SHRUB_PATH."node/node.php";
 
 const CACHE_TTL = 60+30;
 
-json_Begin();
 
 $node_id = intval(json_ArgShift());
+api_Exec([
+["stats/api", API_GET, API_CHARGE_1, function(&$RESPONSE) {
+	$RESPONSE['stats'] = perfstats_GetCurrentPeriodStats();
+}],
+["stats", API_GET, API_CHARGE_1, function(&$RESPONSE) {
+	// This last record will match any stats/* which wasn't caught by an earlier API record.
+	GetNodeStats($RESPONSE);
+}]
+]);
 
-if ( !$node_id ) {
-	json_EmitFatalError_Forbidden(null, $RESPONSE);
-}
+function GetNodeStats(&$RESPONSE) {
+	$node_id = intval(json_ArgShift());
 
-$node = node_GetById($node_id);
-
-if ( !$node ) {
-	json_EmitFatalError_NotFound(null, $RESPONSE);
-}
-
-if ( $node['id'] )
-	$RESPONSE['id'] = $node['id'];
-	
-if ( $node['type'] )
-	$RESPONSE['type'] = $node['type'];
-if ( $node['subtype'] )
-	$RESPONSE['subtype'] = $node['subtype'];
-if ( $node['subsubtype'] )
-	$RESPONSE['subsubtype'] = $node['subsubtype'];
-
-$stats = null;
-
-switch ( $node['type'] ) {
-	case 'post': {
-		break;
+	if ( !$node_id ) {
+		json_EmitFatalError_Forbidden(null, $RESPONSE);
 	}
 
-	case 'item': {
-		switch ( $node['subtype'] ) {
-			case 'game':
-				// Games Only
+	$node = node_GetById($node_id);
+
+	if ( !$node ) {
+		json_EmitFatalError_NotFound(null, $RESPONSE);
+	}
+
+	if ( $node['id'] )
+		$RESPONSE['id'] = $node['id'];
+		
+	if ( $node['type'] )
+		$RESPONSE['type'] = $node['type'];
+	if ( $node['subtype'] )
+		$RESPONSE['subtype'] = $node['subtype'];
+	if ( $node['subsubtype'] )
+		$RESPONSE['subsubtype'] = $node['subsubtype'];
+
+	$stats = null;
+
+	switch ( $node['type'] ) {
+		case 'post': {
+			break;
+		}
+
+		case 'item': {
+			switch ( $node['subtype'] ) {
+				case 'game':
+					// Games Only
+					
+					break;
+			};
+			
+			// Items Only
+
+			break;
+		}
+
+		case 'event': {
+			$CACHE_KEY = '!API!STATS!'.$node['id'];
+			
+			if ( $stats = cache_Fetch($CACHE_KEY) ) {
+				$RESPONSE['cached'] = [$node['id']];
+			}
+			else {
+				$stats = [];
+				$stats['signups'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, null,
+					null
+				);
+				$stats['authors'] = nodeMeta_CountByABKeyScope(
+					$node['id'], null, null, 'author'
+				);
 				
-				break;
-		};
+				$stats['unpublished'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, null,
+					false
+				);
+				
+				// Item Types
+				$stats['game'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', 'game', null
+				);
+				$stats['craft'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', 'craft', null
+				);
+				$stats['tool'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', 'tool', null
+				);
+				$stats['demo'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', 'demo', null
+				);
+		//		$stats['other'] = node_CountByParentAuthorType(
+		//			$node['id'], null, null,
+		//			'item', 'other', null
+		//		);
+		//		$stats['media'] = node_CountByParentAuthorType(
+		//			$node['id'], null, null,
+		//			'item', 'media', null
+		//		);
 		
-		// Items Only
-
-		break;
-	}
-
-	case 'event': {
-		$CACHE_KEY = '!API!STATS!'.$node['id'];
+				// Item SubTypes
+				$stats['jam'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, 'jam'
+				);
+				$stats['compo'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, 'compo'
+				);
+				$stats['warmup'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, 'warmup'
+				);
+				$stats['late'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, 'late'
+				);
+				$stats['release'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, 'release'
+				);
+				$stats['unfinished'] = node_CountByParentAuthorType(
+					$node['id'], null, null,
+					'item', null, 'unfinished'
+				);
 		
-		if ( $stats = cache_Fetch($CACHE_KEY) ) {
-			$RESPONSE['cached'] = [$node['id']];
+				$stats['grade-20-plus'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=20');
+				$stats['grade-15-20'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=15') - ($stats['grade-20-plus']);
+				$stats['grade-10-15'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=10') - ($stats['grade-20-plus'] + $stats['grade-15-20']);
+				$stats['grade-5-10'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=5') - ($stats['grade-20-plus'] + $stats['grade-15-20'] + $stats['grade-10-15']);
+				$stats['grade-0-5'] = nodeMagic_CountByParentName($node['id'], 'grade', '<5');
+				$stats['grade-0-only'] = nodeMagic_CountByParentName($node['id'], 'grade', '=0');
+		
+				$stats['timestamp'] = str_replace('+00:00', 'Z', date(DATE_W3C, time()));
+				
+				cache_Store($CACHE_KEY, $stats, CACHE_TTL);
+			}
+			
+			break;
 		}
-		else {
-			$stats = [];
-			$stats['signups'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, null,
-				null
-			);
-			$stats['authors'] = nodeMeta_CountByABKeyScope(
-				$node['id'], null, null, 'author'
-			);
-			
-			$stats['unpublished'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, null,
-				false
-			);
-			
-			// Item Types
-			$stats['game'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', 'game', null
-			);
-			$stats['craft'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', 'craft', null
-			);
-			$stats['tool'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', 'tool', null
-			);
-			$stats['demo'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', 'demo', null
-			);
-	//		$stats['other'] = node_CountByParentAuthorType(
-	//			$node['id'], null, null,
-	//			'item', 'other', null
-	//		);
-	//		$stats['media'] = node_CountByParentAuthorType(
-	//			$node['id'], null, null,
-	//			'item', 'media', null
-	//		);
-	
-			// Item SubTypes
-			$stats['jam'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, 'jam'
-			);
-			$stats['compo'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, 'compo'
-			);
-			$stats['warmup'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, 'warmup'
-			);
-			$stats['late'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, 'late'
-			);
-			$stats['release'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, 'release'
-			);
-			$stats['unfinished'] = node_CountByParentAuthorType(
-				$node['id'], null, null,
-				'item', null, 'unfinished'
-			);
-	
-			$stats['grade-20-plus'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=20');
-			$stats['grade-15-20'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=15') - ($stats['grade-20-plus']);
-			$stats['grade-10-15'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=10') - ($stats['grade-20-plus'] + $stats['grade-15-20']);
-			$stats['grade-5-10'] = nodeMagic_CountByParentName($node['id'], 'grade', '>=5') - ($stats['grade-20-plus'] + $stats['grade-15-20'] + $stats['grade-10-15']);
-			$stats['grade-0-5'] = nodeMagic_CountByParentName($node['id'], 'grade', '<5');
-			$stats['grade-0-only'] = nodeMagic_CountByParentName($node['id'], 'grade', '=0');
-	
-			$stats['timestamp'] = str_replace('+00:00', 'Z', date(DATE_W3C, time()));
-			
-			cache_Store($CACHE_KEY, $stats, CACHE_TTL);
-		}
-		
-		break;
-	}
-};
+	};
 
-$RESPONSE['stats'] = $stats;
-//$RESPONSE['timestamp'] = str_replace('+00:00', 'Z', date(DATE_W3C, time()));
+	$RESPONSE['stats'] = $stats;
+	//$RESPONSE['timestamp'] = str_replace('+00:00', 'Z', date(DATE_W3C, time()));
 
-// Do Actions
-//$action = json_ArgShift();
-//switch ( $action ) {
-//	case 'stats': //grade/stats
-//		json_ValidateHTTPMethod('GET');
-//		//$event_id = intval(json_ArgGet(0));
-//
-//	default:
-//		
-//		
-//		break; // default
-//};
+	// Do Actions
+	//$action = json_ArgShift();
+	//switch ( $action ) {
+	//	case 'stats': //grade/stats
+	//		json_ValidateHTTPMethod('GET');
+	//		//$event_id = intval(json_ArgGet(0));
+	//
+	//	default:
+	//		
+	//		
+	//		break; // default
+	//};
 
-json_End();
+}
+

--- a/src/shrub/src/constants.php
+++ b/src/shrub/src/constants.php
@@ -11,6 +11,7 @@ include __DIR__."/legacy/constants.php";
 include __DIR__."/note/constants.php";
 include __DIR__."/notification/constants.php";
 include __DIR__."/other/constants.php";
+include __DIR__."/perfstats/constants.php";
 include __DIR__."/schedule/constants.php";
 include __DIR__."/theme/constants.php";
 include __DIR__."/user/constants.php";

--- a/src/shrub/src/core/json.php
+++ b/src/shrub/src/core/json.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__."/core.php";
+require_once __DIR__."/../perfstats/perfstats.php";
 
 /// @defgroup JSON
 /// @brief JSON emitting module (typically for making APIs) 
@@ -215,6 +216,18 @@ function json_Emit( $out, $allow_jsonp = true ) {
 	// Prepend the status code //
 	$out = ['status' => http_response_code()]+$out;
 		
+		
+	// Compute / Update API stats //
+	global $json_starttime;
+	$json_endtime = microtime(true);
+	$totaltime = $json_endtime - $json_starttime;		
+	$apiname = "unknown";
+	if ( isset($GLOBALS["API_NAME"]) ) {
+		$apiname = $GLOBALS["API_NAME"];
+	}
+	perfstats_RecordApiPerformance($apiname, $totaltime);
+	
+		
 	// Debug Info //
 	if ( defined('SH_PHP_DEBUG') && isset($_GET['debug']) ) {
 		$out['debug'] = [];
@@ -248,10 +261,6 @@ function json_Emit( $out, $allow_jsonp = true ) {
 		if ( getenv('REDIRECT_QUERY_STRING') ) {
 			$out['debug']['redirect_query'] = getenv('REDIRECT_QUERY_STRING');
 		}
-		
-		global $json_starttime;
-		$json_endtime = microtime(true);
-		$totaltime = $json_endtime - $json_starttime;
 		
 		$out['debug']['request_time'] = $totaltime;
 		

--- a/src/shrub/src/node/node_randomgames.php
+++ b/src/shrub/src/node/node_randomgames.php
@@ -1,6 +1,6 @@
 <?php
 
-const SH_NODERG_CACHE_TTL = 3*60;
+const SH_NODERG_CACHE_TTL = 90;
 const SH_NODERG_CACHE_KEY = "!SH!NODE!RG";
 
 function nodeRandomGames_CurrentGamesList( ) {
@@ -107,10 +107,6 @@ function nodeRandomGames_CurrentGamesList( ) {
 		cache_Store(SH_NODERG_CACHE_KEY, $data, SH_NODERG_CACHE_TTL);
 	}
 	return $data;
-}
-
-function nodeRandomGames_InvalidateCache( ) {
-	cache_Delete(SH_NODERG_CACHE_KEY);
 }
 
 function nodeRandomGames_GetGames( $count, $removegames, $filter = null ) {

--- a/src/shrub/src/perfstats/constants.php
+++ b/src/shrub/src/perfstats/constants.php
@@ -1,0 +1,14 @@
+<?php
+/// @defgroup PerfStats
+/// @ingroup Modules
+
+
+/// @name Performance statistics record tables
+/// @addtogroup Tables
+/// @{
+const SH_TABLE_PERFSTATS =	    "perfstats";
+/// @}
+
+global_AddTableConstant( 
+	'SH_TABLE_PERFSTATS'
+);

--- a/src/shrub/src/perfstats/perfstats.php
+++ b/src/shrub/src/perfstats/perfstats.php
@@ -1,0 +1,4 @@
+<?php
+// Tables and Features
+require_once __DIR__."/perfstats_core.php";
+

--- a/src/shrub/src/perfstats/perfstats_core.php
+++ b/src/shrub/src/perfstats/perfstats_core.php
@@ -1,7 +1,7 @@
 <?php
 
 const PERFSTAT_MAX_COUNTER_LENGTH = 64;
-const PERFSTAT_PERIOD_LENGTH = 15*60;
+const PERFSTAT_PERIOD_LENGTH = 15*60; // Number of seconds - Should divide evenly into a day, otherwise a period at the day transition will be missed.
 const PERFSTAT_BUFFER_LENGTH = 10*60;
 
 const HISTOGRAM_POWER = 1.08;
@@ -10,9 +10,22 @@ const HISTOGRAM_BUCKET_MAX = 127;
 // With a base/origin value of 0.0005 (0.5 ms) and a step of 8% (1.08), +127 steps is 8.785 seconds
 // So the accurate range of the histogram is 0.5ms to 8.7 seconds in logarithmic steps (smaller steps near lower values)
 
-function perfstats_GetPeriodId() {
+function perfstats_GetCurrentPeriodEnd() {
+	// Date manipulation in php is the worst.
+	$now = time();
+	$data = getdate($now);
+	$dayseconds = $data["seconds"] + $data["minutes"]*60 + $data["hours"]*3600;
+	$periodseconds = $dayseconds % PERFSTAT_PERIOD_LENGTH;
+	$periodend = $now + (PERFSTAT_PERIOD_LENGTH-$periodseconds);
+	
+	return $periodend;
+}
 
-
+function perfstats_GetPeriodId($periodtime = null) {
+	if ( $periodtime == null ) {
+		$periodtime = perfstats_GetCurrentPeriodEnd();
+	}
+	return $periodtime;
 }
 
 function perfstats_HistogramBucket($time) [
@@ -33,7 +46,7 @@ function perfstats_MicrosecondTime($time) {
 function perfstats_Accumulate($period, $countername, $microseconds, $bucket) {
 	$timeout = PERFSTAT_PERIOD_LENGTH*2 + PERFSTAT_BUFFER_LENGTH;
 	
-	$keycount = "!SH!PERFSTATS!".$countername;
+	$keycount = "!SH!PERFSTATS!" . $period . "!" . $countername;
 	$keytime = $keycount . "!TIME";
 	$keybucket = $keycount . "!" . $bucket;
 
@@ -50,6 +63,23 @@ function perfstats_Accumulate($period, $countername, $microseconds, $bucket) {
 
 
 
+function perfstats_ComputeCachedPeriodStats($periodend)
+{
+
+
+}
+
+
+
+// If we crossed a time interval, collect and store the previous period's stats and remove the cache objects.
+function perfstats_Cron()
+{
+
+}
+
+
+
+
 function perfstats_RecordApiPerformance($apiname, $totaltime) {
 	$period = perfstats_GetPeriodId();
 	
@@ -62,4 +92,11 @@ function perfstats_RecordApiPerformance($apiname, $totaltime) {
 
 	perfstats_Accumulate($period, "all", $microseconds, $bucket);
 	perfstats_Accumulate($period, $apiname, $microseconds, $bucket);
+}
+
+function perfstats_GetCurrentPeriodStats()
+{
+	$period = perfstats_GetCurrentPeriodEnd();
+	$stats = perfstats_ComputeCachedPeriodStats();
+	return $stats; // todo: Don't send back administrative data that was collected.
 }

--- a/src/shrub/src/perfstats/perfstats_core.php
+++ b/src/shrub/src/perfstats/perfstats_core.php
@@ -1,0 +1,65 @@
+<?php
+
+const PERFSTAT_MAX_COUNTER_LENGTH = 64;
+const PERFSTAT_PERIOD_LENGTH = 15*60;
+const PERFSTAT_BUFFER_LENGTH = 10*60;
+
+const HISTOGRAM_POWER = 1.08;
+const HISTOGRAM_ORIGIN = 0.0005;
+const HISTOGRAM_BUCKET_MAX = 127;
+// With a base/origin value of 0.0005 (0.5 ms) and a step of 8% (1.08), +127 steps is 8.785 seconds
+// So the accurate range of the histogram is 0.5ms to 8.7 seconds in logarithmic steps (smaller steps near lower values)
+
+function perfstats_GetPeriodId() {
+
+
+}
+
+function perfstats_HistogramBucket($time) [
+	$bucket = intval(round(log($time/HISTOGRAM_ORIGIN, HISTOGRAM_POWER)));
+	if ( $bucket < 0 ) {
+		$bucket = 0;
+	}
+	if ( $bucket > HISTOGRAM_BUCKET_MAX ) {
+		$bucket = HISTOGRAM_BUCKET_MAX;
+	}
+	return $bucket;
+}
+
+function perfstats_MicrosecondTime($time) {
+	return intval(round($time*1000000));
+}
+
+function perfstats_Accumulate($period, $countername, $microseconds, $bucket) {
+	$timeout = PERFSTAT_PERIOD_LENGTH*2 + PERFSTAT_BUFFER_LENGTH;
+	
+	$keycount = "!SH!PERFSTATS!".$countername;
+	$keytime = $keycount . "!TIME";
+	$keybucket = $keycount . "!" . $bucket;
+
+	// Ensure apcu records are created for this period
+	apcu_add($keycount, 0, $timeout);
+	apcu_add($keytime, 0, $timeout);
+	apcu_add($keybucket, 0, $timeout);
+	
+	// Accumulate APCU records with new data
+	apcu_inc($keycount, 1);
+	apcu_inc($keytime, $microseconds);
+	apcu_inc($keybucket, 1);
+}
+
+
+
+function perfstats_RecordApiPerformance($apiname, $totaltime) {
+	$period = perfstats_GetPeriodId();
+	
+	if ( strlen($apiname) > PERFSTAT_MAX_COUNTER_LENGTH ) {
+		$apiname = substr($apiname, 0, PERFSTAT_MAX_COUNTER_LENGTH);
+	}
+
+	$bucket = perfstats_HistogramBucket($totaltime);
+	$microseconds = perfstats_MicrosecondTime($totaltime);
+
+	perfstats_Accumulate($period, "all", $microseconds, $bucket);
+	perfstats_Accumulate($period, $apiname, $microseconds, $bucket);
+}

--- a/src/shrub/src/perfstats/table_create.php
+++ b/src/shrub/src/perfstats/table_create.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__."/perfstats.php";
+
+
+// Notification table record is a small discrete event that a user should be notified about.
+// Usually this will be a reference to a comment on a user's node or a node where that user has commented.
+// It can also be due to a game link error, or a post by a user you are following, or other notifications we decide to add in the future.
+$table = 'SH_TABLE_PERFSTATS';
+if ( in_array($table, $TABLE_LIST) ) {
+	$ok = null;
+
+	table_Init($table);
+	switch ( $TABLE_VERSION ) {
+	case 0:
+		$ok = table_Create( $table,
+			"CREATE TABLE ".SH_TABLE_PREFIX.constant($table)." (
+				id ".DB_TYPE_UID.",
+				apiname ".DB_TYPE_ASCII(64).",
+				periodend ".DB_TYPE_TIMESTAMP.",
+				periodduration ".DB_TYPE_INT32.",	
+				count ".DB_TYPE_INT32.",
+				avg ".DB_TYPE_FLOAT64.",
+				p0 ".DB_TYPE_FLOAT64.",
+				p10 ".DB_TYPE_FLOAT64.",
+				p20 ".DB_TYPE_FLOAT64.",
+				p30 ".DB_TYPE_FLOAT64.",
+				p40 ".DB_TYPE_FLOAT64.",
+				p50 ".DB_TYPE_FLOAT64.",
+				p60 ".DB_TYPE_FLOAT64.",
+				p70 ".DB_TYPE_FLOAT64.",
+				p80 ".DB_TYPE_FLOAT64.",
+				p90 ".DB_TYPE_FLOAT64.",
+				p95 ".DB_TYPE_FLOAT64.",
+				p98 ".DB_TYPE_FLOAT64.",
+				p100 ".DB_TYPE_FLOAT64."
+			)".DB_CREATE_SUFFIX);
+		$created = true;
+		if (!$ok) break; $TABLE_VERSION++;
+
+	};
+
+	table_Exit($table);
+}
+


### PR DESCRIPTION
This addresses #1287. Presented here for awareness and testing purposes; I don't know how this is going to interact with the live site, but it's working pretty well for me in private. 
Feel free to merge if you don't feel it's too risky :)

Still to come:
* UX to render this data - Two pages, "API health" for general user consumption, and dev-focused per-API statistics page.
* Refactor API framework to switch to charge pool syntax  (e.g. API_CHARGE_SEARCH | 1)
* Switch all other APIs to using new API framework, so stats can discriminate between APIs
* Bit more characterization of how much time this adds to requests, and trying to mitigate that further.

What has been done:
* **ALL** API calls now record performance data. We keep track of, per API type (and all APIs together) - Total request count, Total time taken working on requests, and a histogram giving us detailed information on how long individual requests are taking (while still being cheap and not taking a lot of space)
* Stats API calls added to provide realtime detailed information on the current in-cache data, and historical data which is recorded to the database. The histogram is not persisted to the database, instead it is summarized to a set of percentile figures.
  * `/vx/stats/api` - Endpoint to get current realtime stats from the current period (up to 15 minutes). This fetches data from the redis structures and performs some basic computation, and it includes the full histogram data which gives a very accurate picture of the distribution of request completion times.
  * `/vx/stats/api/history` - Endpoint to get historical data. At the moment this is hardcoded to return the last ~48 records (12 hours) of data from the database. Further refinement to this API is anticipated.
* Magic cron task updated to flush previous period data to database when a new period is entered. This is expected to take 0ms typically and about 10ms when performing a flush (every 15 minutes).

Some other details:
* For clarity, think of the percentile data as follows: Percentiles["95"] is a request time, which 95% of requests are <= that much time. So if I see Percentiles["95"] = 0.001165, I know that 95% of the site requests are taking less than 1.165ms to complete. 
* We should observe the site with these changes and define some standards. e.g. "the site is in good health if P[95] < 20ms