### PR TITLE
Theme fusion prototype

### DIFF
--- a/src/com/content-event/event-fusion.js
+++ b/src/com/content-event/event-fusion.js
@@ -2,9 +2,9 @@ import {h, Component}					from 'preact/preact';
 import SVGIcon 							from 'com/svg-icon/icon';
 import NavLink 							from 'com/nav-link/link';
 
-import ButtonBase						from 'com/button-base/base';
+import UIButton							from 'com/ui/button/button';
 
-import $ThemeIdea						from '../../shrub/js/theme/theme_idea';
+import $ThemeIdeaVote					from '../../shrub/js/theme/theme_idea_vote';
 
 
 export default class ContentEventFusion extends Component {
@@ -13,10 +13,13 @@ export default class ContentEventFusion extends Component {
 		this.state = {
 			'ideas': {},
 			'fusionSeeds': [],
-			'ideasPerGroup': 6,
+			'ideasPerGroup': 12,
 			'fused': {},
 			'defused': {},
+			'selected': [],
 		};
+
+		this.handleFuseFiss = this.handleFuseFiss.bind(this);
 	}
 
 	componentDidMount() {
@@ -24,7 +27,7 @@ export default class ContentEventFusion extends Component {
 			.then(r => {
 				if ( r.ideas ) {
 					this.setState({'ideas': r.ideas});
-					this.getGroup();
+					this.getGroup(r.ideas);
 				}
 				else {
 					this.setState({'ideas': []});
@@ -36,18 +39,71 @@ export default class ContentEventFusion extends Component {
 
 	}
 
-	getRandomSeed() {
-		const {fusionSeeds, ideas} = this.state;
+	handleToggleIdea(ideaId) {
+		const {selected} = this.state;
+		if ( selected.indexOf(ideaId) === -1 ) {
+			this.setState({'selected': [ideaId].concat(selected)});
+		}
+		else {
+			this.setState({'selected': selected.filter(selectedId => selectedId !== ideaId)});
+		}
+	}
+
+	handleFuseFiss() {
+		const {selected, group, ideas} = this.state;
+		const doFuse = (selected.length > 1);
+		if ( doFuse ) {
+			console.log('FUSE', selected.map(ideaId => ideas[ideaId]));
+		}
+		else if ( selected.length === 0 ) {
+			console.log('FISSion', group.map(ideaId => ideas[ideaId]));
+		}
+		else {
+			console.log("TODO: Disable selecting only one");
+		}
+		this.getGroup();
+	}
+
+	getRandomSeed(ideas) {
+		const {fusionSeeds} = this.state;
 		const ideaIds = Object.keys(ideas).filter(i => fusionSeeds.indexOf(i) === -1);
-		if (ideaIds.length == 0) {
+		//console.log(fusionSeeds, Object.keys(ideas));
+		if (ideaIds.length === 0) {
 			return null;
 		}
-		const index = parseInt(Math.random() * available.length);
+		const index = parseInt(Math.random() * ideaIds.length);
 		return ideaIds[index];
 	}
 
-	getLongestCommonSubsequenceLength( A, B ) {
-		return 0;
+	getLongestCommonSubsequenceLength( a, b ) {
+		// Adapted form from
+		// https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Longest_common_subsequence#JavaScript
+		const m = a.length;
+		const n = b.length;
+		const C = [];
+		for ( let i = 0; i <= m; i += 1 ) {
+			C.push([0]);
+		}
+		for ( let j = 0; j < n; j += 1 ) {
+			C[0].push(0);
+		}
+		for ( let i = 0; i < m; i += 1 ) {
+			for ( let j = 0; j < n; j += 1 ) {
+				C[i + 1][j + 1] = a[i] === b[j] ? (C[i][j] + 1) : Math.max(C[i + 1][j], C[i][j + 1]);
+			}
+		}
+		const bt = (i, j) => {
+			if ( i * j === 0 ) {
+				return "";
+			}
+			else if ( a[i - 1] === b[j - 1]) {
+				return bt(i - 1, j - 1) + a[i - 1];
+			}
+			else {
+				return (C[i][j - 1] > C[i - 1][j]) ? bt(i, j - 1) : bt(i - 1, j);
+			}
+		};
+		return bt(m, n);
 	}
 
 	fisherYatesShuffle( arr ) {
@@ -64,44 +120,57 @@ export default class ContentEventFusion extends Component {
 
 	reportOnGroup( group, scores, ideas ) {
 		console.log('SEED:', ideas[group[0]]);
-		for ( let i = 1; i < group.length; i += 1 ){
-			console.log(i, scores[group[i]], ideas[group[i]]);
+		for ( let i = 1; i < group.length; i += 1 ) {
+			console.log(i, scores[group[i]].length, scores[group[i]], ideas[group[i]]);
 		}
 	}
 
-	getGroup() {
-		const {ideas, ideasPerGroup} = this.state;
-		const seedId = getRandomSeed();
-		const scores = {};
+	getGroup(ideas) {
+		const {ideasPerGroup} = this.state;
+		const seedId = this.getRandomSeed(ideas);
 		if (seedId == null) {
 			return [];
 		}
+		const scores = {};
 		const seed = ideas[seedId];
-		const ideaIds = Object.keys(ideas);
-		for (let idx = 0; idx < ideaIds.length; i+= 1) {
+		const ideaIds = Object.keys(ideas).filter(ideaId => ideaId !== seedId);
+		for (let idx = 0; idx < ideaIds.length; idx+= 1) {
 			const curId = ideaIds[idx];
 			if (curId == seedId) {
 				continue;
 			}
 			scores[curId] = this.getLongestCommonSubsequenceLength(seed, ideas[curId]);
 		}
-
-		const best = ideaIds.sort((a, b) => scores[b] - scores[a]);
-		const group = [seed].concat(best.slice(0, ideasPerGroup - 1));
+		const best = ideaIds.sort((a, b) => scores[b].length - scores[a].length);
+		const group = [seedId].concat(best.slice(0, ideasPerGroup - 1));
 		this.reportOnGroup(group, scores, ideas);
-		return this.fisherYatesShuffle(group);
+		this.setState({'group': this.fisherYatesShuffle(group), 'selected': []});
 	}
 
 	render( props, state ) {
 		const {user} = props;
+		const {group, ideas, selected} = state;
 		const Title = <h3>Theme Fusion Round</h3>;
 		if ( user && user.id ) {
+			let ShowGroup = null;
+			if (group) {
+				const Ideas = group.map(ideaId => <UIButton class={cN('-idea', selected.indexOf(ideaId) > -1 ? '-selected' : null)} key={ideaId} onclick={this.handleToggleIdea.bind(this, ideaId)}>{ideas[ideaId]}</UIButton>);
+				ShowGroup = (
+					<div class="fusion-box">
+						<div class="-ideas">{Ideas}</div>
+						<UIButton onclick={this.handleFuseFiss}>Fuse</UIButton>
+					</div>
+				);
+			}
+
 			return (
-				<div class="-body">
+				<div class="-body event-fusion">
 					{Title}
+					<div class="-warning">This is just a prototype and will not actually have any effect if you fuse or 'fiss'</div>
 					<div>
 						If any, mark the ones below that should be fused. You should only mark one group per set. Most of  the sets you will probably not find anything to fuse. This is expected and normal.
 					</div>
+					{ShowGroup}
 				</div>
 			);
 		}

--- a/src/com/content-event/event-fusion.js
+++ b/src/com/content-event/event-fusion.js
@@ -1,4 +1,4 @@
-import { h, Component } 				from 'preact/preact';
+import {h, Component}					from 'preact/preact';
 import SVGIcon 							from 'com/svg-icon/icon';
 import NavLink 							from 'com/nav-link/link';
 
@@ -10,21 +10,98 @@ import $ThemeIdea						from '../../shrub/js/theme/theme_idea';
 export default class ContentEventFusion extends Component {
 	constructor( props ) {
 		super(props);
-
+		this.state = {
+			'ideas': {},
+			'fusionSeeds': [],
+			'ideasPerGroup': 6,
+			'fused': {},
+			'defused': {},
+		};
 	}
 
 	componentDidMount() {
+		$ThemeIdeaVote.Get(this.props.node.id)
+			.then(r => {
+				if ( r.ideas ) {
+					this.setState({'ideas': r.ideas});
+					this.getGroup();
+				}
+				else {
+					this.setState({'ideas': []});
+				}
+			})
+			.catch(err => {
+				this.setState({'error': err});
+			});
+
 	}
 
+	getRandomSeed() {
+		const {fusionSeeds, ideas} = this.state;
+		const ideaIds = Object.keys(ideas).filter(i => fusionSeeds.indexOf(i) === -1);
+		if (ideaIds.length == 0) {
+			return null;
+		}
+		const index = parseInt(Math.random() * available.length);
+		return ideaIds[index];
+	}
 
-	render( {/*node,*/ user/*, path, extra*/} ) {
-		var Title = <h3>Theme Fusion Round</h3>;
+	getLongestCommonSubsequenceLength( A, B ) {
+		return 0;
+	}
 
-		if ( user && user['id'] ) {
+	fisherYatesShuffle( arr ) {
+		let counter = arr.length;
+		while ( counter > 0 ) {
+			const idx = Math.floor(Math.random() * counter);
+			counter -= 1;
+			const tmp = arr[counter];
+			arr[counter] = arr[idx];
+			arr[idx] = tmp;
+		}
+		return arr;
+	}
+
+	reportOnGroup( group, scores, ideas ) {
+		console.log('SEED:', ideas[group[0]]);
+		for ( let i = 1; i < group.length; i += 1 ){
+			console.log(i, scores[group[i]], ideas[group[i]]);
+		}
+	}
+
+	getGroup() {
+		const {ideas, ideasPerGroup} = this.state;
+		const seedId = getRandomSeed();
+		const scores = {};
+		if (seedId == null) {
+			return [];
+		}
+		const seed = ideas[seedId];
+		const ideaIds = Object.keys(ideas);
+		for (let idx = 0; idx < ideaIds.length; i+= 1) {
+			const curId = ideaIds[idx];
+			if (curId == seedId) {
+				continue;
+			}
+			scores[curId] = this.getLongestCommonSubsequenceLength(seed, ideas[curId]);
+		}
+
+		const best = ideaIds.sort((a, b) => scores[b] - scores[a]);
+		const group = [seed].concat(best.slice(0, ideasPerGroup - 1));
+		this.reportOnGroup(group, scores, ideas);
+		return this.fisherYatesShuffle(group);
+	}
+
+	render( props, state ) {
+		const {user} = props;
+		const Title = <h3>Theme Fusion Round</h3>;
+		if ( user && user.id ) {
 			return (
 				<div class="-body">
 					{Title}
-					<div>welcome</div>
+					<div>
+						If any, mark the ones below that should be fused. You should only mark one group per set. Most of  the sets you will probably not find anything to fuse. This is expected and normal.
+					</div>
 				</div>
 			);
 		}

--- a/src/com/content-event/event-fusion.js
+++ b/src/com/content-event/event-fusion.js
@@ -61,7 +61,7 @@ export default class ContentEventFusion extends Component {
 		else {
 			console.log("TODO: Disable selecting only one");
 		}
-		this.getGroup();
+		this.getGroup(ideas);
 	}
 
 	getRandomSeed(ideas) {

--- a/src/com/content-event/event-fusion.js
+++ b/src/com/content-event/event-fusion.js
@@ -155,10 +155,28 @@ export default class ContentEventFusion extends Component {
 			let ShowGroup = null;
 			if (group) {
 				const Ideas = group.map(ideaId => <UIButton class={cN('-idea', selected.indexOf(ideaId) > -1 ? '-selected' : null)} key={ideaId} onclick={this.handleToggleIdea.bind(this, ideaId)}>{ideas[ideaId]}</UIButton>);
+				let ActionText = null;
+				let actionButtonClass = null;
+				let actionDisabled = null;
+				if ( selected.length === 0) {
+					ActionText = 'FISS';
+					actionButtonClass = '-fiss';
+				}
+				else if ( selected.length === 1 ) {
+					ActionText = '----';
+					actionButtonClass = '-disabled';
+					actionDisabled = 'disabled';
+				}
+				else {
+					ActionText = 'FUSE';
+					actionButtonClass = '-fuse';
+				}
 				ShowGroup = (
 					<div class="fusion-box">
 						<div class="-ideas">{Ideas}</div>
-						<UIButton onclick={this.handleFuseFiss}>Fuse</UIButton>
+						<div class="-button-box">
+							<UIButton onclick={this.handleFuseFiss} class={cN('fuse-fiss', actionButtonClass)} disabled={actionDisabled}>{ActionText}</UIButton>
+						</div>
 					</div>
 				);
 			}
@@ -167,7 +185,7 @@ export default class ContentEventFusion extends Component {
 				<div class="-body event-fusion">
 					{Title}
 					<div class="-warning">This is just a prototype and will not actually have any effect if you fuse or 'fiss'</div>
-					<div>
+					<div class="-instructions">
 						If any, mark the ones below that should be fused. You should only mark one group per set. Most of  the sets you will probably not find anything to fuse. This is expected and normal.
 					</div>
 					{ShowGroup}

--- a/src/com/content-event/event-fusion.less
+++ b/src/com/content-event/event-fusion.less
@@ -14,6 +14,11 @@
 	}
 
 	& > .fusion-box {
+		& > .-progress {
+			margin: 1em;
+			font-weight: bold;
+		}
+
 		& > .-ideas {
 			display: flex;
 			max-width: 800px;

--- a/src/com/content-event/event-fusion.less
+++ b/src/com/content-event/event-fusion.less
@@ -2,17 +2,66 @@
 @import "defs.less";
 
 .event-fusion {
+	& > .-warning {
+		color: @COL_A;
+		margin: 1em;
+		font-weight: bold;
+	}
+
+	& > .-instructions {
+		font-style: italic;
+		margin: 0.5em;
+	}
+
 	& > .fusion-box {
 		& > .-ideas {
 			display: flex;
 			max-width: 800px;
+			flex-wrap: wrap;
+			justify-content: center;
 
 			& > .-idea {
-				border: 1px @COL_K;
+				border: 1px @COL_K solid;
+				padding: 0.25em 0.5em;
+				margin: 0.5em 0.25em;
 
 				&.-selected {
 					background: @COL_A;
 					color: @COL_L;
+					border: 1px @COL_A solid;
+				}
+			}
+		}
+
+		& > .-button-box {
+			width: 100%;
+			max-width: 800px;
+			text-align: center;
+
+			& > .fuse-fiss {
+				margin: 0.5em;
+				border: 1px @COL_K solid;
+				padding: 0.25em 0.5em;
+				float: center;
+				display: inline-block;
+
+				&.-fiss {
+					color: @COL_L;
+					background: @COL_CA;
+					border: 1px @COL_CA solid;
+				}
+
+				&.-fuse {
+					color: @COL_L;
+					background: @COL_BC;
+					border: 1px @COL_BC solid;
+				}
+
+				&.-disabled
+				{
+					color: @COL_L;
+					background: @COL_NL;
+					border: 1px @COL_NL solid;
 				}
 			}
 		}

--- a/src/com/content-event/event-fusion.less
+++ b/src/com/content-event/event-fusion.less
@@ -1,0 +1,20 @@
+
+@import "defs.less";
+
+.event-fusion {
+	& > .fusion-box {
+		& > .-ideas {
+			display: flex;
+			max-width: 800px;
+
+			& > .-idea {
+				border: 1px @COL_K;
+
+				&.-selected {
+					background: @COL_A;
+					color: @COL_L;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
![ld-theme-fusion-prototype](https://user-images.githubusercontent.com/8041100/35777158-5e53062e-09a9-11e8-8a83-8221c604e00b.gif)

This prototype doesn't post anything to any api, it is just for evaluating a way to do theme fusion (UI) and a way to find similar themes to ask input from the user.

* Current version randomly picks a theme and finds similar themes based on longest common substring.
* It filters out low scores and picks maximum of 7 similar and presents the group of up to 8 to the user.
* It asks for either 'FUSE' or 'NO FUSE' (non of the themes should be fused with each other).
* It sometimes will present only on option (the random selected theme), this would mean no similar at all in the whole set of themes, and in the future this would trigger it to pick next theme to find similarity group.
* Since it just records the state in the component, refresh page to try again.