### PR TITLE
User groups!

### DIFF
--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -5,6 +5,7 @@ include_once __DIR__."/".CONFIG_PATH."config.php";
 require_once __DIR__."/".SHRUB_PATH."api.php";
 require_once __DIR__."/".SHRUB_PATH."node/node.php";
 require_once __DIR__."/".SHRUB_PATH."notification/notification.php";
+require_once __DIR__."/".SHRUB_PATH."user/user.php";
 
 json_Begin();
 
@@ -547,6 +548,10 @@ switch ( $action ) {
 			];
 
 			// TODO: Do things that modify limits here
+			if (userGroup_GetUserHasStatus($user_id, USER_GROUP_FLAG_CAN_NEWS)) {
+				$create_limits['post/news'] = -1;
+			}
+
 			$true_limit = 2;	// TODO: up this as a user becomes more trustworthy.
 
 

--- a/public-api/vx/user.php
+++ b/public-api/vx/user.php
@@ -669,7 +669,8 @@ switch ( $action ) {
 		if ( $id > 0 ) {
 			$node = nodeComplete_GetById($id);
 			if ( count($node) ) {
-				$RESPONSE['node'] = $node;
+				$node['meta']['group'] = userGroup_GetUserStatusNames($id);
+				$RESPONSE['node'] = $node;				
 			}
 			else {
 				$id = 0;

--- a/src/com/dialog/common/common.js
+++ b/src/com/dialog/common/common.js
@@ -96,7 +96,10 @@ export default class DialogCommon extends Component {
 	onAbort() {
 		//console.log(location.pathname + location.search);
 		//window.history.pushState(null, null, location.pathname + location.search);
-    window.location.hash = "--";
+		window.location.hash = "--";
+		if (this.props.onAbort) {
+			this.props.onAbort();
+		}
 		//location.href = location.pathname+location.search;
 	}
 

--- a/src/com/dialog/create/create.js
+++ b/src/com/dialog/create/create.js
@@ -48,7 +48,8 @@ export default class DialogCreate extends Component {
 
 	render( props, {error} ) {
 		var new_props = {
-			'title': 'Create'
+			'title': 'Create',
+			'onAbort': props.onAbort,
 		};
 		if ( error ) {
 			new_props.error = error;
@@ -80,15 +81,25 @@ export default class DialogCreate extends Component {
 					</DialogCommon>
 				);
 			}
-			if ( What == "post" ) {
-				var ShowType = "Blog Post";
+			if ( What.startsWith("post" )) {
+				let ShowType = null;
+				let ShowInfo = null;
+				if ( What == 'post/news' ) {
+					ShowType = TargetNode == 1 ? "General News Post" : "Event News Post";
+					ShowInfo = <div>You have to keep track of the URI if you don't write and publish in one go...</div>;
+				}
+				else {
+					ShowType = "Blog Post";
+					ShowInfo = <div>You can find your unpublished draft posts on your user page.</div>;
+				}
+
 				new_props.title += ' '+ShowType;
 				new_props.oktext = "Create "+ShowType;
 
 				return (
 					<DialogCommon ok onok={this.doCreate} cancel explicit {...new_props}>
-						<div>Create a new Blog Post?</div>
-						<div>You can find your unpublished draft posts on your user page.</div>
+						<div>Create a new {ShowType}?</div>
+						{ShowInfo}
 					</DialogCommon>
 				);
 			}

--- a/src/com/dialog/create/create.js
+++ b/src/com/dialog/create/create.js
@@ -86,12 +86,11 @@ export default class DialogCreate extends Component {
 				let ShowInfo = null;
 				if ( What == 'post/news' ) {
 					ShowType = TargetNode == 1 ? "General News Post" : "Event News Post";
-					ShowInfo = <div>You have to keep track of the URI if you don't write and publish in one go...</div>;
 				}
 				else {
 					ShowType = "Blog Post";
-					ShowInfo = <div>You can find your unpublished draft posts on your user page.</div>;
 				}
+				ShowInfo = <div>You can find your unpublished draft posts on your user page.</div>;
 
 				new_props.title += ' '+ShowType;
 				new_props.oktext = "Create "+ShowType;

--- a/src/com/page/home/news/news.js
+++ b/src/com/page/home/news/news.js
@@ -1,8 +1,25 @@
 import {h, Component}					from 'preact/preact';
 import ContentTimeline					from 'com/content-timeline/timeline';
 import UIButton							from 'com/ui/button/button';
+import DialogCreate						from 'com/dialog/create/create';
 
 export default class PageHomeNews extends Component {
+
+	constructor (props) {
+		super(props);
+
+		this.onCreateGeneralNews = this.onCreateNews.bind(this, "general");
+		this.onCreateEventNews = this.onCreateNews.bind(this, "event");
+		this.onAbortCreate = this.onAbortCreate.bind(this);
+	}
+
+	onCreateNews(newsType) {
+		this.setState({'showDialog': newsType});
+	}
+
+	onAbortCreate() {
+		this.setState({'showDialog': null});
+	}
 
 	userCanCreateNews( user ) {
 		return user && user.meta && user.meta.group && user.meta.group.filter(g => g == 'canNews').length > 0;
@@ -12,21 +29,36 @@ export default class PageHomeNews extends Component {
 		return user && user.meta && user.meta.group && user.meta.group.filter(g => g == 'canNews' || g == 'activeEventHost').length > 0;
 	}
 
-    render( props ) {
-        let {node, user, path, extra} = props;
+    render( props, state ) {
+        const {node, user, path, extra, featured} = props;
+		const {showDialog} = state;
 		let ShowCreateNews = null;
 		let ShowCreteEventNews = null;
-		if (this.userCanCreateNews(user)) {
-			ShowCreateNews = <UIButton href="/add/0/post/news">Create general news post</UIButton>;
+		let ShowDialog = null;
+		if (showDialog) {
+			const extra = [];
+			if (showDialog == 'general') {
+				extra.push(1);
+			}
+			else {
+				extra.push(featured.id);
+			}
+			extra.push('post');
+			extra.push('news');
+			ShowDialog = <DialogCreate extra={extra} onAbort={this.onAbortCreate}/>;
 		}
-		if (this.userCanCreateEventNews(user)) {
-			ShowCreteEventNews = <UIButton href="/add/0/post/news">Create event news post</UIButton>;
+		if (this.userCanCreateNews(user)) {
+			ShowCreateNews = <UIButton onClick={this.onCreateGeneralNews}>Create general news post</UIButton>;
+		}
+		if (featured && this.userCanCreateEventNews(user)) {
+			ShowCreteEventNews = <UIButton onClick={this.onCreateEventNews}>Create event news post</UIButton>;
 		}
         return (
 			<div>
 				{ShowCreateNews}
 				{ShowCreteEventNews}
 				<ContentTimeline class="content-timeline-news" types={['post']} subtypes={['news']} methods={['all']} node={node} user={user} path={path} extra={extra} />
+				{ShowDialog}
 			</div>
         );
     }

--- a/src/com/page/home/news/news.js
+++ b/src/com/page/home/news/news.js
@@ -32,9 +32,10 @@ export default class PageHomeNews extends Component {
     render( props, state ) {
         const {node, user, path, extra, featured} = props;
 		const {showDialog} = state;
-		let ShowCreateNews = null;
-		let ShowCreteEventNews = null;
+		let ShowCreateItems = [];
+		let ShowCreateBar = null;
 		let ShowDialog = null;
+
 		if (showDialog) {
 			const extra = [];
 			if (showDialog == 'general') {
@@ -47,16 +48,21 @@ export default class PageHomeNews extends Component {
 			extra.push('news');
 			ShowDialog = <DialogCreate extra={extra} onAbort={this.onAbortCreate}/>;
 		}
+
+
 		if (this.userCanCreateNews(user)) {
-			ShowCreateNews = <UIButton onClick={this.onCreateGeneralNews}>Create general news post</UIButton>;
+			ShowCreateItems.push(<UIButton onClick={this.onCreateGeneralNews} key="general">Create general news post</UIButton>);
 		}
 		if (featured && this.userCanCreateEventNews(user)) {
-			ShowCreteEventNews = <UIButton onClick={this.onCreateEventNews}>Create event news post</UIButton>;
+			ShowCreateItems.push(<UIButton onClick={this.onCreateEventNews} key="event">Create event news post</UIButton>);
 		}
+		if (ShowCreateItems.length > 0) {
+			ShowCreateBar = <div class="news-create-bar">{ShowCreateItems}</div>;
+		}
+
         return (
 			<div>
-				{ShowCreateNews}
-				{ShowCreteEventNews}
+				{ShowCreateBar}
 				<ContentTimeline class="content-timeline-news" types={['post']} subtypes={['news']} methods={['all']} node={node} user={user} path={path} extra={extra} />
 				{ShowDialog}
 			</div>

--- a/src/com/page/home/news/news.js
+++ b/src/com/page/home/news/news.js
@@ -1,12 +1,33 @@
 import {h, Component}					from 'preact/preact';
 import ContentTimeline					from 'com/content-timeline/timeline';
+import UIButton							from 'com/ui/button/button';
 
 export default class PageHomeNews extends Component {
+
+	userCanCreateNews( user ) {
+		return user && user.meta && user.meta.group && user.meta.group.filter(g => g == 'canNews').length > 0;
+	}
+
+	userCanCreateEventNews( user ) {
+		return user && user.meta && user.meta.group && user.meta.group.filter(g => g == 'canNews' || g == 'activeEventHost').length > 0;
+	}
+
     render( props ) {
         let {node, user, path, extra} = props;
-
+		let ShowCreateNews = null;
+		let ShowCreteEventNews = null;
+		if (this.userCanCreateNews(user)) {
+			ShowCreateNews = <UIButton href="/add/0/post/news">Create general news post</UIButton>;
+		}
+		if (this.userCanCreateEventNews(user)) {
+			ShowCreteEventNews = <UIButton href="/add/0/post/news">Create event news post</UIButton>;
+		}
         return (
-            <ContentTimeline class="content-timeline-news" types={['post']} subtypes={['news']} methods={['all']} node={node} user={user} path={path} extra={extra} />
+			<div>
+				{ShowCreateNews}
+				{ShowCreteEventNews}
+				<ContentTimeline class="content-timeline-news" types={['post']} subtypes={['news']} methods={['all']} node={node} user={user} path={path} extra={extra} />
+			</div>
         );
     }
 }

--- a/src/com/page/home/news/news.less
+++ b/src/com/page/home/news/news.less
@@ -1,0 +1,21 @@
+@import "defs.less";
+
+& .news-create-bar {
+	margin: 0.5em 0em;
+
+	& > .ui-button {
+		display: inline-block;
+		padding: 0.5em 1em;
+		border: 1px solid @COL_C;
+		margin: 0 0.5em 0 0;
+		color: @MAJOR_LIGHT;
+		background: @COL_C;
+		font-weight: bold;
+
+		&:hover, &:focus {
+			background: @MAJOR_COLOR1;
+			border: 1px solid @MAJOR_COLOR1;
+			color: @MAJOR_LIGHT;
+		}
+	}
+}

--- a/src/shrub/src/user/constants.php
+++ b/src/shrub/src/user/constants.php
@@ -35,8 +35,6 @@ global_AddReservedName(
 	'anon'
 );
 
-//ALTER TABLE `sh_user` ADD `user_group` SMALLINT UNSIGNED NOT NULL DEFAULT '0' AFTER `last_auth`;
-
 const USER_GROUP_FLAG_PARTICIPANT = 0;
 const USER_GROUP_FLAG_VETERAN = 1;
 const USER_GROUP_FLAG_MODERATOR = 2;

--- a/src/shrub/src/user/constants.php
+++ b/src/shrub/src/user/constants.php
@@ -34,3 +34,15 @@ global_AddReservedName(
 	'anonymous',
 	'anon'
 );
+
+//ALTER TABLE `sh_user` ADD `user_group` SMALLINT UNSIGNED NOT NULL DEFAULT '0' AFTER `last_auth`;
+
+const USER_GROUP_FLAG_PARTICIPANT = 0;
+const USER_GROUP_FLAG_VETERAN = 1;
+const USER_GROUP_FLAG_MODERATOR = 2;
+const USER_GROUP_FLAG_CONTRIBUTOR = 3;
+const USER_GROUP_FLAG_MEDIA = 4;
+const USER_GROUP_FLAG_ADMIN = 5;
+const USER_GROUP_FLAG_CAN_NEWS = 6;
+const USER_GROUP_FLAG_ACTIVE_EVENT_HOST = 7;
+//SMALLINT allows adding up to 18 non-exclusive categories

--- a/src/shrub/src/user/constants.php
+++ b/src/shrub/src/user/constants.php
@@ -45,4 +45,5 @@ const USER_GROUP_FLAG_MEDIA = 4;
 const USER_GROUP_FLAG_ADMIN = 5;
 const USER_GROUP_FLAG_CAN_NEWS = 6;
 const USER_GROUP_FLAG_ACTIVE_EVENT_HOST = 7;
+const USER_GROUP_FLAG_OWNER = 8;
 //SMALLINT allows adding up to 18 non-exclusive categories

--- a/src/shrub/src/user/user.php
+++ b/src/shrub/src/user/user.php
@@ -2,4 +2,5 @@
 include __DIR__."/user_core.php";
 include __DIR__."/user_mail.php";
 include __DIR__."/user_password.php";
+include __DIR__."/user_group.php";
 

--- a/src/shrub/src/user/user_core.php
+++ b/src/shrub/src/user/user_core.php
@@ -6,7 +6,7 @@ require_once __DIR__."/../node/node.php";
 const _SH_USER_ROW_MAP = [
 	'id'=>SH_FIELD_TYPE_INT,
 	'node'=>SH_FIELD_TYPE_INT,
-	'user_group'=>SH_FIELD_TYPE_INT,
+//	'user_group'=>SH_FIELD_TYPE_INT,
 //	'created'=>SH_FIELD_TYPE_DATETIME,
 //	'last_auth'=>SH_FIELD_TYPE_DATETIME,
 ];

--- a/src/shrub/src/user/user_core.php
+++ b/src/shrub/src/user/user_core.php
@@ -6,6 +6,7 @@ require_once __DIR__."/../node/node.php";
 const _SH_USER_ROW_MAP = [
 	'id'=>SH_FIELD_TYPE_INT,
 	'node'=>SH_FIELD_TYPE_INT,
+	'user_group'=>SH_FIELD_TYPE_INT,
 //	'created'=>SH_FIELD_TYPE_DATETIME,
 //	'last_auth'=>SH_FIELD_TYPE_DATETIME,
 ];

--- a/src/shrub/src/user/user_group.php
+++ b/src/shrub/src/user/user_group.php
@@ -8,7 +8,8 @@ const USER_GROUP_NAMES_MAP = [
 	USER_GROUP_FLAG_MEDIA => 'media',
 	USER_GROUP_FLAG_ADMIN => 'admin',
 	USER_GROUP_FLAG_CAN_NEWS => 'canNews',
-	USER_GROUP_FLAG_ACTIVE_EVENT_HOST => 'activeEventHost'
+	USER_GROUP_FLAG_ACTIVE_EVENT_HOST => 'activeEventHost',
+	USER_GROUP_FLAG_OWNER => 'owner',
 ];
 
 function _userGroup_GetFlagStatus( $status, $flag ) {

--- a/src/shrub/src/user/user_group.php
+++ b/src/shrub/src/user/user_group.php
@@ -38,7 +38,7 @@ function _userGroup_GetByNode( $node_id, $query_suffix = ";" ) {
 function userGroup_GetStatusCodeFromFlags( ...$flags ) {
 	$status = 0;
 	foreach ($flags as $flag) {
-		$status = _userGroup_GetUpdatedFlagStatusAdd($flag);
+		$status = _userGroup_GetUpdatedFlagStatusAdd($status, $flag);
 	}
 	return $status;
 }

--- a/src/shrub/src/user/user_group.php
+++ b/src/shrub/src/user/user_group.php
@@ -1,0 +1,76 @@
+<?php
+
+function _userGroup_GetFlagStatus( $status, $flag ) {
+	return $status & (1 << $flag);
+}
+
+function _userGroup_GetUpdatedFlagStatusAdd( $status, $flag ) {
+	return $status | (1 << $flag);
+}
+
+function _userGroup_GetUpdatedFlagStatusRemove( $status, $flag ) {
+	return $status & (~(1 << $flag));
+}
+
+function _userGroup_GetById( $id, $query_suffix = ";" ) {
+	$ret = db_QueryFetchFirst(
+		"SELECT user_group
+		FROM ".SH_TABLE_PREFIX.SH_TABLE_USER."
+		WHERE id=?
+		LIMIT 1".$query_suffix,
+		$id
+	);
+	return db_ParseRow($ret, _SH_USER_ROW_MAP);
+}
+
+function userGroup_GetStatusCodeFromFlags( ...$flags ) {
+	$status = 0;
+	foreach ($flags as $flag) {
+		$status = _userGroup_GetUpdatedFlagStatusAdd($flag);
+	}
+	return $status;
+}
+
+function userGroup_GetUserHasStatus( $id, $userGroupStatus ) {
+	$data = _userGroup_GetById($id);
+	if ($data && isset($data['user_group'])) {
+		return _userGroup_GetFlagStatus($data['user_group'], $userGroupStatus);
+	}
+	return false;
+}
+
+function userGroup_SetUserStatusAdd( $id, $flag ) {
+	$data = _userGroup_GetById( $id );
+	$status = 0;
+	if ($data && isset($data['user_group'])) {
+		$status = $data['user_group'];
+	}
+	$status = _userGroup_GetUpdatedFlagStatusAdd($status, $flag);
+	return db_QueryUpdate(
+		"UPDATE ".SH_TABLE_PREFIX.SH_TABLE_USER."
+		SET
+			user_group=?
+		WHERE
+			id=?;",
+		$status, $id
+	);
+}
+
+function userGroup_SetUserStatusRemove( $id, $flag ) {
+	$data = _userGroup_GetById( $id );
+	$status = 0;
+	if ($data && isset($data['user_group'])) {
+		$status = $data['user_group'];
+	}
+	$status = _userGroup_GetUpdatedFlagStatusRemove($status, $flag);
+	return db_QueryUpdate(
+		"UPDATE ".SH_TABLE_PREFIX.SH_TABLE_USER."
+		SET
+			user_group=?
+		WHERE
+			id=?;",
+		$status, $id
+	);
+}
+
+?>

--- a/src/shrub/src/user/user_group.php
+++ b/src/shrub/src/user/user_group.php
@@ -57,12 +57,24 @@ function userGroup_GetUserStatusNames( $node_id ) {
 	return $names;
 }
 
-function userGroup_GetUserHasStatus( $node_id, $userGroupStatus ) {
+function userGroup_GetUserHasStatus( $node_id, ...$userGroupStatus ) {
+	$multi = is_array($userGroupStatus);
+	if (!$multi) {
+		$userGroupStatus = [$userGroupStatus];
+	}	
 	$data = _userGroup_GetByNode($node_id);
-	if ($data && isset($data['user_group'])) {
-		return _userGroup_GetFlagStatus($data['user_group'], $userGroupStatus);
+	$status = $data && isset($data['user_group']) ? $data['user_group'] : 0;
+	$ret = [];
+	foreach ($userGroupStatus as $statusFlag) {
+		 $ret[] = _userGroup_GetFlagStatus($data['user_group'], $statusFlag);
 	}
-	return false;
+	if ($multi) {
+		return $ret;
+	}
+	else {
+		$ret[0];
+	}
+	
 }
 
 function userGroup_SetUserStatusAdd( $node_id, $flag ) {


### PR DESCRIPTION
This adds the ability to post news (if you have privileges for it), from new news feed.

![ldmakenews](https://user-images.githubusercontent.com/8041100/34321069-991aa10a-e806-11e7-8ef6-d4bf62345c5b.gif)

## Important!

The `sh_user` table needs updating. And I don't fully understand the `table_create.php` files so I left it out. It doesn't have to be `SMALLINT`  but I think it ought to be sufficient with 16 combinatorial categories.

```
ALTER TABLE `sh_user` ADD `user_group` SMALLINT UNSIGNED NOT NULL DEFAULT '0' AFTER `last_auth`;
```

## Things to consider

* Currently posting to current event is disabled because I don't know how to validate a particular node as current event on the end-point.
* I didn't dare mess with current db-calls so the user post is gotten more times than is strictly needed in some scenarios.
* The user group belonging is public
* The only way to put a user in the "can post general news"-group is to update the `user_group` value of that user in the database. To have general news rights (but no other group belongings) set value to 64 or you can use `userGroup_GetStatusCodeFromFlags` passing in the group constants that the user should have and it returns the correct value.

