### PR TITLE
[WIP] Theme selection in the meta

### DIFF
--- a/public-api/vx/theme.php
+++ b/public-api/vx/theme.php
@@ -342,7 +342,7 @@ switch ( $action ) {
 				if ( $event = validateEvent($event_id) ) {
 					// Is Event Accepting Suggestions ?
 					if ( isset($event['meta']) && isset($event['meta']['theme-mode']) && intval($event['meta']['theme-mode']) === 1 ) {
-						$theme_limit = isset($event['meta']['theme-idea-limit']) ? intval($event['meta']['theme-idea-limit']) : 3;
+						$theme_limit = isset($event['meta']['theme-idea-limit']) ? intval($event['meta']['theme-idea-limit']) : 0;
 						
 						$RESPONSE['response'] = themeIdea_Add($idea, $event_id, $user, $theme_limit);
 						

--- a/src/com/content-event/event-idea.js
+++ b/src/com/content-event/event-idea.js
@@ -121,9 +121,11 @@ export default class ContentEventIdea extends Component {
 
 		return (
 			<div class="-item">
-				<div class="-x" onclick={this.removeIdea.bind(this, id)}><SVGIcon>cross</SVGIcon></div>
 				<SVGIcon>ticket</SVGIcon>
 				<div class="-text" title={idea}>{idea}</div>
+				<div class="-x" onclick={this.removeIdea.bind(this, id)}>
+					<SVGIcon>cross</SVGIcon>
+				</div>
 			</div>
 		);
 	}

--- a/src/com/content-event/event-idea.js
+++ b/src/com/content-event/event-idea.js
@@ -5,8 +5,7 @@ import UIButton							from 'com/ui/button/button';
 import $ThemeIdea						from '../../shrub/js/theme/theme_idea';
 
 
-const MAX_IDEAS = 3;
-const canHaveMoreIdeas = (ideas, submitting) => Object.keys(ideas).length + (submitting ? 1 : 0) < MAX_IDEAS;
+const canHaveMoreIdeas = (ideas, submitting, max) => Object.keys(ideas).length + (submitting ? 1 : 0) < max;
 const hasSubmittedIdeas = (ideas) => Object.keys(ideas).length > 0;
 
 export default class ContentEventIdea extends Component {
@@ -17,6 +16,7 @@ export default class ContentEventIdea extends Component {
 			'idea': '',
 			'ideas': null,
 			'enableSubmit': false,
+			'maxIdeas': props.node.meta && props.node.meta['theme-idea-limit'] ? props.node.meta['theme-idea-limit'] : 0,
 		};
 
 		this.onKeyDown = this.onKeyDown.bind(this);
@@ -31,7 +31,7 @@ export default class ContentEventIdea extends Component {
 		.then(r => {
 			//console.log(r);
 			if ( r.ideas ) {
-				this.setState({'ideas': r.ideas, 'enableSubmit': canHaveMoreIdeas(r.ideas)});
+				this.setState({'ideas': r.ideas, 'enableSubmit': canHaveMoreIdeas(r.ideas, false, this.state.maxIdeas)});
 			}
 			else {
 				this.setState({'ideas': {}});
@@ -71,7 +71,7 @@ export default class ContentEventIdea extends Component {
 			$ThemeIdea.Remove(this.props.node.id, id)
 			.then(r => {
 				//console.log(r.ideas);
-				this.setState({'ideas': r.ideas, 'enableSubmit': canHaveMoreIdeas(r.ideas)});
+				this.setState({'ideas': r.ideas, 'enableSubmit': canHaveMoreIdeas(r.ideas, false, this.state.maxIdeas)});
 			})
 			.catch(err => {
 				this.setState({'error': 'Error processing the request. Make sure you are still logged in.'});
@@ -101,11 +101,11 @@ export default class ContentEventIdea extends Component {
 			});
 		}
 		else if ( idea.length > 0 && idea.length <= 64 ) {
-			this.setState({'enableSubmit': canHaveMoreIdeas(this.state.ideas, true), 'processingIdea': idea, 'error': null});
+			this.setState({'enableSubmit': canHaveMoreIdeas(this.state.ideas, true, this.state.maxIdeas), 'processingIdea': idea, 'error': null});
 			$ThemeIdea.Add(this.props.node.id, idea)
 			.then(r => {
 				//console.log('r', r);
-				this.setState({'ideas': r.ideas, 'idea': r.status === 201 ? '' : idea, 'enableSubmit': canHaveMoreIdeas(r.ideas), 'processingIdea': null});
+				this.setState({'ideas': r.ideas, 'idea': r.status === 201 ? '' : idea, 'enableSubmit': canHaveMoreIdeas(r.ideas, false, this.state.maxIdeas), 'processingIdea': null});
 			})
 			.catch(err => {
 				this.setState({'error': 'Error processing the request. Make sure you are still logged in.', 'processingIdea': null});
@@ -131,9 +131,17 @@ export default class ContentEventIdea extends Component {
 		return Object.keys(this.state.ideas).map(this.renderIdea);
 	}
 
-	render( {node, user/*, path, extra*/}, {idea, ideas, error, enableSubmit} ) {
+	render( {node, user/*, path, extra*/}, {idea, ideas, error, enableSubmit, maxIdeas} ) {
 		if ( node.slug && ideas ) {
 			if ( user && user['id'] ) {
+				if (maxIdeas == 0) {
+					return (
+						<div class="idea-body">
+							<h3>Theme Suggestion Round</h3>
+							<div>This event doesn't allow suggesting themes.</div>
+						</div>
+					);
+				}
 				const ShowError = error ? <div class="content-base content-post idea-error">{error}</div> : null;
 				let ShowSubmit = null;
 				if (enableSubmit) {
@@ -158,7 +166,7 @@ export default class ContentEventIdea extends Component {
 					);
 				}
 				let ShowRemaining = null;
-				const remaining = Math.max(0, MAX_IDEAS - Object.keys(ideas).length);
+				const remaining = Math.max(0, maxIdeas - Object.keys(ideas).length);
 				if (remaining > 1) {
 					ShowRemaining = <div class="foot-note small">You have <strong>{remaining}</strong> suggestions left</div>;
 				}
@@ -181,7 +189,7 @@ export default class ContentEventIdea extends Component {
 			}
 			else {
 				return (
-					<div class="-body">
+					<div class="idea-body">
 						<h3>Theme Suggestion Round</h3>
 						<div>Please log in</div>
 					</div>

--- a/src/com/content-event/event-idea.less
+++ b/src/com/content-event/event-idea.less
@@ -9,10 +9,11 @@
 	}
 
 	& > .idea-form {
-		width: 26em;
+		max-width: 30em;
 		margin-top: 0.5em;
 		padding: 0em 0em 0em 0.5em;
 		display: flex;
+		flex-wrap: wrap;
 
 		& > .-suggestion {
 			border: 1px solid @COL_NLLL;
@@ -21,13 +22,16 @@
 			padding: 0.5em;
 			display: inline-block;
 			flex-grow: 1;
+			min-width: 20;
+			margin-right: 0.5em;
+			margin-top: 0.5em;
 		}
 
 		& > .ui-button {
 			color: @COL_NDD;
 			border: 1px solid;
 			padding: 0.5em;
-			margin: 0em 0.5em;
+			margin-top: 0.5em;
 
 			&:hover,
 			&:focus {
@@ -39,19 +43,23 @@
 	}
 
 	& > .idea-mylist {
-		width: 26em;
+		max-width: 30em;
 
 		& > .-item {
 			padding: 0.125em 0em 0em 1.0em;
 			margin-top: 0.5em;
+			display: flex;
+
+			& > svg {
+				margin-top: 0.2em;
+				line-height: 1em;
+			}
 
 			& > div {
 				display: inline-block;
 			}
 
 			& > .-x {
-				position: relative;
-				float: right;
 				z-index: 1;
 
 				line-height: 1.0em;
@@ -60,18 +68,19 @@
 				cursor: pointer;
 
 				&:hover {
-					color:#F00;
+					color:@COL_A;
 				}
 
 				&:active {
-					color:#FFF;
-					text-shadow: 0 0px 6px #F00;
+					color:@COL_A;
+					text-shadow: 0 0px 6px @COL_A;
 				}
 			}
 
 			& > .-text {
 				padding:0 0.25em;
 				font-style: italic;
+				flex-grow: 1;
 			}
 		}
 	}

--- a/src/shrub/tools/theme/theme-selection.php
+++ b/src/shrub/tools/theme/theme-selection.php
@@ -87,14 +87,15 @@ else if ($ACTION == "idea-limit") {
 		}
 	}
 	else if (ctype_digit($argv[0])) {
-		nodeMeta_Add($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, intval($argv[0]));
-		print " SUCCESS! (max=".$argv[0].")\n";
+		$maxIdeas = intval($argv[0]);
+		nodeMeta_Add($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, $maxIdeas);
+		print " SUCCESS! (max=".$maxIdeas.")\n";
 	}
 	else if ($argv[0] == 'disabled') {
 		nodeMeta_Remove($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, $event['meta'][$metaKey]);
 		print " SUCCESS! (disabled)\n";
 	} else {
-		print " ** ERROR: Can only set a number or 'disabled'\n";
+		print " ** ERROR: Can only set a number >= 0 or 'disabled'\n";
 	}	
 } else {
 	if ($ACTION) {

--- a/src/shrub/tools/theme/theme-selection.php
+++ b/src/shrub/tools/theme/theme-selection.php
@@ -1,0 +1,109 @@
+#!/usr/bin/env php
+<?php
+const CONFIG_PATH = "../../";
+const SHRUB_PATH = "../../src/";
+
+include_once __DIR__."/".CONFIG_PATH."config.php";
+require_once __DIR__."/".SHRUB_PATH."core/cli.php";	// Confirm CLI
+require_once __DIR__."/".SHRUB_PATH."core/db.php";
+require_once __DIR__."/".SHRUB_PATH."core/core.php";
+require_once __DIR__."/".SHRUB_PATH."constants.php";		// For the SH_TABLE constants. run gen.sh if not up-to-date.
+require_once __DIR__."/".SHRUB_PATH."global/global.php";
+require_once __DIR__."/".SHRUB_PATH."node/node.php";
+
+print "\nEVENT THEME MANAGEMENT\n";
+print "----------------------\n\n";
+
+if ( count($argv) < 3 ) {
+	echo "Usage: ".$argv[0]." [ACTION] event-node \n";
+	echo "Usage: ".$argv[0]." [ACTION] event-node [parameters]\n";
+}
+
+array_shift($argv);
+$ACTION = array_shift($argv);
+$EVENT_ID = intval(array_shift($argv));
+
+$root = nodeComplete_GetById(1);
+$eventsId = db_QueryFetchValue(
+	"SELECT
+		n.id
+	FROM
+		".SH_TABLE_PREFIX.SH_TABLE_NODE." AS n
+	WHERE n.type = 'events'
+	LIMIT 1
+	;"
+);
+
+if (!$root || !$eventsId) {
+	print " ** Error: Database not yet fully setup\n";
+	exit(1);
+}
+
+if ($EVENT_ID > 0) {
+	$event = nodeComplete_GetById($EVENT_ID, F_NODE_NO_BODY | F_NODE_META | F_NODE_PATH);
+
+	if (!$event) {
+		print " ** Error: Event with id ".$EVENT_ID." doesn't exist\n";
+		exit(1);
+	}
+
+	if ($event['parents'][0] != $root['id'] || $event['parents'][1] != $eventsId) {
+		print " ** Error: The node '".$event['name']."' is not a properly setup event.\n";
+		exit(1);
+	}
+} 
+else {
+	$ACTION = null;
+}
+//print_r($event);
+
+if ($ACTION == "has-selection") {
+	$metaKey = 'theme-has-selection';
+	if (sizeof($argv) == 0) {
+		if (array_key_exists($metaKey, $event['meta'])) {
+			print "\t* Theme selection enabled.\n";
+		} else {
+			print "\t* Theme selection disabled.\n";			
+		}
+	}
+	else if ($argv[0] == 'enabled') {
+		nodeMeta_Add($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, 'enabled');
+		print " SUCCESS! (enabled)\n";
+	}
+	else if ($argv[0] == 'disabled') {
+		nodeMeta_Remove($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, 'enabled');
+		print " SUCCESS! (disabled)\n";
+	} else {
+		print " ** ERROR: Can only set 'enabled' or 'disabled'\n";
+	}
+}
+else if ($ACTION == "idea-limit") {
+	$metaKey = 'theme-idea-limit';
+	if (sizeof($argv) == 0) {
+		if (array_key_exists($metaKey, $event['meta'])) {
+			print "\t* ".$event['meta'][$metaKey]." suggestions per user.\n";
+		} else {
+			print "\t* No suggestions from users.\n";
+		}
+	}
+	else if (ctype_digit($argv[0])) {
+		nodeMeta_Add($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, intval($argv[0]));
+		print " SUCCESS! (max=".$argv[0].")\n";
+	}
+	else if ($argv[0] == 'disabled') {
+		nodeMeta_Remove($EVENT_ID, 0, SH_SCOPE_PUBLIC, $metaKey, $event['meta'][$metaKey]);
+		print " SUCCESS! (disabled)\n";
+	} else {
+		print " ** ERROR: Can only set a number or 'disabled'\n";
+	}	
+} else {
+	if ($ACTION) {
+		print " ** ERROR: Action '".$ACTION."' unknown.\n";
+	}
+	print "\nACTIONS:\n";
+	print "\t* 'has-selection': If event includes theme suggestions round.\n";
+	print "\t* 'idea-limit': The number of idea suggestions per user.\n";
+}
+
+print "\n";
+?>


### PR DESCRIPTION
**This builds upon #1569**

This introduces a shrub-tool for the CLI to change theme-related event settings. These settings are stored in the node-meta table as `public` with `b=0`.

Currently the only used setting is the `theme-ideas-limit` which changes the number of ideas that can be suggested by a user.

## Important

This changes the number of default allowed suggestions from 3 to 0. To me this makes much more sense given that there now is an easy tool to set the value of suggestions to anything. It also makes more sense because it allows simple understanding of 0 or lack of value to be meaning that the event doesn't include theme suggestion round. (Can still have selection round).

I aim to extend the shrub-tool with all different theme-related settings in a similar manner to the two that are in there. I aim to use `theme-has-selection` or similar key to denote that the event includes any type of theme-process. Understanding that if it doesn't such tab will not show on the UI and if the event has a theme, it will have been set by the event creator.

In the shrub-tool, I'm planning to make a `ld-default` master setting that does all the needed settings to make theme-suggestion work like previously.

I'm thinking of using date-time stamps rather than theme-stages since the latter can be inferred from the former but not the other way around. That also means we can show schedules for the theme-parts of the event. 

This of course will break compatibility with previous LD on the site, but only in the sense that they would not show any information about the theme-selection in their current state (which should be fine since they don't do that anyhow). It should also be possible to remedy this by using the above `ld-default` in the shrub tool on the existing ld-events.