### PR TITLE
Let main author get feedback notifications again

### DIFF
--- a/src/shrub/src/notification/notification_core.php
+++ b/src/shrub/src/notification/notification_core.php
@@ -218,7 +218,7 @@ function notification_AddForNote( $node_id, $note, $author, $mentions = [] ) {
 		$notifications[] = ['user' => $uid, 'node' => $node_id, 'note' => $note, 'type' => SH_NOTIFICATION_MENTION];
 	}	
 	foreach($feedback_notify as $uid)	{
-		if ( $uid == $nodeauthor )
+		if ( $uid == $author )
 			continue; // Don't bother sending the author of the note a notification for their own note.
 			
 		$notifications[] = ['user' => $uid, 'node' => $node_id, 'note' => $note, 'type' => SH_NOTIFICATION_FEEDBACK];


### PR DESCRIPTION
Last update to the notifications system had an error that causes feedback-notification only to occur if you are not the main author of the `node` as reported in #1507 

This makes the proper comparison so that feedbacks are only omitted if you were the one that wrote the note on your own node.

I've run the simulator and logged in as someone who wrote a post and they are now getting feedback notifications.