### PR TITLE
Made simulator put events under correct node

### DIFF
--- a/sandbox/simulator/main
+++ b/sandbox/simulator/main
@@ -100,6 +100,17 @@ define("TOP_STATS",10); // keep top 10 stats
 
 // Figure out event index to use for this run, and start loggers.
 
+$events_root = db_QueryFetch(
+		"SELECT
+			n.id,
+			".DB_FIELD_DATE('n.modified', 'modified')."
+		FROM
+			".SH_TABLE_PREFIX.SH_TABLE_NODE." AS n
+		WHERE n.type = 'events'
+		LIMIT 1
+		;"
+	);
+	
 $events = db_QueryFetch(
 		"SELECT
 			n.id, n.name, n.slug, 
@@ -113,6 +124,7 @@ $events = db_QueryFetch(
 	);
 
 $eventindex = count($events) + 1;
+$eventsId = $events_root[0]['id'];
 
 if($enable_file_logs)
 {

--- a/sandbox/simulator/main
+++ b/sandbox/simulator/main
@@ -100,17 +100,24 @@ define("TOP_STATS",10); // keep top 10 stats
 
 // Figure out event index to use for this run, and start loggers.
 
-$events_root = db_QueryFetch(
+$eventsId = db_QueryFetchValue(
 		"SELECT
-			n.id,
-			".DB_FIELD_DATE('n.modified', 'modified')."
+			n.id
 		FROM
 			".SH_TABLE_PREFIX.SH_TABLE_NODE." AS n
 		WHERE n.type = 'events'
 		LIMIT 1
 		;"
 	);
-	
+
+if ($eventsId == null) {
+	ReportError("Your databases are not correctly setup");
+	print "\n";
+	print "  In the home directory of your scotch box, run db-create.sh\n";
+	print "  Then you can return and simulate an event.\n";
+	exit(1);	
+}
+
 $events = db_QueryFetch(
 		"SELECT
 			n.id, n.name, n.slug, 
@@ -124,7 +131,6 @@ $events = db_QueryFetch(
 	);
 
 $eventindex = count($events) + 1;
-$eventsId = $events_root[0]['id'];
 
 if($enable_file_logs)
 {

--- a/sandbox/simulator/model_default
+++ b/sandbox/simulator/model_default
@@ -156,7 +156,8 @@ function SetupEvent()
 	// Now generate an event
 	global $event_nodeid;
 	global $eventindex;
-	$parentnode = 1; // Future: build out a more complex structure for this test.
+	global $eventsId;
+
 	$author = $event_admin_user["id"];
 	$eventname = "Testumdare " . ($eventindex);  
 	$event_name = $eventname;
@@ -175,7 +176,7 @@ function SetupEvent()
 
 
 	// Create event
-	$event_nodeid = node_Add( $parentnode, $author, "event", "", "", null, $eventname, $eventbody);
+	$event_nodeid = node_Add( $eventsId, $author, "event", "", "", null, $eventname, $eventbody);
 
 	// Add metadata
 	nodeMeta_Add($event_nodeid, 0, SH_SCOPE_PUBLIC, 'event-start', $formatStart);


### PR DESCRIPTION
Before the events didn't end up under the `events` node.

Fixed it.

Tested by running simulator and making sure `/events` listed the event.

Seems fine.