### PR TITLE
Fixes

### DIFF
--- a/public-api/vx/grade.php
+++ b/public-api/vx/grade.php
@@ -80,8 +80,9 @@ switch ( $action ) {
 
 		// Determine the user's game in the referenced event.
 		$published_game = false;
-		$authored_list = nodeComplete_GetWhatIdHasAuthoredByParent($user_id, $parent_id);
-		if ( count($authored_list) > 0 ) [
+		$authored_ids = nodeComplete_GetWhatIdHasAuthoredByParent($user_id, $parent_id);
+		if ( !empty($authored_ids) ) {
+			$authored_list = nodeCache_GetById($authored_ids);
 			foreach ( $authored_list as $authored ) {
 				// Don't allow user to vote on a game they're the author of
 				if ( $authored['id'] == $node_id ) {

--- a/public-api/vx/note.php
+++ b/public-api/vx/note.php
@@ -103,6 +103,9 @@ switch ( $action ) {
 					$mentions = notification_GetMentionedUsers($body);
 					notification_AddForNote($node['id'], $RESPONSE['note'], $author, $mentions);
 				}
+
+				// Invalidate the cache for the containing node so we recompute the note count immediately on the site.
+				nodeCache_InvalidateById($node['id']);
 			}
 			else {
 				json_EmitFatalError_Permission(null, $RESPONSE);

--- a/sandbox/simulator/model_default
+++ b/sandbox/simulator/model_default
@@ -666,6 +666,11 @@ function VoteOnGame(&$user, $phase)
 			if(random_int(1,20) != 1) { continue; } 
 		}
 		
+		if ( $id == $user["game_node"] ) {
+			Verbose("Skipping game ID $id as this is the user's game");
+			continue;
+		}
+		
 		Verbose("Voting on game ID $id");
 		
 		// Future, consider opt-outs on this game. For now just vote all categories.

--- a/sandbox/simulator/model_default
+++ b/sandbox/simulator/model_default
@@ -646,6 +646,11 @@ function CommentOnGame(&$user, $phase)
 // Find a game through one of the game lists, and vote on it. Or change the votes to something else.
 function VoteOnGame(&$user, $phase)
 {
+	if ( !$user["publishedgame"] ) {
+		Verbose("Not going to vote because game is unpublished.");
+		return false;
+	}
+
 	$games = GetVoteGames($user);
 	
 	$rate_count = random_int(5,10);

--- a/src/shrub/src/node/node_complete.php
+++ b/src/shrub/src/node/node_complete.php
@@ -251,12 +251,8 @@ function nodeComplete_GetWhereIdCanCreate( $id ) {
 function nodeComplete_GetWhatIdHasAuthoredByParent( $id, $parent ) {
 	$node_ids = nodeComplete_GetAuthored($id);
 	if ( !empty($node_ids) ) {
-		$nodes = node_GetById($node_ids);			// OPTIMIZE: Use a cached function (we only need parent)
-		
-		global $RESPONSE;
-		$RESPONSE['_node_ids'] = $node_ids;
-		$RESPONSE['_nodes'] = $nodes;
-		
+		$nodes = nodeCache_GetById($node_ids);
+
 		$authored_ids = [];
 		foreach ( $nodes as &$node ) {
 			if ( $node['parent'] == $parent ) {


### PR DESCRIPTION
* Resolve #1195 (Prevent user from voting on their own game, prevent user with unpublished game from voting) - The site already blocks these two cases, but the API did not.
  * `/grade/add` average time in simulator 2.093ms, Slight increase from 1.561ms before changes, due to additional data being fetched. Probably not a concern.
* Posting a comment now immediately invalidates the node cache (so website will immediately reflect new comments)