### PR TITLE
Autocomplete!

### DIFF
--- a/src/com/content-comments/comment-autocomplete.js
+++ b/src/com/content-comments/comment-autocomplete.js
@@ -2,19 +2,69 @@ import {h, Component} 				from 'preact/preact';
 import UIButton						from 'com/ui/button/button';
 
 class Autocompletions extends Component {
-	componentWillReceiveProps(nextProps) {
+	constructor(props) {
+		super(props);
+		this.onKeyUp = this.onKeyUp.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
+		//this.handleAbort = this.handleAbort.bind(this);
+		//this.updateSelected = this.updateSelected.bind(this);
+		//this.selectSelected = this.selectSelected.bind(this);
+		//this.removeCharacter = this.removeCharacter.bind(this);
+		//this.updateText = this.updateText.bind(this);
+	}
+
+	onKeyDown( e ) {
+		e.preventDefault();
+		switch (e.key) {
+			case "Shift":
+				this.setState({'shiftKey': true});
+				break;
+			default:
+				this.updateText(e.key, this.state.shiftKey);
+		}
+		return false;
+	}
+
+	onKeyUp( e ) {
+		//console.log("Key Event", this, e);
+		e.preventDefault();
+		switch (e.key) {
+			case "Escape":
+				this.handleAbort();
+				return false;
+			case "ArrowUp":
+				this.updateSelected(-1);
+				return false;
+			case "ArrowDown":
+				this.updateSelected(1);
+				return false;
+			case "Enter":
+				this.selectSelected();
+				return false;
+			case "Shift":
+				this.setState({'shiftKey': false});
+				return false;
+			case "Backspace":
+				this.removeCharacter();
+				return false;
+			default:
+				return false;
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
 		let {text, cursorPos} = nextProps;
 		//console.log('New props', nextProps);
 		if (text) {
 			cursorPos = cursorPos ? cursorPos : 0;
-			const {startPattern, endPattern} = this.state;
-			const left = text.slice(0, cursorPos).match(startPattern);
-			const right = text.slice(cursorPos).match(endPattern);
-			if (left) {
+			const matchObj = this.getMatch(text, cursorPos);
+			if (matchObj) {
 				this.setState({
-					'match': left[2] + right[0],
-					'matchStart': cursorPos - left[2].length,
-					'matchEnd': cursorPos + right[0].length,
+					'text': text,
+					'cursorPos': cursorPos,
+					'match': matchObj.match,
+					'matchStart': matchObj.matchStart,
+					'matchEnd': matchObj.matchEnd,
 				});
 			}
 			else {
@@ -26,7 +76,73 @@ class Autocompletions extends Component {
 		}
 	}
 
-	handleSelect(item, e) {
+	getMatch( text, cursorPos ) {
+		const {startPattern, endPattern} = this.state;
+		const left = text.slice(0, cursorPos).match(startPattern);
+		if (!left) {
+			return null;
+		}
+		const right = text.slice(cursorPos).match(endPattern);
+		return {
+			'match': left[2] + right[0],
+			'matchStart': cursorPos - left[2].length,
+			'matchEnd': cursorPos + right[0].length,
+		};
+	}
+
+	removeCharacter() {
+		const {text, cursorPos, matchStart, matchEnd} = this.state;
+		const {onSelect} = this.props;
+		const updatedText = text.slice(0, cursorPos - 1) + text.slice(cursorPos);
+		if (cursorPos - 1 == matchStart) {
+			if (onSelect) {
+				onSelect(updatedText, cursorPos - 1);
+			}
+		}
+		else {
+			const matchObj = this.getMatch(updatedText, cursorPos);
+			this.setState({'text': updatedText, 'cursorPos': cursorPos - 1, 'match': matchObj.match, 'matchEnd': matchObj.matchEnd});
+		}
+	}
+
+	updateText( key, hasShift ) {
+		if (key.length == 1) {
+			const {text, cursorPos, matchEnd} = this.state;
+			const updatedText = text.slice(0, cursorPos) + (hasShift ? key.toUpperCase() : key) + text.slice(cursorPos);
+			const matchObj = this.getMatch(updatedText, cursorPos);
+			this.setState({'text': updatedText, 'cursorPos': cursorPos + 1, 'match': matchObj.match, 'matchEnd': matchObj.matchEnd});
+		}
+	}
+
+	selectSelected() {
+		const {text, cursorPos, match, matchStart, matchEnd} = this.state;
+		const {onSelect} = this.props;
+		let {selected} = this.state;
+		if (!selected) {
+			selected = this.getMatching(match).sort((a, b) => b.score - a.score)[0].name;
+		}
+		const updatedText = text.slice(0, matchStart) + selected + text.slice(matchEnd);
+		this.setState({'text': updatedText});
+		if (onSelect) {
+			onSelect(updatedText, cursorPos + selected.length);
+		}
+
+	}
+
+	updateSelected(indexChange) {
+
+	}
+
+	handleAbort() {
+		const {text, cursorPos, match} = this.state;
+		const {onSelect} = this.props;
+		this.setState({'selected': match});
+		if (onSelect) {
+			onSelect(text, cursorPos);
+		}
+	}
+
+	handleSelect( item, e ) {
 		/* Bind per element so that the match/item is the first argument.
 		*/
 		const {onSelect, text} = this.props;
@@ -42,7 +158,7 @@ class Autocompletions extends Component {
 		}
 	}
 
-	getMatching(hint) {
+	getMatching( hint ) {
 		/* Should return an array of objects that contains the
 		fields `name` and `score`. Could have more fields if useful for the render function and callbacks.
 		Name should be the exact word that is expected to be written in
@@ -69,8 +185,21 @@ class Autocompletions extends Component {
 				}
 			}
 			if (selected ? matches.length > 1 || (matches.length == 1 && matches[0].length != selected) : matches.length > 0) {
-				return <div class={cN("-auto-complete", props.class)}>{matches.map((m, i) => this.renderSuggestion(m, i == selectedIndex ? '-selected' : ''))}</div>;
+				return (
+					<div class={cN("-auto-complete", props.class)} tabindex="0" ref={(elem) => this.autocompleteContainer = elem}>
+						{matches.map((m, i) => this.renderSuggestion(m, i == selectedIndex ? '-selected' : ''))}
+					</div>
+				);
 			}
+		}
+	}
+
+	componentDidUpdate() {
+		if (this.autocompleteContainer && !this.autocompleteContainer.onkeyup) {
+			this.autocompleteContainer.onkeyup = this.onKeyUp;
+			this.autocompleteContainer.onkeydown = this.onKeyDown;
+			this.autocompleteContainer.focus();
+			//console.log(this.autocompleteContainer, this.autocompleteContainer.focus);
 		}
 	}
 }
@@ -106,6 +235,20 @@ export class AutocompleteAtNames extends Autocompletions {
 	}
 
 	renderSuggestion(item, classModifier) {
-		return <UIButton key={item.name} class={cN(classModifier)} onclick={this.handleSelect.bind(this, item)}>{item.name}</UIButton>;
+		let {match} = this.state;
+		match = match.substr(1);
+		let ShowLeft = null;
+		let ShowMatch = null;
+		let ShowRight = null;
+		if (match.length) {
+			const matchStart = item.name.indexOf(match);
+			ShowLeft = item.name.substr(0, matchStart);
+			ShowMatch = <b>{match}</b>;
+			ShowRight = item.name.substr(matchStart + match.length);
+		}
+		else {
+			ShowLeft = item.name;
+		}
+		return <UIButton key={item.name} class={cN(classModifier)} onclick={this.handleSelect.bind(this, item)}>{ShowLeft}{ShowMatch}{ShowRight}</UIButton>;
 	}
 }

--- a/src/com/content-comments/comment-autocomplete.js
+++ b/src/com/content-comments/comment-autocomplete.js
@@ -1,0 +1,111 @@
+import {h, Component} 				from 'preact/preact';
+import UIButton						from 'com/ui/button/button';
+
+class Autocompletions extends Component {
+	componentWillReceiveProps(nextProps) {
+		let {text, cursorPos} = nextProps;
+		//console.log('New props', nextProps);
+		if (text) {
+			cursorPos = cursorPos ? cursorPos : 0;
+			const {startPattern, endPattern} = this.state;
+			const left = text.slice(0, cursorPos).match(startPattern);
+			const right = text.slice(cursorPos).match(endPattern);
+			if (left) {
+				this.setState({
+					'match': left[2] + right[0],
+					'matchStart': cursorPos - left[2].length,
+					'matchEnd': cursorPos + right[0].length,
+				});
+			}
+			else {
+				this.setState({'match': null});
+			}
+		}
+		else {
+			this.setState({'match': null});
+		}
+	}
+
+	handleSelect(item, e) {
+		/* Bind per element so that the match/item is the first argument.
+		*/
+		const {onSelect, text} = this.props;
+		const {matchStart, matchEnd} = this.state;
+		const updatedText = text.slice(0, matchStart) + item.name + text.slice(matchEnd);
+		this.setState({
+			'selected': item.name,
+			'match': item.name,
+			'text': updatedText,
+		});
+		if (onSelect) {
+			onSelect(updatedText);
+		}
+	}
+
+	getMatching(hint) {
+		/* Should return an array of objects that contains the
+		fields `name` and `score`. Could have more fields if useful for the render function and callbacks.
+		Name should be the exact word that is expected to be written in
+		the input if option is selected.
+		*/
+		return [];
+	}
+
+	renderSuggestion(item, classModifier) {
+		/* Should return a JSX element rendering the option
+		*/
+		return null;
+	}
+
+	render( props, state ) {
+		const {selected, match} = state;
+		if (match && match != selected) {
+			const matches = this.getMatching(match).sort((a, b) => b.score - a.score);
+			let selectedIndex = 0;
+			if (selected) {
+				const selectedMatch = matches.map((m, i) => [m, i]).filter(m => m[0].name == selected);
+				if (selectedMatch.length == 1) {
+					selectedIndex = selectedMatch[0][1];
+				}
+			}
+			if (selected ? matches.length > 1 || (matches.length == 1 && matches[0].length != selected) : matches.length > 0) {
+				return <div class={cN("-auto-complete", props.class)}>{matches.map((m, i) => this.renderSuggestion(m, i == selectedIndex ? '-selected' : ''))}</div>;
+			}
+		}
+	}
+}
+
+export class AutocompleteAtNames extends Autocompletions {
+	constructor(props) {
+		super(props);
+		this.state = {
+			'startPattern': /([\s ]|^)(@[A-Za-z-_0-9]*)$/,
+			'endPattern': /^[A-Za-z-_0-9]*/,
+		};
+	}
+
+	getMatching(hint) {
+		const {authors} = this.props;
+		const matches = [];
+		const hintWithoutAt = hint.substr(1);
+		if (authors) {
+			for (let author in authors) {
+				const authorData = authors[author];
+				const matchStart = authorData.name.indexOf(hintWithoutAt);
+				if (hint.length == 0 || matchStart > -1) {
+					let score = matchStart == 0 ? 1 : 0.5;
+					score = Math.pow(hint.length / authorData.name.length, score);
+					matches.push({
+						'name': '@' + authorData.name,
+						'score': score,
+					});
+				}
+			}
+		}
+		return matches;
+	}
+
+	renderSuggestion(item, classModifier) {
+		return <UIButton key={item.name} class={cN(classModifier)} onclick={this.handleSelect.bind(this, item)}>{item.name}</UIButton>;
+	}
+}

--- a/src/com/content-comments/comment-autocomplete.js
+++ b/src/com/content-comments/comment-autocomplete.js
@@ -38,7 +38,7 @@ class Autocompletions extends Component {
 			'text': updatedText,
 		});
 		if (onSelect) {
-			onSelect(updatedText);
+			onSelect(updatedText, matchStart + item.name.length);
 		}
 	}
 

--- a/src/com/content-comments/comment-autocomplete.js
+++ b/src/com/content-comments/comment-autocomplete.js
@@ -69,7 +69,7 @@ class Autocompletions extends Component {
 		const {onSelect} = this.props;
 		let {selected} = this.state;
 		if (!selected) {
-			selected = this.getMatching(match).sort((a, b) => b.score - a.score)[0].name;
+			selected = this.getOptions(match).sort((a, b) => b.score - a.score)[0].name;
 		}
 		const updatedText = text.slice(0, matchStart) + selected + text.slice(matchEnd);
 		this.setState({'text': updatedText});

--- a/src/com/content-comments/comment-autocomplete.js
+++ b/src/com/content-comments/comment-autocomplete.js
@@ -178,7 +178,8 @@ export class AutocompleteEmojis extends Autocompletions {
 		this.state = {
 			'name': 'emojis',
 			'startPattern': /([\s ]|^)(:[A-Za-z_0-9]*)$/,
-			'endPattern': /^[A-Za-z-_0-9]*/,
+			'endPattern': /^[A-Za-z-_0-9]*:?/,
+			'maxItems': 16,
 		};
 	}
 
@@ -231,7 +232,7 @@ export class AutocompleteAtNames extends Autocompletions {
 		this.state = {
 			'name': 'at-names',
 			'startPattern': /([\s ]|^)(@[A-Za-z-_0-9]*)$/,
-			'endPattern': /^[A-Za-z-_0-9]*:?/,
+			'endPattern': /^[A-Za-z-_0-9]*/,
 			'maxItems': 8,
 		};
 	}

--- a/src/com/content-comments/comment-autocomplete.js
+++ b/src/com/content-comments/comment-autocomplete.js
@@ -94,12 +94,7 @@ class Autocompletions extends Component {
 	}
 
 	handleAbort() {
-		const {text, cursorPos, match} = this.state;
-		const {onSelect} = this.props;
-		this.setState({'selected': match});
-		if (onSelect) {
-			onSelect(text, cursorPos);
-		}
+		this.setState({'selected': this.state.match});
 	}
 
 	handleSelect( item, e ) {
@@ -160,7 +155,7 @@ class Autocompletions extends Component {
 			if (options.length > 0 && !selected) {
 				selected = options[0].name;
 			}
-			if (selected ? options.length > 1 || (options.length == 1 && options[0].name != match) : options.length > 0) {
+			if (selected ? options.length > 1 || (options.length == 1 && options[0].name != match && match != selected) : options.length > 0) {
 				props.captureKeyDown(name, this.onKeyDown);
 				return (
 					<div class={cN("-auto-complete", props.class)}>

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -146,13 +146,13 @@ export default class ContentCommentsComment extends Component {
 		}
 	}
 
-	onAutocompleteSelect(replaceText) {
+	onAutocompleteSelect(replaceText, cursorPosAfterUpdate) {
+		this.props.comment.body = replaceText;
 		this.setState({
 			'editText': replaceText,
 			'replaceText': replaceText,
-			'cursorPos': 0, //TODO: fix
+			'cursorPos': cursorPosAfterUpdate,
 		});
-		
 	}
 
 	render( props, state ) {
@@ -306,7 +306,7 @@ export default class ContentCommentsComment extends Component {
 						{ShowError}
 						<div class="-text">
 							<div class="-title">{ShowTitle}</div>
-							<ContentCommentsMarkup user={user} editing={state.editing && !state.preview} onmodify={this.onModify} placeholder="type a comment here" limit={props.limit} replaceText={state.replaceText}>{comment.body}</ContentCommentsMarkup>
+							<ContentCommentsMarkup user={user} editing={state.editing && !state.preview} onmodify={this.onModify} placeholder="type a comment here" limit={props.limit} replaceText={state.replaceText} cursorPos={state.cursorPos}>{comment.body}</ContentCommentsMarkup>
 						</div>
 						{ShowBottomNav}
 					</div>

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -50,6 +50,7 @@ export default class ContentCommentsComment extends Component {
 
 		this.onTextAreaBlur = this.onTextAreaBlur.bind(this);
 		this.onTextAreaFocus = this.onTextAreaFocus.bind(this);
+		this.onTextAreaCaret = this.onTextAreaCaret.bind(this);
 
 		this.onAutocompleteSelect = this.onAutocompleteSelect.bind(this);
 		this.onAutoselectCaptureKeyDown = this.onAutoselectCaptureKeyDown.bind(this);
@@ -109,6 +110,11 @@ export default class ContentCommentsComment extends Component {
 
 	onTextAreaBlur( e ) {
 		this.setState({'textareaFocus': false});
+		return true;
+	}
+
+	onTextAreaCaret( e ) {
+		this.setState({'editCursorPos': e.target.selectionStart});
 		return true;
 	}
 
@@ -384,6 +390,7 @@ export default class ContentCommentsComment extends Component {
 								onkeyup={this.onKeyUp}
 								onfocus={this.onTextAreaFocus}
 								onblur={this.onTextAreaBlur}
+								oncaret={this.onTextAreaCaret}
 								placeholder="type a comment here"
 								limit={props.limit}
 								replaceText={state.replaceText}

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -8,7 +8,7 @@ import SVGIcon 							from 'com/svg-icon/icon';
 import IMG2 							from 'com/img2/img2';
 
 import ContentCommentsMarkup			from 'comments-markup';
-import {AutocompleteAtNames}			from 'comment-autocomplete';
+import {AutocompleteAtNames, AutocompleteEmojis}			from 'comment-autocomplete';
 import $Note							from '../../shrub/js/note/note';
 import $NoteLove						from '../../shrub/js/note/note_love';
 
@@ -109,7 +109,7 @@ export default class ContentCommentsComment extends Component {
 	}
 
 	onTextAreaBlur( e ) {
-		this.setState({'textareaFocus': false});
+		//this.setState({'textareaFocus': false});
 		return true;
 	}
 
@@ -362,8 +362,17 @@ export default class ContentCommentsComment extends Component {
 			}
 
 			let ShowAutocompleteAt = null;
+			let ShowAutocompleteEmoji = null;
 			if (state.textareaFocus) {
 				ShowAutocompleteAt = <AutocompleteAtNames
+					text={state.editText}
+					cursorPos={state.editCursorPos}
+					authors={props.authors}
+					onSelect={this.onAutocompleteSelect}
+					captureKeyDown={this.onAutoselectCaptureKeyDown}
+					captureKeyUp={this.onAutoselectCaptureKeyUp}
+				/>;
+				ShowAutocompleteEmoji = <AutocompleteEmojis
 					text={state.editText}
 					cursorPos={state.editCursorPos}
 					authors={props.authors}
@@ -377,6 +386,7 @@ export default class ContentCommentsComment extends Component {
 				<div id={"comment-"+comment.id} class={"-item -comment -indent-"+props.indent}>
 					{ShowAvatar}
 					{ShowAutocompleteAt}
+					{ShowAutocompleteEmoji}
 					<div class="-body">
 						{ShowTopNav}
 						{ShowError}

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -8,7 +8,7 @@ import SVGIcon 							from 'com/svg-icon/icon';
 import IMG2 							from 'com/img2/img2';
 
 import ContentCommentsMarkup			from 'comments-markup';
-
+import {AutocompleteAtNames}			from 'comment-autocomplete';
 import $Note							from '../../shrub/js/note/note';
 import $NoteLove						from '../../shrub/js/note/note_love';
 
@@ -43,6 +43,7 @@ export default class ContentCommentsComment extends Component {
 		this.onLove = this.onLove.bind(this);
 		this.onReply = this.onReply.bind(this);
 		this.onSubscribe = this.onSubscribe.bind(this);
+		this.onAutocompleteSelect = this.onAutocompleteSelect.bind(this);
 	}
 
 	onEditing( e ) {
@@ -59,8 +60,14 @@ export default class ContentCommentsComment extends Component {
 	}
 
 	onModify( e ) {
+		//console.log('modified', e);
 		this.props.comment.body = e.target.value;
-		this.setState({'modified': this.canSave()});
+		this.setState({
+			'modified': this.canSave(),
+			'editText': e.target.value,
+			'editCursorPos': e.target.selectionStart,
+			'replaceText': null,
+		});
 	}
 
 	onCancel( e ) {
@@ -137,6 +144,15 @@ export default class ContentCommentsComment extends Component {
 		if ( this.props.onsubscribe ) {
 			this.props.onsubscribe(e, this.props.cansubscribe);
 		}
+	}
+
+	onAutocompleteSelect(replaceText) {
+		this.setState({
+			'editText': replaceText,
+			'replaceText': replaceText,
+			'cursorPos': 0, //TODO: fix
+		});
+		
 	}
 
 	render( props, state ) {
@@ -284,12 +300,13 @@ export default class ContentCommentsComment extends Component {
 			return (
 				<div id={"comment-"+comment.id} class={"-item -comment -indent-"+props.indent}>
 					{ShowAvatar}
+					<AutocompleteAtNames text={state.editText} cursorPos={state.editCursorPos} authors={props.authors} onSelect={this.onAutocompleteSelect}/>
 					<div class="-body">
 						{ShowTopNav}
 						{ShowError}
 						<div class="-text">
 							<div class="-title">{ShowTitle}</div>
-							<ContentCommentsMarkup user={user} editing={state.editing && !state.preview} onmodify={this.onModify} placeholder="type a comment here" limit={props.limit}>{comment.body}</ContentCommentsMarkup>
+							<ContentCommentsMarkup user={user} editing={state.editing && !state.preview} onmodify={this.onModify} placeholder="type a comment here" limit={props.limit} replaceText={state.replaceText}>{comment.body}</ContentCommentsMarkup>
 						</div>
 						{ShowBottomNav}
 					</div>

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -109,7 +109,7 @@ export default class ContentCommentsComment extends Component {
 	}
 
 	onTextAreaBlur( e ) {
-		//this.setState({'textareaFocus': false});
+		this.setState({'textareaFocus': false});
 		return true;
 	}
 

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -33,7 +33,6 @@ export default class ContentCommentsComment extends Component {
 		this.onPreview = this.onPreview.bind(this);
 
 		this.onModify = this.onModify.bind(this);
-
 		this.onEdit = this.onEdit.bind(this);
 
 		this.onSave = this.onSave.bind(this);
@@ -300,7 +299,7 @@ export default class ContentCommentsComment extends Component {
 			return (
 				<div id={"comment-"+comment.id} class={"-item -comment -indent-"+props.indent}>
 					{ShowAvatar}
-					<AutocompleteAtNames text={state.editText} cursorPos={state.editCursorPos} authors={props.authors} onSelect={this.onAutocompleteSelect}/>
+					<AutocompleteAtNames text={state.editText} cursorPos={state.editCursorPos} authors={props.authors} onSelect={this.onAutocompleteSelect} />
 					<div class="-body">
 						{ShowTopNav}
 						{ShowError}

--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -48,6 +48,9 @@ export default class ContentCommentsComment extends Component {
 		this.onReply = this.onReply.bind(this);
 		this.onSubscribe = this.onSubscribe.bind(this);
 
+		this.onTextAreaBlur = this.onTextAreaBlur.bind(this);
+		this.onTextAreaFocus = this.onTextAreaFocus.bind(this);
+
 		this.onAutocompleteSelect = this.onAutocompleteSelect.bind(this);
 		this.onAutoselectCaptureKeyDown = this.onAutoselectCaptureKeyDown.bind(this);
 		this.onAutoselectCaptureKeyUp = this.onAutoselectCaptureKeyUp.bind(this);
@@ -96,6 +99,16 @@ export default class ContentCommentsComment extends Component {
 				return false;
 			}
 		}
+		return true;
+	}
+
+	onTextAreaFocus( e ) {
+		this.setState({'textareaFocus': true});
+		return true;
+	}
+
+	onTextAreaBlur( e ) {
+		this.setState({'textareaFocus': false});
 		return true;
 	}
 
@@ -342,23 +355,42 @@ export default class ContentCommentsComment extends Component {
 				ShowAvatar = <div class="-avatar"><IMG2 src={Avatar} /></div>;
 			}
 
+			let ShowAutocompleteAt = null;
+			if (state.textareaFocus) {
+				ShowAutocompleteAt = <AutocompleteAtNames
+					text={state.editText}
+					cursorPos={state.editCursorPos}
+					authors={props.authors}
+					onSelect={this.onAutocompleteSelect}
+					captureKeyDown={this.onAutoselectCaptureKeyDown}
+					captureKeyUp={this.onAutoselectCaptureKeyUp}
+				/>;
+			}
+
 			return (
 				<div id={"comment-"+comment.id} class={"-item -comment -indent-"+props.indent}>
 					{ShowAvatar}
-					<AutocompleteAtNames
-						text={state.editText}
-						cursorPos={state.editCursorPos}
-						authors={props.authors}
-						onSelect={this.onAutocompleteSelect}
-						captureKeyDown={this.onAutoselectCaptureKeyDown}
-						captureKeyUp={this.onAutoselectCaptureKeyUp}
-					/>
+					{ShowAutocompleteAt}
 					<div class="-body">
 						{ShowTopNav}
 						{ShowError}
 						<div class="-text">
 							<div class="-title">{ShowTitle}</div>
-							<ContentCommentsMarkup user={user} editing={state.editing && !state.preview} onmodify={this.onModify} onkeydown={this.onKeyDown} onkeyup={this.onKeyUp} placeholder="type a comment here" limit={props.limit} replaceText={state.replaceText} cursorPos={state.cursorPos}>{comment.body}</ContentCommentsMarkup>
+							<ContentCommentsMarkup
+								user={user}
+								editing={state.editing && !state.preview}
+								onmodify={this.onModify}
+								onkeydown={this.onKeyDown}
+								onkeyup={this.onKeyUp}
+								onfocus={this.onTextAreaFocus}
+								onblur={this.onTextAreaBlur}
+								placeholder="type a comment here"
+								limit={props.limit}
+								replaceText={state.replaceText}
+								cursorPos={state.cursorPos}
+							>
+								{comment.body}
+							</ContentCommentsMarkup>
 						</div>
 						{ShowBottomNav}
 					</div>

--- a/src/com/content-comments/comments-markup.js
+++ b/src/com/content-comments/comments-markup.js
@@ -38,6 +38,7 @@ export default class ContentCommentsMarkup extends Component {
 						value={Text}
 						onmodify={props.onmodify}
 						placeholder={props.placeholder}
+						replaceText={props.replaceText}
 						ref={(input) => { this.textarea = input; }}
 						maxlength={Limit}
 					/>

--- a/src/com/content-comments/comments-markup.js
+++ b/src/com/content-comments/comments-markup.js
@@ -1,5 +1,5 @@
-import { h, Component } 				from 'preact/preact';
-import { shallowDiff }	 				from 'shallow-compare/index';
+import {h, Component} 				from 'preact/preact';
+import {shallowDiff}	 				from 'shallow-compare/index';
 
 import NavLink							from 'com/nav-link/link';
 import SVGIcon							from 'com/svg-icon/icon';
@@ -37,6 +37,8 @@ export default class ContentCommentsMarkup extends Component {
 						user={props.user}
 						value={Text}
 						onmodify={props.onmodify}
+						onkeydown={props.onkeydown}
+						onkeyup={props.onkeyup}
 						placeholder={props.placeholder}
 						replaceText={props.replaceText}
 						cursorPos={props.cursorPos}

--- a/src/com/content-comments/comments-markup.js
+++ b/src/com/content-comments/comments-markup.js
@@ -41,6 +41,7 @@ export default class ContentCommentsMarkup extends Component {
 						onkeyup={props.onkeyup}
 						onblur={props.onblur}
 						onfocus={props.onfocus}
+						oncaret={props.oncaret}
 						placeholder={props.placeholder}
 						replaceText={props.replaceText}
 						cursorPos={props.cursorPos}

--- a/src/com/content-comments/comments-markup.js
+++ b/src/com/content-comments/comments-markup.js
@@ -39,6 +39,8 @@ export default class ContentCommentsMarkup extends Component {
 						onmodify={props.onmodify}
 						onkeydown={props.onkeydown}
 						onkeyup={props.onkeyup}
+						onblur={props.onblur}
+						onfocus={props.onfocus}
 						placeholder={props.placeholder}
 						replaceText={props.replaceText}
 						cursorPos={props.cursorPos}

--- a/src/com/content-comments/comments-markup.js
+++ b/src/com/content-comments/comments-markup.js
@@ -39,6 +39,7 @@ export default class ContentCommentsMarkup extends Component {
 						onmodify={props.onmodify}
 						placeholder={props.placeholder}
 						replaceText={props.replaceText}
+						cursorPos={props.cursorPos}
 						ref={(input) => { this.textarea = input; }}
 						maxlength={Limit}
 					/>

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -1,4 +1,4 @@
-import { h, Component } 				from 'preact/preact';
+import {h, Component} 				from 'preact/preact';
 
 import NavSpinner						from 'com/nav-spinner/spinner';
 
@@ -29,7 +29,6 @@ export default class ContentComments extends Component {
 
 	componentWillMount() {
 		this.getComments(this.props.node);
-		console.log(this.props.node);
 	}
 
 	genComment() {
@@ -135,8 +134,8 @@ export default class ContentComments extends Component {
 	}
 
 	getAuthors() {
-		var user = this.props.user;
-		var comments = this.state.comments;
+		const {user, node} = this.props;
+		const comments = this.state.comments;
 
 		if ( comments ) {
 			var Authors = [];
@@ -150,18 +149,28 @@ export default class ContentComments extends Component {
 			if ( user && user.id ) {
 				Authors.push(user.id);
 			}
+
+			// Add authors from node
+			if (node.meta && node.meta.authors) {
+				node.meta.authors.forEach((author) => Authors.push(author));
+			}
+			else if (node) {
+				Authors.push(node.author);
+			}
+
 			// http://stackoverflow.com/a/23282067/5678759
 			// Remove Duplicates
-			Authors = Authors.filter(function(item, i, ar){ return ar.indexOf(item) === i; });
+			// Skip anonymous comments (user 0)
+			Authors = Authors.filter((item, i, ar) => ar.indexOf(item) === i && item > 0);
 
 			// Fetch authors
 
 			return $Node.GetKeyed( Authors )
 			.then(r => {
-				this.setState({ 'authors': r.node });
+				this.setState({'authors': r.node});
 			})
 			.catch(err => {
-				this.setState({ 'error': err });
+				this.setState({'error': err});
 			});
 		}
 	}
@@ -185,7 +194,8 @@ export default class ContentComments extends Component {
 
 			if ( tree[item].child ) {
 				ret.push(<ContentCommentsComment user={user} comment={comment} author={author} indent={indent}><div class="-indent">{this.renderComments(tree[item].child, indent+1)}</div></ContentCommentsComment>);
-			} else {
+			}
+			else {
 				ret.push(<ContentCommentsComment user={user} comment={comment} author={author} indent={indent}/>);
 			}
 		}
@@ -210,7 +220,7 @@ export default class ContentComments extends Component {
 	onPublish( e, publishAnon ) {
 		const node = this.props.node;
 		const newcomment = this.state.newcomment;
-		this.setState({'error': null });
+		this.setState({'error': null});
 
 		$Note.Add( newcomment.parent, newcomment.node, newcomment.body, null, publishAnon )
 		.then(r => {
@@ -275,7 +285,7 @@ export default class ContentComments extends Component {
 		}
 
 		return (
-			<div class={['content-base','content-common','content-comments',props['no_gap']?'-no-gap':'',props['no_header']?'-no-header':'']}>
+			<div class={['content-base', 'content-common', 'content-comments', props['no_gap'] ? '-no-gap' : '', props['no_header'] ? '-no-header' : '']}>
 				<div class="-headline">COMMENTS</div>
 				{ShowComments}
 				{ShowPostNew}

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -203,7 +203,7 @@ export default class ContentComments extends Component {
 		// We can subscribe if we haven't subscribed and we don't have a comment in this thread, and we're not an author. Otherwise we can unsubscribe.
 		let canSubscribe = (this.state.subscribed === null) ? !( this.state.hascomment || this.state.isauthor ) : !this.state.subscribed;
 
-		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} cansubscribe={canSubscribe} onsubscribe={this.onSubscribe} /></div>;
+		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} cansubscribe={canSubscribe} onsubscribe={this.onSubscribe} authors={authors}/></div>;
 	}
 
 	onPublish( e, publishAnon ) {

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -29,6 +29,7 @@ export default class ContentComments extends Component {
 
 	componentWillMount() {
 		this.getComments(this.props.node);
+		console.log(this.props.node);
 	}
 
 	genComment() {

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -19,6 +19,7 @@
 	& .-auto-complete {
 		position: absolute;
 		left: 100px;
+		bottom: 0px;
 		z-index: 500;
 		background: @COL_L;
 		border: 1px solid @COL_NDDD;

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -16,6 +16,23 @@
 	}
 	*/
 
+	& .-auto-complete {
+		position: absolute;
+		left: 100px;
+		z-index: 500;
+		background: @COL_L;
+		border: 1px solid @COL_NDDD;
+
+		& > .-selected {
+			font-weight: bold;
+		}
+
+		& > div {
+			border-top: 1px solid @COL_NDDD;
+			padding: 0.5em;
+		}
+	}
+
 	& .-headline {
 		position: relative;
 

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -17,9 +17,9 @@
 	*/
 
 	& .-auto-complete {
-		position: absolute;
-		left: 100px;
-		bottom: 0px;
+		position: fixed;
+		left: 0.5em;
+		bottom: 0;
 		z-index: 500;
 		background: @COL_L;
 		border: 1px solid @COL_NDDD;

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -32,6 +32,16 @@
 		& > div {
 			border-top: 1px solid @COL_NDDD;
 			padding: 0.5em;
+
+			& .-emoji-autocomplete-markup {
+				display: inline-block;
+				margin-right: 0.5em;
+
+				& > p {
+					margin: 0;
+					padding: 0;
+				}
+			}
 		}
 	}
 

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -24,7 +24,8 @@
 		border: 1px solid @COL_NDDD;
 
 		& > .-selected {
-			font-weight: bold;
+			background: @COL_A;
+			color: @COL_NLLLLL;
 		}
 
 		& > div {

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -27,11 +27,13 @@ export default class InputTextarea extends Component {
 	}
 
 	componentWillReceiveProps(nextProps) {
-		const {replaceText} = nextProps;
+		const {replaceText, cursorPos} = nextProps;
 		this.props.value = replaceText;
 		if (replaceText && this.textarea) {
 			this.textarea.value = replaceText;
 			this.textarea.focus();
+			this.textarea.selectionStart = cursorPos;
+			this.textarea.selectionEnd = cursorPos;
 		}
 	}
 

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -24,6 +24,7 @@ export default class InputTextarea extends Component {
 		this.onFileChange = this.onFileChange.bind(this);
 		this.onBlur = this.onBlur.bind(this);
 		this.onFocus = this.onFocus.bind(this);
+		this.onClick = this.onClick.bind(this);
 	}
 
 	shouldComponentUpdate( nextProps ) {
@@ -139,9 +140,25 @@ export default class InputTextarea extends Component {
 	}
 
 	onKeyDown( e ) {
-		const {onkeydown} = this.props;
+		const {onkeydown, oncaret} = this.props;
 		if (onkeydown && !onkeydown(e)) {
 			e.preventDefault();
+		}
+		else if (oncaret) {
+			switch (e.key) {
+				case "ArrowUp":
+				case "ArrowDown":
+				case "ArrowLeft":
+				case "ArrowRight":
+				case "Home":
+				case "End":
+				case "PageUp":
+				case "PageDown":
+					if (!oncaret(e)) {
+						e.preventDefault();
+					}
+					break;
+			}
 		}
 	}
 
@@ -160,8 +177,18 @@ export default class InputTextarea extends Component {
 	}
 
 	onFocus( e ) {
-		const {onfocus} = this.props;
+		const {onfocus, oncaret} = this.props;
 		if (onfocus && !onfocus(e)) {
+			e.preventDefault();
+		}
+		if (oncaret && !oncaret(e)) {
+			e.preventDefault();
+		}
+	}
+
+	onClick( e ) {
+		const {oncaret} = this.props;
+		if (oncaret && !oncaret(e)) {
 			e.preventDefault();
 		}
 	}
@@ -178,6 +205,7 @@ export default class InputTextarea extends Component {
 						oninput={this.onInput}
 						onkeydown={this.onKeyDown}
 						onkeyup={this.onKeyUp}
+						onclick={this.onClick}
 						ref={(input) => { this.textarea = input; }}
 					/>
 				</div>

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -22,6 +22,8 @@ export default class InputTextarea extends Component {
 		this.onKeyUp = this.onKeyUp.bind(this);
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.onFileChange = this.onFileChange.bind(this);
+		this.onBlur = this.onBlur.bind(this);
+		this.onFocus = this.onFocus.bind(this);
 	}
 
 	shouldComponentUpdate( nextProps ) {
@@ -146,6 +148,20 @@ export default class InputTextarea extends Component {
 	onKeyUp( e ) {
 		const {onkeyup} = this.props;
 		if (onkeyup && !onkeyup(e)) {
+			e.preventDefault();
+		}
+	}
+
+	onBlur( e ) {
+		const {onblur} = this.props;
+		if (onblur && !onblur(e)) {
+			e.preventDefault();
+		}
+	}
+
+	onFocus( e ) {
+		const {onfocus} = this.props;
+		if (onfocus && !onfocus(e)) {
 			e.preventDefault();
 		}
 	}

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -1,4 +1,4 @@
-import { h, Component } 				from 'preact/preact';
+import {h, Component} 				from 'preact/preact';
 import Shallow			 				from 'shallow/shallow';
 
 import NavLink							from 'com/nav-link/link';
@@ -19,6 +19,8 @@ export default class InputTextarea extends Component {
 		};
 
 		this.onInput = this.onInput.bind(this);
+		this.onKeyUp = this.onKeyUp.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
 		this.onFileChange = this.onFileChange.bind(this);
 	}
 
@@ -128,9 +130,23 @@ export default class InputTextarea extends Component {
 			this.props.onmodify(e);
 		}
 
-		if( this.state.microsoftEdge ) {
+		if ( this.state.microsoftEdge ) {
 			e.preventDefault();
 			this.setState({'cursorPos': e.target.selectionEnd});
+		}
+	}
+
+	onKeyDown( e ) {
+		const {onkeydown} = this.props;
+		if (onkeydown && !onkeydown(e)) {
+			e.preventDefault();
+		}
+	}
+
+	onKeyUp( e ) {
+		const {onkeyup} = this.props;
+		if (onkeyup && !onkeyup(e)) {
+			e.preventDefault();
 		}
 	}
 
@@ -144,6 +160,8 @@ export default class InputTextarea extends Component {
 				<div class="-textarea">
 					<textarea {...props}
 						oninput={this.onInput}
+						onkeydown={this.onKeyDown}
+						onkeyup={this.onKeyUp}
 						ref={(input) => { this.textarea = input; }}
 					/>
 				</div>

--- a/src/com/input-textarea/input-textarea.js
+++ b/src/com/input-textarea/input-textarea.js
@@ -26,6 +26,15 @@ export default class InputTextarea extends Component {
 		return Shallow.Diff(this.props, nextProps);
 	}
 
+	componentWillReceiveProps(nextProps) {
+		const {replaceText} = nextProps;
+		this.props.value = replaceText;
+		if (replaceText && this.textarea) {
+			this.textarea.value = replaceText;
+			this.textarea.focus();
+		}
+	}
+
 	resizeTextarea() {
 		// Reference: http://stackoverflow.com/a/18262927/5678759
 		// Reference: https://quirksmode.org/dom/core/


### PR DESCRIPTION
![ld_autocomplete4](https://user-images.githubusercontent.com/8041100/34456015-1d7421e4-ed8c-11e7-97ba-ee52e36a68e8.gif)

This introduces auto-completion thingy for at-names and emojis.

When typing if you start a pattern that matches being an at-name the at-name-autocompleter activates. If you start a pattern of something being an emoji-code that autocompleter activates.

Autocompleters filter their list of known things (`window.emoji.emojiList` or the authors of the node and all the comments) for things that match what has been written. This does not have to be start of name/word. But needs to be exact match (including case).

Autocompleters score matches and shows the best at top.

User can change selected thing to autocomplete by using arrow keys (up / down).
User can select selected thing by pressing enter.

Because there's a lot of work to get overflow of the css not to limit the list extent and to figure out where the caret is in the textarea, I opted for using a fixed position.

Because it felt important that the autocomplete should disappear if you defocus the textarea I opted for not actually allowing mouse clicking on the options.