### PR TITLE
Notifications issues

### DIFF
--- a/src/com/content-notifications/base.js
+++ b/src/com/content-notifications/base.js
@@ -346,7 +346,7 @@ export default class NotificationsBase extends Component {
 		return this.state.notificationIds;
 	}
 
-	getNotifications( maxCount ) {
+	getNotifications( maxCount, clickCallback ) {
 		let Notifications = [];
 		const notifications = this.state.notifications;
 		const notificationsOrder = this.getNotificationsOrder();
@@ -355,7 +355,7 @@ export default class NotificationsBase extends Component {
 			notificationsOrder.forEach((id) => {
 				let notification = notifications.get(id);
 				if ( (maxCount > 0) && this.shouldShowNotification(notification) ) {
-					Notifications.push([id, <Notification notification={notification} />]);
+					Notifications.push([id, <Notification notification={notification} onclick={clickCallback} />]);
 					maxCount -= 1;
 				}
 			});

--- a/src/com/content-notifications/notification.js
+++ b/src/com/content-notifications/notification.js
@@ -1,5 +1,6 @@
 import {h, Component}	 				from 'preact/preact';
 import NavLink 							from 'com/nav-link/link';
+import ButtonLink						from 'com/button-link/link';
 import SVGIcon 							from 'com/svg-icon/icon';
 
 
@@ -203,17 +204,17 @@ export default class NotificationItem extends Component {
 			const NoteAuthor = this.getNoteAuthorAsSubjectJSX(notification);
 			const NodeAuthor = this.getNodeAuthorAsObjectJSX(notification);
 			return (
-				<NavLink {...navProps} >
+				<ButtonLink {...navProps} >
 					<SVGIcon>quesition</SVGIcon>{timePrefix} {NoteAuthor} caused unhandled notification {NotificationType} for {NodeAuthor} {NodeType} "<em>{node.name}</em>"
-				</NavLink>
+				</ButtonLink>
 			);
 		}
 		else {
 			const NodeAuthor = this.getNodeAuthorAsSubjectJSX(notification);
 			return (
-				<NavLink {...navProps} >
+				<ButtonLink {...navProps} >
 					<SVGIcon>quesition</SVGIcon>{timePrefix} {NodeAuthor} caused unhandled notification {NotificationType} with their {NodeType} "<em>{node.name}</em>"
-				</NavLink>
+				</ButtonLink>
 			);
 		}
 	}
@@ -224,9 +225,9 @@ export default class NotificationItem extends Component {
 		const {node} = notification;
 
 		return (
-			<NavLink {...navProps} >
+			<ButtonLink {...navProps} >
 				<SVGIcon>bubble-empty</SVGIcon>{timePrefix} {NoteAuthor} commented on your {NodeType} "<em>{node.name}</em>"
-			</NavLink>
+			</ButtonLink>
 		);
 	}
 
@@ -237,9 +238,9 @@ export default class NotificationItem extends Component {
 		const {node, note} = notification;
 
 		return (
-			<NavLink {...navProps} >
+			<ButtonLink {...navProps} >
 				<SVGIcon>{note.length > 1 ? 'bubbles' : 'bubble'}</SVGIcon>{timePrefix} {NoteAuthor} commented on {NodeAuthor} {NodeType} "<em>{node.name}</em>"
-			</NavLink>
+			</ButtonLink>
 		);
 	}
 
@@ -249,9 +250,9 @@ export default class NotificationItem extends Component {
 		const {node} = notification;
 
 		return (
-			<NavLink {...navProps} >
+			<ButtonLink {...navProps} >
 				<SVGIcon>gamepad</SVGIcon> {timePrefix} {NodeAuthor} published a {NodeType} "<em>{node.name}</em>"
-			</NavLink>
+			</ButtonLink>
 		);
 	}
 
@@ -260,9 +261,9 @@ export default class NotificationItem extends Component {
 		const {node} = notification;
 
 		return (
-			<NavLink {...navProps} >
+			<ButtonLink {...navProps} >
 				<SVGIcon>feed</SVGIcon> {timePrefix} {NodeAuthor} posted "<em>{node.name}</em>"
-			</NavLink>
+			</ButtonLink>
 		);
 	}
 
@@ -274,17 +275,17 @@ export default class NotificationItem extends Component {
 			const NoteAuthor = this.getNoteAuthorAsSubjectJSX(notification);
 			const NodeAuthor = this.getNodeAuthorAsObjectJSX(notification);
 			return (
-				<NavLink {...navProps} >
+				<ButtonLink {...navProps} >
 					<SVGIcon>at</SVGIcon> {timePrefix} {NoteAuthor} mentioned you in a comment on {NodeAuthor} {NodeType} "<em>{node.name}</em>"
-				</NavLink>
+				</ButtonLink>
 			);
 		}
 		else {
 			const NodeAuthor = this.getNodeAuthorAsSubjectJSX(notification);
 			return (
-				<NavLink {...navProps} >
+				<ButtonLink {...navProps} >
 					<SVGIcon>at</SVGIcon> {timePrefix} {NodeAuthor} mentioned you in their {NodeType} "<em>{node.name}</em>"
-				</NavLink>
+				</ButtonLink>
 			);
 		}
 	}

--- a/src/com/content-notifications/notification.js
+++ b/src/com/content-notifications/notification.js
@@ -173,7 +173,13 @@ export default class NotificationItem extends Component {
 	getNavProps( props ) {
 		const {notification} = props;
 		const notificationData = notification.notification[0];
-		const navProps = {"href": notification.node.path, "title": ('Notification Id: ' + notificationData.id), "class": props.class, "id": props.id};
+		const navProps = {
+			"href": notification.node.path,
+			"title": ('Notification Id: ' + notificationData.id),
+			"class": props.class,
+			"id": props.id,
+			'onclick': props.onclick,
+		};
 
 		if ( notification.note ) {
 			navProps.href += "#/comment-" + notification.earliestNote;

--- a/src/com/nav-link/link.js
+++ b/src/com/nav-link/link.js
@@ -45,10 +45,6 @@ export default class NavLink extends Component {
 		if (e.shiftKey || e.metaKey || e.ctrlKey || e.altKey)
 			return;
 
-		if (this.props.onclick) {
-			this.props.onclick(e);
-		}
-
 		// Internet Explorer 11 doesn't set the origin, so we need to extract it
 		// Cleverness: we slice at the 1st slash, but offset by length of 'https://' first, so it's after the domain
 		let origin = this.base && (this.base.origin || (this.base.href && this.base.href.slice(0, this.base.href.indexOf('/','https://'.length))));

--- a/src/com/nav-link/link.js
+++ b/src/com/nav-link/link.js
@@ -45,6 +45,10 @@ export default class NavLink extends Component {
 		if (e.shiftKey || e.metaKey || e.ctrlKey || e.altKey)
 			return;
 
+		if (this.props.onclick) {
+			this.props.onclick(e);
+		}
+
 		// Internet Explorer 11 doesn't set the origin, so we need to extract it
 		// Cleverness: we slice at the 1st slash, but offset by length of 'https://' first, so it's after the domain
 		let origin = this.base && (this.base.origin || (this.base.href && this.base.href.slice(0, this.base.href.indexOf('/','https://'.length))));

--- a/src/com/view/bar/bar-notifications.js
+++ b/src/com/view/bar/bar-notifications.js
@@ -25,6 +25,7 @@ export default class DropdownNotification extends NotificationsBase {
 		};
 		this.hide = this.hide.bind(this);
 		this.clearNotifications = this.clearNotifications.bind(this);
+		this.markAndClearNotifications = this.markAndClearNotifications.bind(this);
 	}
 
 	componentDidMount() {
@@ -32,6 +33,9 @@ export default class DropdownNotification extends NotificationsBase {
 	}
 
 	hasNewNotification(feed) {
+		if (!feed) {
+			return;
+		}
 		const {notificationIds} = this.state;
 		for (let i=0; i<feed.length; i++) {
 			if (notificationIds.indexOf(feed[i].id) == -1) {
@@ -54,8 +58,12 @@ export default class DropdownNotification extends NotificationsBase {
 		}
 	}
 
-	clearNotifications() {
+	markAndClearNotifications() {
 		this.markReadHighest();
+		this.clearNotifications();
+	}
+
+	clearNotifications() {
 		if (this.props.clearCallback) {
 			this.props.clearCallback();
 		}
@@ -90,7 +98,7 @@ export default class DropdownNotification extends NotificationsBase {
 		}
 
 		if ( !loading && this.hasUnreadNotifications() ) {
-			Notifications.push([-2, (<ButtonLink onclick={this.clearNotifications} ><em>Mark all as read</em></ButtonLink>)]);
+			Notifications.push([-2, (<ButtonLink onclick={this.markAndClearNotifications} ><em>Mark all as read</em></ButtonLink>)]);
 		}
 
 		Notifications.push([-1, (<ButtonLink onclick={this.hide} href="/my/notifications"><em>Open notifications feed...</em></ButtonLink>)]);

--- a/src/com/view/bar/bar-notifications.js
+++ b/src/com/view/bar/bar-notifications.js
@@ -86,7 +86,7 @@ export default class DropdownNotification extends NotificationsBase {
 			if (loading) {
 				ShowSpinner = (<NavSpinner />);
 			}
-			Notifications = this.getNotifications(showMax);
+			Notifications = this.getNotifications(showMax, props.hideCallback);
 		}
 
 		if (ShowSpinner !== null) {

--- a/src/com/view/bar/bar.js
+++ b/src/com/view/bar/bar.js
@@ -31,7 +31,7 @@ export default class ViewBar extends Component {
 		this.state - {
 			'notifications': 0,
 			'notificationsHidden': 0,
-			'notificationsFeed': {},
+			'notificationsFeed': null,
 			'notificationsMore': false,
 		};
 
@@ -43,7 +43,7 @@ export default class ViewBar extends Component {
 		this.setState({
 			'notifications': 0,
 			'notificationsHidden': 0,
-			'notificationsFeed': {},
+			'notificationsFeed': null,
 			'notificationsMore': false,
 		});
 	}


### PR DESCRIPTION
This deals with #1556 
It relates to #1413, but opposes it. Though I agree on the general principle of marking things read if they are read. It is a bit problematic given our notification-system.

* Clicking on a notification now has now effect on if it is read or not (since it is a bit obscure in how the marking read works, now marking read only happens if one clicks 'Mark read').
* Nav-change doesn't cause any error and shows pages like they should be.
* Clicking on a notification in the dropdown also hides the dropdown.
* If there are no notifications it will show most recent notifications. This isn't perfect since server doesn't know of user's filters but better than nothing.