### PR TITLE
Fixed missing change to comment

### DIFF
--- a/private/magic.php
+++ b/private/magic.php
@@ -5,7 +5,7 @@ const SHRUB_PATH = "../src/shrub/src";
 include_once __DIR__."/".CONFIG_PATH."/config.php";
 require_once __DIR__."/".SHRUB_PATH."/cron.php";
 require_once __DIR__."/".SHRUB_PATH."/node/node.php";
-require_once __DIR__."/".SHRUB_PATH."/note/note.php";
+require_once __DIR__."/".SHRUB_PATH."/comment/comment.php";
 require_once __DIR__."/".SHRUB_PATH."/grade/grade.php";
 
 // This is a CRON job that regularly updates magic
@@ -188,8 +188,8 @@ if ( $featured_id ) {
 					$classic_grade = sqrt($classic_team_grades * 100.0 / max(1.0, $classic_given_grades)) * 100.0 / 10.0;
 
 					// ** Calculate Feedback Score **************************************
-					$raw_team_feedback = noteLove_CountBySuperNotNodeAuthorKnownNotAuthor($node['parent'], $node['id'], $authors);
-					$raw_given_feedback = noteLove_CountBySuperNodeNotAuthorKnownNotAuthor($node['parent'], $node['id'], $authors);
+					$raw_team_feedback = commentLove_CountBySuperNotNodeAuthorKnownNotAuthor($node['parent'], $node['id'], $authors);
+					$raw_given_feedback = commentLove_CountBySuperNodeNotAuthorKnownNotAuthor($node['parent'], $node['id'], $authors);
 
 					$team_feedback = $raw_team_feedback / FEEDBACK_PER_NOTE;
 					$given_feedback = $raw_given_feedback / FEEDBACK_PER_NOTE;

--- a/public-api/vx/notification.php
+++ b/public-api/vx/notification.php
@@ -58,7 +58,7 @@ function SetSubscription($value, &$RESPONSE) {
 	
 	// Verify that this node makes sense to subscribe to (use the same rules as note posting)
 	$node = node_GetById($node_id);
-	if ( !note_IsNotePublicByNode($node) ) {
+	if ( !comment_IsCommentPublicByNode($node) ) {
 		json_EmitFatalError_Permission("You don't have permission to subscribe to this node.", $RESPONSE);
 	}
 


### PR DESCRIPTION
This resolves the bug reported in #1533 

For reference there's still the use of the word `note` in:

* `src/shurb/src/comment/constants.php`:

```php
SH_TABLE_NOTE_TREE =                  "note_tree";            // Ancestry
SH_TABLE_NOTE_VERSION =               "note_version";         // History
SH_TABLE_NOTE_LOVE =                  "note_love";
```

* In last sandbox-event I ran (before the change) `sandbox/ld_event.1.stats.html` just make sure you don't use them perhaps?

The use of the word `NOTE` in:

* `src/shrub/src/comment/comment_core.php`, `comment_love.php`, `comment_version.php` pointing to the constants in the `constants.php` above. Also in the `table_create.php`.