### PR TITLE
Notify optout

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -241,10 +241,10 @@ export default class ContentCommentsComment extends Component {
 				var ShowRight = [];
 
 				if ( props.cansubscribe ) {
-					ShowRight.push(<div class={"-button -publish -modified"} onclick={this.onSubscribe}><div>Follow Thread</div></div>);
+					ShowRight.push(<div class={"-button -subscribe"} onclick={this.onSubscribe}><SVGIcon>bubble</SVGIcon><div>Follow Thread</div></div>);
 				}
 				else {
-					ShowRight.push(<div class={"-button -publish -modified"} onclick={this.onSubscribe}><div>Unfollow Thread</div></div>);
+					ShowRight.push(<div class={"-button -unsubscribe"} onclick={this.onSubscribe}><SVGIcon>bubble-empty</SVGIcon><div>Unfollow Thread</div></div>);
 				}
 
 				if ( props.publish ) {

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -41,6 +41,7 @@ export default class ContentCommentsComment extends Component {
 		this.onPublishAnon = this.onPublishAnon.bind(this);
 		this.onLove = this.onLove.bind(this);
 		this.onReply = this.onReply.bind(this);
+		this.onSubscribe = this.onSubscribe.bind(this);
 	}
 
 	onEditing( e ) {
@@ -128,6 +129,13 @@ export default class ContentCommentsComment extends Component {
 
 	onReply( e ) {
 		console.log('reply');
+	}
+
+	onSubscribe( e ) {
+		// consider disabling element temporarily. But this should go by quickly
+		if ( this.props.onsubscribe ) {
+			this.props.onsubscribe(e, this.props.cansubscribe);
+		}
 	}
 
 	render( props, state ) {
@@ -231,6 +239,14 @@ export default class ContentCommentsComment extends Component {
 				}
 
 				var ShowRight = [];
+
+				if ( props.cansubscribe ) {
+					ShowRight.push(<div class={"-button -publish -modified"} onclick={this.onSubscribe}><div>Follow Thread</div></div>);
+				}
+				else {
+					ShowRight.push(<div class={"-button -publish -modified"} onclick={this.onSubscribe}><div>Unfollow Thread</div></div>);
+				}
+
 				if ( props.publish ) {
 					if (props.allowAnonymous) {
 						ShowRight.push(<div class={"-button -publish"+(state.modified?" -modified":"")} onclick={this.onPublishAnon}><SVGIcon>publish</SVGIcon><div>Publish Anonymously</div></div>);

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -7,6 +7,7 @@ import ContentCommentsComment			from 'comments-comment';
 import $Note							from '../../shrub/js/note/note';
 import $Node							from '../../shrub/js/node/node';
 import $NoteLove						from '../../shrub/js/note/note_love';
+import $Notification					from '../../shrub/js/notification/notification';
 
 export default class ContentComments extends Component {
 	constructor( props ) {
@@ -17,9 +18,13 @@ export default class ContentComments extends Component {
 			'tree': null,
 			'authors': null,
 			'newcomment': null,
+			'subscribed': null,
+			'hascomment': false,
+			'isauthor': false,
 		};
 
 		this.onPublish = this.onPublish.bind(this);
+		this.onSubscribe = this.onSubscribe.bind(this);
 	}
 
 	componentWillMount() {
@@ -38,15 +43,47 @@ export default class ContentComments extends Component {
 	}
 
 	getComments( node ) {
+		let user = this.props.user;
+		if ( user & user.id ) {
+			$Notification.GetSubscription( node.id )
+			.then(r => {
+				// Determine whether user is subscribed to the thread explicitly
+				this.setState({'subscribed': r['subscribed']});
+			});
+		}
+
 		$Note.Get( node.id )
 		.then(r => {
+			// Determine if current user is one of the authors of this node
+			let isauthor = false;
+			if ( node.meta && node.meta.authors ) {
+				for ( const index in node.meta.authors ) {
+					if ( node.meta.authors[index] == user.id ) {
+						isauthor = true;
+						break;
+					}
+				}
+			}
+			if ( node.author == user.id ) {
+				isauthor = true;
+			}
+			this.setState({'isauthor': isauthor});
+
 			// Has comments
 			if ( r.note && r.note.length ) {
-				this.setState({ 'comments': r.note, 'tree': null, 'authors': null });
+				// Determine whether the user has made a comment in this thread.
+				let hasComment = false;
+				for ( const index in r.note ) {
+					if ( r.note[index].author == user.id ) {
+						hasComment = true;
+						break;
+					}
+				}
+				this.setState({'comments': r.note, 'tree': null, 'authors': null, 'hascomment': hasComment});
 			}
 			// Does not have comments
 			else if ( r.note ) {
-				this.setState({ 'comments': [], 'tree': null, 'authors': null });
+				this.setState({'comments': [], 'tree': null, 'authors': null});
 			}
 
 			// Async first
@@ -56,14 +93,14 @@ export default class ContentComments extends Component {
 
 			$NoteLove.GetMy(node.id)
 			.then(r => {
-					this.setState({ "lovedComments": r["my-love"]});
+					this.setState({"lovedComments": r["my-love"]});
 
 					// Sync last
 					this.setState({'tree': this.buildTree()});
 			});
 		})
 		.catch(err => {
-			this.setState({ 'error': err });
+			this.setState({'error': err});
 		});
 	}
 
@@ -163,7 +200,10 @@ export default class ContentComments extends Component {
 		const author = authors[comment.author];
 		const allowAnonymous = parseInt(this.props.node.meta['allow-anonymous-comments']);
 
-		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} /></div>;
+		// We can subscribe if we haven't subscribed and we don't have a comment in this thread, and we're not an author. Otherwise we can unsubscribe.
+		let canSubscribe = (this.state.subscribed === null) ? !( this.state.hascomment || this.state.isauthor ) : !this.state.subscribed;
+
+		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} cansubscribe={canSubscribe} onsubscribe={this.onSubscribe} /></div>;
 	}
 
 	onPublish( e, publishAnon ) {
@@ -189,7 +229,7 @@ export default class ContentComments extends Component {
 				newcomment.parent = 0;
 				newcomment.body = '';
 
-				this.setState({'tree': this.buildTree()});
+				this.setState({'tree': this.buildTree(), 'hascomment': true});
 			}
 			else {
 				this.setState({'error': (r.message ? r.message : "Unknown error when posting comment")});
@@ -197,6 +237,20 @@ export default class ContentComments extends Component {
 		})
 		.catch(err => {
 			this.setState({'error': err});
+		});
+	}
+
+	onSubscribe( e, subscribe ) {
+		let promise = null;
+		if ( subscribe ) {
+			promise = $Notification.Subscribe( this.props.node.id );
+		}
+		else {
+			promise = $Notification.Unsubscribe( this.props.node.id );
+		}
+
+		promise.then(r => {
+			this.setState({'subscribed': subscribe});
 		});
 	}
 

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -298,6 +298,16 @@
 					background: @COL_C;
 					color: @COL_L;
 				}
+
+				& .-subscribe {
+					background: @COL_BCM;
+					color: @COL_NLLLL;
+				}
+
+				& .-unsubscribe {
+					background: @COL_ABM;
+					color: @COL_NLLLL;
+				}
 			}
 		}
 

--- a/src/shrub/js/notification/notification.js
+++ b/src/shrub/js/notification/notification.js
@@ -6,6 +6,9 @@ export default {
 	GetFeedUnread,
 	GetFeedAll,
 	SetMarkRead,
+	GetSubscription,
+	Subscribe,
+	Unsubscribe,
 };
 
 //Gets count, caller_id, and satus for unread notifications
@@ -29,5 +32,17 @@ export function GetFeedAll( offset, length ) {
 }
 
 export function SetMarkRead( id ) {
-	return Fetch.Post(API_ENDPOINT+'/vx/notification/markread', {max_read: id});
+	return Fetch.Post(API_ENDPOINT+'/vx/notification/markread', {'max_read': id});
+}
+
+export function GetSubscription( id ) {
+	return Fetch.Get(API_ENDPOINT+'/vx/notification/subscription/get/' + id, true);
+}
+
+export function Subscribe( id ) {
+	return Fetch.Post(API_ENDPOINT+'/vx/notification/subscription/add/' + id, {});
+}
+
+export function Unsubscribe( id ) {
+	return Fetch.Post(API_ENDPOINT+'/vx/notification/subscription/remove/' + id, {});
 }

--- a/src/shrub/src/notification/constants.php
+++ b/src/shrub/src/notification/constants.php
@@ -15,9 +15,11 @@ const SH_NOTIFICATION_MENTION =			'mention';
 /// @name Notification Tables (notify on replies in thread, etc.)
 /// @addtogroup Tables
 /// @{
-const SH_TABLE_NOTIFICATION =	    "notification";
+const SH_TABLE_NOTIFICATION =		"notification";
+const SH_TABLE_NOTIFICATION_SUB =	"notification_sub";
 /// @}
 
 global_AddTableConstant( 
-	'SH_TABLE_NOTIFICATION'
+	'SH_TABLE_NOTIFICATION',
+	'SH_TABLE_NOTIFICATION_SUB'
 );

--- a/src/shrub/src/notification/notification.php
+++ b/src/shrub/src/notification/notification.php
@@ -1,4 +1,5 @@
 <?php
 // Tables and Features
 require_once __DIR__."/notification_core.php";
+require_once __DIR__."/notification_subscribe.php";
 

--- a/src/shrub/src/notification/notification_core.php
+++ b/src/shrub/src/notification/notification_core.php
@@ -174,8 +174,25 @@ function notification_AddForNote( $node, $note, $author, $mentions = [] ) {
 			$users[] = $link['a'];
 	}
 	
+	// Look up what users have expressly opted in and out of notifications for this thread.
+	$subs = notification_GetAllSubscriptionsForNode($node);
+	$optin = [];
+	$optout = [];
+	foreach ( $subs as $sub ) {
+		if ( $sub['subscribed'] ) {
+			$optin[] = $sub['user'];
+		}
+		else {
+			$optout[] = $sub['user'];
+		}
+	}
+	
+	// Add users that are opting in to notifications
+	$users = array_merge($users, $optin);	
 	// Eliminate duplicate users - don't send duplicate notifications.
 	$users = array_unique($users);
+	// Remove users that opt-out of notifications
+	$users = array_diff($users, $optout);
 	// Supersede normal notifications with "mention" notifications if the user was at-mentioned
 	$users = array_diff($users, $mentions); 
 	

--- a/src/shrub/src/notification/notification_subscribe.php
+++ b/src/shrub/src/notification/notification_subscribe.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once __DIR__."/../node/node.php";
+
+function notification_GetAllSubscriptionsForNode( $node ) {
+	return db_QueryFetch(
+		"SELECT user, subscribed
+		FROM ".SH_TABLE_PREFIX.SH_TABLE_NOTIFICATION_SUB."
+		WHERE node=?
+		;",
+		$node
+	);
+}
+
+function notification_GetSubscriptionForNode( $user, $node ) {
+	$sub = db_QueryFetchSingle(
+		"SELECT subscribed
+		FROM ".SH_TABLE_PREFIX.SH_TABLE_NOTIFICATION_SUB." 
+		WHERE user=? AND node=?;",
+		$user, $node
+	);
+	if ( empty($sub) ) {
+		return null;
+	}
+	return $sub ? true : false;
+}
+
+
+function notification_SetSubscriptionForNode( $user, $node, $subscribed ) {
+	$subscribed_value = $subscribed ? 1 : 0;
+	
+	return db_QueryInsert(
+		"INSERT INTO ".SH_TABLE_PREFIX.SH_TABLE_NOTIFICATION_SUB." (
+			user,
+			node,
+			subscribed
+		)
+		VALUES (
+			?,
+			?,
+			?,
+		)
+		ON DUPLICATE KEY UPDATE
+			subscribed=VALUES(subscribed),
+		;",
+		$user,
+		$node,
+		$subscribed_value
+	);
+}

--- a/src/shrub/src/notification/notification_subscribe.php
+++ b/src/shrub/src/notification/notification_subscribe.php
@@ -22,7 +22,7 @@ function notification_GetSubscriptionForNode( $user, $node ) {
 	if ( empty($sub) ) {
 		return null;
 	}
-	return $sub ? true : false;
+	return $sub['subscribed'] ? true : false;
 }
 
 
@@ -41,7 +41,7 @@ function notification_SetSubscriptionForNode( $user, $node, $subscribed ) {
 			?,
 		)
 		ON DUPLICATE KEY UPDATE
-			subscribed=VALUES(subscribed),
+			subscribed=VALUES(subscribed)
 		;",
 		$user,
 		$node,

--- a/src/shrub/src/notification/notification_subscribe.php
+++ b/src/shrub/src/notification/notification_subscribe.php
@@ -38,7 +38,7 @@ function notification_SetSubscriptionForNode( $user, $node, $subscribed ) {
 		VALUES (
 			?,
 			?,
-			?,
+			?
 		)
 		ON DUPLICATE KEY UPDATE
 			subscribed=VALUES(subscribed)

--- a/src/shrub/src/notification/table_create.php
+++ b/src/shrub/src/notification/table_create.php
@@ -40,3 +40,34 @@ if ( in_array($table, $TABLE_LIST) ) {
 	table_Exit($table);
 }
 
+// Notification subscription is a table storing subscription preference for users on threads (post nodes)
+// when the user takes discrete action to change subscription status.
+// When no record is present, the default behavior is to treat users as subscribed if they have commented.
+// The 'subscribed' value is stored in a u8, with 0 = unsubscribed, 1 = subscribed
+$table = 'SH_TABLE_NOTIFICATION_SUB';
+if ( in_array($table, $TABLE_LIST) ) {
+	$ok = null;
+
+	table_Init($table);
+	switch ( $TABLE_VERSION ) {
+	case 0:
+		$ok = table_Create( $table,
+			"CREATE TABLE ".SH_TABLE_PREFIX.constant($table)." (
+				id ".DB_TYPE_UID.",
+				user ".DB_TYPE_ID.",
+				node ".DB_TYPE_ID.",
+					INDEX(node),
+				subscribed ".DB_TYPE_UINT8."
+			)".DB_CREATE_SUFFIX);
+		$created = true;
+		if (!$ok) break; $TABLE_VERSION++;
+	case 1:
+		$ok = table_Update( $table,
+			"ALTER TABLE ".SH_TABLE_PREFIX.constant($table)."
+				ADD UNIQUE `user_node` (`user`, `node`);"
+			);
+		if (!$ok) break; $TABLE_VERSION++;		
+	};
+
+	table_Exit($table);
+}


### PR DESCRIPTION
Add arbitrary opt-in and opt-out to notifications. Add a UI button to enable opting in/out, mainly for the users who prefer not to get notifications for every thread.

Changes:
* Add API paths 
  * GET `vx/notification/subscription/get/[nodeid]` - Am I subscribed to this node? check `subscribed`
  * POST `vx/notification/subscription/add/[nodeid]` - Subscribe me to this thread
  * POST `vx/notification/subscription/remove/[nodeid]` - Unsubscribe me from this thread
* If no subscribe/unsubscribe has been registered, the default behavior is your user will receive notificiations if you are the author of the node (or an author for teams), or if you have commented on this thread. Unsubscribe will prevent notifications if either of those are the case, Subscribe will allow notifications without the above conditions.
* Regardless of the subscription status, you will always get notifications for at-mentions.
* This data is stored minimally without history in a new table (notifications_sub)
* UI correctly reflects the current subscription status and lets you toggle it. Examples below.

![image](https://user-images.githubusercontent.com/620920/33475230-87e071f2-d632-11e7-8b2f-dac7b3e42017.png)
After posting a comment, the status updates to reflect that the user is subscribed to the thread.
![image](https://user-images.githubusercontent.com/620920/33475245-9da06326-d632-11e7-98ec-b057a2fc298f.png)


