### PR TITLE
Stops travis failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"WARN: no tests specified\" && exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
  You've enabled travis but npm test function fails by default. This should stop travis failing till we add real tests.

#1548