### PR TITLE
change icons for notifications on your posts

### DIFF
--- a/src/com/content-notifications/notification.js
+++ b/src/com/content-notifications/notification.js
@@ -120,14 +120,14 @@ export default class NotificationItem extends Component {
 
 					return (
 						<NavLink {...navProps} >
-						<SVGIcon>bubble</SVGIcon>{timePrefix} {following.string} {extra} {also} commented on {NodeAuthor} {nodeType} "<em>{node.name}</em>"
+						<SVGIcon>bubble-empty</SVGIcon>{timePrefix} {following.string} {extra} {also} commented on {NodeAuthor} {nodeType} "<em>{node.name}</em>"
 						</NavLink>);
 
 				}
 				else {
 					return (
 						<NavLink {...navProps} >
-						<SVGIcon>bubble</SVGIcon>{timePrefix} {count} users {also} commented on {NodeAuthor} {nodeType} "<em>{node.name}</em>"
+						<SVGIcon>{NodeAuthor == 'your' ? 'bubble' : 'bubble-empty'}</SVGIcon>{timePrefix} {count} users {also} commented on {NodeAuthor} {nodeType} "<em>{node.name}</em>"
 						</NavLink>);
 
 				}
@@ -154,7 +154,7 @@ export default class NotificationItem extends Component {
 				else {
 					return (
 						<NavLink {...navProps} >
-						<SVGIcon>bubble</SVGIcon>{timePrefix} {NoteAuthor} also commented on {NodeAuthor} {nodeType} "<em>{node.name}</em>"
+						<SVGIcon>bubble-empty</SVGIcon>{timePrefix} {NoteAuthor} also commented on {NodeAuthor} {nodeType} "<em>{node.name}</em>"
 						</NavLink>);
 				}
 			}


### PR DESCRIPTION
As mentioned at the of #1484

![screenshot from 2017-12-07 09-25-38](https://user-images.githubusercontent.com/18352787/33708032-3ee79da0-db31-11e7-8d38-e016546fe229.png)

Essentially if the notification has a `your` in it, the bubble is solid otherwise the bubble isn't solid.