### PR TITLE
Make the code font bigger plz

### DIFF
--- a/src/com/content-common/common-code.less
+++ b/src/com/content-common/common-code.less
@@ -35,7 +35,6 @@
 		color: @base3;
 		background-color: @base03;
 		line-height: 1;
-		font-size: 75%;
 	}
 
 	// Code Blocks
@@ -48,7 +47,6 @@
 		overflow: auto;
 
 		font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-		font-size: 75%;
 
 		line-height: 1.1;
 		tab-size: 4;

--- a/src/com/content-common/common-code.less
+++ b/src/com/content-common/common-code.less
@@ -24,10 +24,9 @@
 @cyan: @COL_C;
 @green: @COL_BC;
 
-// only target stuff within a markup block
-.markup{
-
-	// InLine Code
+/* only target stuff within a markup block */
+.markup {
+	/* Inline Code */
 	:not(pre) > code {
 		padding-left: 0.125em;
 		padding-right: 0.125em;
@@ -35,9 +34,10 @@
 		color: @base3;
 		background-color: @base03;
 		line-height: 1;
+		font-size: 90%;
 	}
 
-	// Code Blocks
+	/* Code Blocks */
 	pre {
 		color: @base02;
 		background-color: @base2;
@@ -47,6 +47,7 @@
 		overflow: auto;
 
 		font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+		font-size: 90%;
 
 		line-height: 1.1;
 		tab-size: 4;
@@ -125,7 +126,7 @@
 		}
 	}
 
-	.namespace{
-		opacity:0.7;
+	.namespace {
+		opacity: 0.7;
 	}
 }


### PR DESCRIPTION
The code font size seems too small.  The real world example that made me want to do this is on this page
https://ldjam.com/events/ludum-dare/40/pet-overload


Before:
![screen shot 2017-12-19 at 22 48 18](https://user-images.githubusercontent.com/10319630/34195235-5f512d9c-e511-11e7-840b-3e75c2496839.png)
After:
![screen shot 2017-12-19 at 22 48 08](https://user-images.githubusercontent.com/10319630/34195238-60ffdae4-e511-11e7-8ab0-6d35d5c625ec.png)
