### PR TITLE
Fix dumb mistakes, now getting subscription status should work correctly

### DIFF
--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -44,7 +44,7 @@ export default class ContentComments extends Component {
 
 	getComments( node ) {
 		let user = this.props.user;
-		if ( user & user.id ) {
+		if ( user && user.id ) {
 			$Notification.GetSubscription( node.id )
 			.then(r => {
 				// Determine whether user is subscribed to the thread explicitly

--- a/src/shrub/src/notification/notification_subscribe.php
+++ b/src/shrub/src/notification/notification_subscribe.php
@@ -22,7 +22,7 @@ function notification_GetSubscriptionForNode( $user, $node ) {
 	if ( empty($sub) ) {
 		return null;
 	}
-	return $sub['subscribed'] ? true : false;
+	return $sub[0] ? true : false;
 }
 
 


### PR DESCRIPTION
Apparently I didn't test that the query worked correctly after some changes, Getting subscription status now works correctly.