### PR TITLE
Rules questions

### DIFF
--- a/src/com/button-base/base.js
+++ b/src/com/button-base/base.js
@@ -13,6 +13,7 @@ export default class ButtonBase extends Component {
 			props.class = "button-base " + props.class;
 		else
 			props.class = "button-base";
+		if ( props.disabled ) props.class += " -disabled";
 
 		if ( props.onclick ) {
 			// As long as you don't set the "keep focus" property //
@@ -20,6 +21,7 @@ export default class ButtonBase extends Component {
 				// Wrap onClick with a function that deselects current element //
 				let func = props.onclick;
 				props.onclick = (e) => {
+					if (props.disabled) return;
 					func(e);
 					if ( typeof document.activeElement.blur !== "undefined" ) {
 						document.activeElement.blur();
@@ -32,7 +34,7 @@ export default class ButtonBase extends Component {
 			}
 
 			props.onkeydown = (e) => {
-				if ( e.keyCode === 13 ) {
+				if ( e.keyCode === 13 && !props.disabled ) {
 					props.onclick();
 				}
 			};

--- a/src/com/button-base/base.less
+++ b/src/com/button-base/base.less
@@ -1,5 +1,19 @@
+@import "defs.less";
 
 .button-base {
 	cursor: pointer;
 	user-select: none;
+
+	&.-disabled {
+		border: 1px solid @COL_NLLL;
+		color: @COL_NLLL;
+
+		&:active,
+		&:hover,
+		&:focus {
+			cursor: not-allowed;
+			border: 1px solid @COL_NLLL;
+			color: @COL_NLLL;
+		}
+	}
 }

--- a/src/com/button-link/link.js
+++ b/src/com/button-link/link.js
@@ -11,6 +11,7 @@ export default class ButtonLink extends NavLink {
 			props.class = "button-base button-link " + props.class;
 		else
 			props.class = "button-base button-link";
+		if ( props.disabled ) props.class += " -disabled";
 
 		let doHistory;
 		if ( props.href ) {
@@ -30,6 +31,7 @@ export default class ButtonLink extends NavLink {
 		// Wrap onClick with a function that deselects current element //
 		let onClickFunc = props.onclick;
 		props.onclick = (e) => {
+			if ( props.disabled ) return;
 			if ( onClickFunc )
 				onClickFunc(e);
 
@@ -46,7 +48,7 @@ export default class ButtonLink extends NavLink {
 		};
 
 		props.onkeydown = (e) => {
-			if ( e.keyCode === 13 ) {
+			if ( e.keyCode === 13 && !props.disabled ) {
 				props.onclick();
 			}
 		};

--- a/src/com/button-link/link.less
+++ b/src/com/button-link/link.less
@@ -1,6 +1,20 @@
+@import "defs.less";
 
 .button-link {
 	display: block;
 	color: inherit;
 	text-decoration: none;
+
+	&.-disabled {
+		border: 1px solid @COL_NLLL;
+		color: @COL_NLLL;
+
+		&:active,
+		&:hover,
+		&:focus {
+			cursor: not-allowed;
+			border: 1px solid @COL_NLLL;
+			color: @COL_NLLL;
+		}
+	}
 }

--- a/src/com/content-common/common-nav-button.js
+++ b/src/com/content-common/common-nav-button.js
@@ -15,13 +15,13 @@ export default class ContentCommonNavButton extends Component {
 
 		if ( props.href ) {
 			return (
-				<ButtonLink class={Class} href={props.href} onclick={props.onclick}>
+				<ButtonLink disabled={props.disabled} class={Class} href={props.href} onclick={props.onclick}>
 					{props.children}
 				</ButtonLink>
 			);
 		}
 		return (
-			<ButtonBase class={Class} onclick={props.onclick}>
+			<ButtonBase disabled={props.disabled} class={Class} onclick={props.onclick}>
 				{props.children}
 			</ButtonBase>
 		);

--- a/src/com/content-common/common-nav-button.less
+++ b/src/com/content-common/common-nav-button.less
@@ -26,6 +26,19 @@
 				border: 1px solid @COL_W;
 				color: @COL_A;
 			}
+
+			&.-disabled {
+				border: 1px solid @COL_NLLL;
+				color: @COL_NLLL;
+
+				&:active,
+				&:hover,
+				&:focus {
+					cursor: not-allowed;
+					border: 1px solid @COL_NLLL;
+					color: @COL_NLLL;
+				}
+			}
 		}
 	}
 }
@@ -58,6 +71,14 @@
 	&.-disabled {
 		border: 1px solid @COL_NLLL;
 		color: @COL_NLLL;
+
+		&:active,
+		&:hover,
+		&:focus {
+			cursor: not-allowed;
+			border: 1px solid @COL_NLLL;
+			color: @COL_NLLL;
+		}
 	}
 
 	&.-selected {

--- a/src/com/content-item/item-rulescheck.js
+++ b/src/com/content-item/item-rulescheck.js
@@ -1,8 +1,8 @@
-import {h, Component} 					from 'preact/preact';
-import ContentCommonBody				from 'com/content-common/common-body';
-import ButtonBase						from 'com/button-base/base';
-import NavLink 							from 'com/nav-link/link';
-import SVGIcon 							from 'com/svg-icon/icon';
+import {h, Component} from 'preact/preact';
+import ContentCommonBody from 'com/content-common/common-body';
+import ButtonBase from 'com/button-base/base';
+import NavLink from 'com/nav-link/link';
+import SVGIcon from 'com/svg-icon/icon';
 
 export default class ContentItemRulesCheck extends Component {
     constructor(props) {
@@ -12,11 +12,17 @@ export default class ContentItemRulesCheck extends Component {
 
     handleChange(field, nextValue) {
         const {onAllowChange} = this.props;
-        const nextState = Object.assign({}, this.state, {[field]: nextValue});
+        const nextState = Object.assign(
+            {},
+            this.state,
+            this.props.answers,
+            {[field]: nextValue}
+        );
         if (onAllowChange) onAllowChange({
             allowJam: this.allowJam(nextState),
             allowCompo: this.allowCompo(nextState),
             allowUnfinished: this.allowUnfinished(nextState),
+            rulesAnswers: nextState,
         });
         this.setState({[field]: nextValue});
     }
@@ -34,7 +40,11 @@ export default class ContentItemRulesCheck extends Component {
         if (!nextState.createdAll) return false;
         if (!nextState.createdWithin48) return false;
         if (!nextState.includedSource) return false;
-        if (nextState.optedOut) return false; // This indicates you misunderstood the rules.
+
+        // This indicates you misunderstood the rules.
+        // but as it is now it would be too confusing to activate
+        //if (nextState.optedOut) return false;
+
         return true;
     }
 
@@ -50,11 +60,13 @@ export default class ContentItemRulesCheck extends Component {
     }
 
     componentDidMount() {
-        const { onAllowChange } = this.props;
+        const { onAllowChange, answers } = this.props;
+        const mountState = Object.assign({}, this.state, answers);
         if (onAllowChange) onAllowChange({
-            allowJam: this.allowJam(this.state),
-            allowCompo: this.allowCompo(this.state),
-            allowUnfinished: this.allowUnfinished(this.state),
+            allowJam: this.allowJam(mountState),
+            allowCompo: this.allowCompo(mountState),
+            allowUnfinished: this.allowUnfinished(mountState),
+            rulesAnswers: mountState,
         });
     }
 
@@ -64,48 +76,52 @@ export default class ContentItemRulesCheck extends Component {
         const MandatoryJam = <span class="-mandatory">JAM</span>;
         const IconUnChecked = <SVGIcon small baseline class="-checkbox">checkbox-unchecked</SVGIcon>;
         const IconChecked = <SVGIcon small baseline class="-checkbox">checkbox-checked</SVGIcon>;
+        const {
+            readRules, workedSolo, createdAll, createdWithin48, createdWithin72,
+            includedSource, willVote, optedOut,
+        } = (props.answers ? props.answers : state);
 
         return (
             <ContentCommonBody class="-rules-check">
                 <div class="-label">Rules</div>
                 <div>Please indicate what applies to you and your game.</div>
-				<ButtonBase onclick={this.handleChange.bind(this, 'readRules', !state.readRules)}>
-                    {state.readRules ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'readRules', !readRules)}>
+                    {readRules ? IconChecked : IconUnChecked}
                     {Mandatory}
                     I have read and understood <NavLink blank href="/events/ludum-dare/rules"><strong>the rules</strong></NavLink>.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'workedSolo', !state.workedSolo)}>
-                    {state.workedSolo ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'workedSolo', !workedSolo)}>
+                    {workedSolo ? IconChecked : IconUnChecked}
                     {MandatoryCompo}
                     I worked <strong>alone</strong> on the game.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'createdAll', !state.createdAll)}>
-                    {state.createdAll ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'createdAll', !createdAll)}>
+                    {createdAll ? IconChecked : IconUnChecked}
                     {MandatoryCompo}
                     I created all the code, art, music and sounds myself during the LD.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'createdWithin48', !state.createdWithin48)}>
-                    {state.createdWithin48 ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'createdWithin48', !createdWithin48)}>
+                    {createdWithin48 ? IconChecked : IconUnChecked}
                     {MandatoryCompo}
                     I created everything during the 48h of the LD.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'includedSource', !state.includedSource)}>
-                    {state.includedSource ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'includedSource', !includedSource)}>
+                    {includedSource ? IconChecked : IconUnChecked}
                     {MandatoryCompo}
                     I included the source code.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'createdWithin72', !state.createdWithin72)}>
-                    {state.createdWithin72 ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'createdWithin72', !createdWithin72)}>
+                    {createdWithin72 ? IconChecked : IconUnChecked}
                     {MandatoryJam}
                     I/We created all conents I/we want to be rated for during the 72h of LD.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'optedOut', !state.optedOut)}>
-                    {state.optedOut ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'optedOut', !optedOut)}>
+                    {optedOut ? IconChecked : IconUnChecked}
                     {MandatoryJam}
                     I/We opt out of all voting categories for which we did not do everything ourselves.
                 </ButtonBase>
-                <ButtonBase onclick={this.handleChange.bind(this, 'willVote', !state.willVote)}>
-                    {state.willVote ? IconChecked : IconUnChecked}
+                <ButtonBase onclick={this.handleChange.bind(this, 'willVote', !willVote)}>
+                    {willVote ? IconChecked : IconUnChecked}
                     {Mandatory}
                     I/We will participate in playing and voting on other games.
                 </ButtonBase>

--- a/src/com/content-item/item-rulescheck.less
+++ b/src/com/content-item/item-rulescheck.less
@@ -6,7 +6,7 @@
     }
 
     & .-mandatory {
-        font-weight: bold;
+      font-weight: bold;
     	color: @MAJOR_COLOR1;
         font-size: 70%;
         margin: 0.5rem;

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -13,6 +13,8 @@ import ContentCommonBodyTitle			from 'com/content-common/common-body-title';
 import ContentCommonNav					from 'com/content-common/common-nav';
 import ContentCommonNavButton			from 'com/content-common/common-nav-button';
 
+import ContentItemRulesCheck from 'com/content-item/item-rulescheck';
+
 import InputStar						from 'com/input-star/star';
 
 import ContentSimple					from 'com/content-simple/simple';
@@ -55,6 +57,7 @@ export default class ContentItem extends Component {
 		this.onSetCompo = this.onSetCompo.bind(this);
 		this.onSetUnfinished = this.onSetUnfinished.bind(this);
 		this.onAnonymousComments = this.onAnonymousComments.bind(this);
+		this.handleAllowSubmission = this.handleAllowSubmission.bind(this);
 	}
 
 	componentDidMount() {
@@ -300,6 +303,10 @@ export default class ContentItem extends Component {
 		return $Node.AddMeta(node.id, Data);
 	}
 
+	handleAllowSubmission(allowed) {
+		this.setState(allowed);
+	}
+
 	// Generates JSX for the links, depending on whether the page is editing or viewing
 	makeLinks( editing ) {
 		let LinkMeta = [];
@@ -429,6 +436,7 @@ export default class ContentItem extends Component {
 		}
 
 		let ShowEventPicker = null;
+		let ShowRulesCheck = null;
 		if ( extra && extra.length && (extra[0] == 'edit') && node_CanPublish(parent) ) {
 			if (shouldCheckRules) {
 				ShowRulesCheck = <ContentItemRulesCheck
@@ -824,6 +832,7 @@ export default class ContentItem extends Component {
 
 		props.editonly = (
 			<div>
+				{ShowRulesCheck}
 				{ShowEventPicker}
 				{ShowOptOut}
 				{ShowImages}

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -426,9 +426,9 @@ export default class ContentItem extends Component {
 			ShowEventPicker = (
 				<ContentCommonNav>
 					<div class="-label">Event</div>
-					<ContentCommonNavButton onclick={this.onSetJam} class={Category == '/jam' ? "-selected" : ""} disabled={!allowJam}><SVGIcon>users</SVGIcon><div>Jam</div></ContentCommonNavButton>
-					<ContentCommonNavButton onclick={this.onSetCompo} class={Category == '/compo' ? "-selected" : ""} disabled={!allowCompo}><SVGIcon>user</SVGIcon><div>Compo</div></ContentCommonNavButton>
-					<ContentCommonNavButton onclick={this.onSetUnfinished} class={Category == '/unfinished' ? "-selected" : ""} disabled={!allowUnfinished}><SVGIcon>trash</SVGIcon><div>Unfinished</div></ContentCommonNavButton>
+					<ContentCommonNavButton onclick={this.onSetJam} class={Category == '/jam' && allowJam ? "-selected" : ""} disabled={!allowJam}><SVGIcon>users</SVGIcon><div>Jam</div></ContentCommonNavButton>
+					<ContentCommonNavButton onclick={this.onSetCompo} class={Category == '/compo' && allowCompo ? "-selected" : ""} disabled={!allowCompo}><SVGIcon>user</SVGIcon><div>Compo</div></ContentCommonNavButton>
+					<ContentCommonNavButton onclick={this.onSetUnfinished} class={Category == '/unfinished' && allowUnfinished ? "-selected" : ""} disabled={!allowUnfinished}><SVGIcon>trash</SVGIcon><div>Unfinished</div></ContentCommonNavButton>
 					<div class="-footer">
 						<strong>NOTE</strong>: You <strong>MUST</strong> click this before you will be able to Publish.<br />
 						Please refer to <NavLink blank href="/events/ludum-dare/rules"><strong>the rules</strong></NavLink>. If you {"don't"} know what to pick, pick the <strong>Jam</strong>.

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -370,6 +370,19 @@ export default class ContentItem extends Component {
 		props = Object.assign({}, props);			// Copy it because we're going to change it
 		let {node, user, path, extra, featured} = props;
 		let {parent, allowCompo, allowJam, allowUnfinished} = state;
+		let shouldCheckRules = true;
+		if (node_IsPublished(node)) {
+			// Since we don't store answers to rules they would be
+			// annoying when editing
+			shouldCheckRules = false;
+			allowCompo = true;
+			allowJam = true;
+			allowUnfinished = true;
+
+			// Could possibly disable allowCompo if not already
+			// marked as compo?
+			// allowCompo = false;
+		}
 		const tooManyAuthorsForCompo = (node_CountAuthors(node) != 1);
 		allowCompo = allowCompo && !tooManyAuthorsForCompo;
 
@@ -394,10 +407,12 @@ export default class ContentItem extends Component {
 			if ( node.subsubtype == 'jam' ) {
 				props.by = "JAM "+props.by;
 				Category = '/jam';
+				props.nopublish = !allowJam;
 			}
 			else if ( node.subsubtype == 'compo' ) {
 				props.by = "COMPO "+props.by;
 				Category = '/compo';
+				props.nopublish = !allowCompo;
 			}
 			else if ( node.subsubtype == 'craft' ) {
 				props.by = "CRAFT";
@@ -411,6 +426,7 @@ export default class ContentItem extends Component {
 				props.headerClass = null;
 				props.by = "UNFINISHED "+props.by;
 				Category = '/unfinished';
+				props.nopublish = !allowUnfinished;
 			}
 			else {
 				props.nopublish = true;
@@ -422,17 +438,19 @@ export default class ContentItem extends Component {
 		let ShowEventPicker = null;
 		let ShowRulesCheck = null;
 		if ( extra && extra.length && (extra[0] == 'edit') && node_CanPublish(parent) ) {
-			ShowRulesCheck = <ContentItemRulesCheck
-				onAllowChange={this.handleAllowSubmission}
-				answers={state.rulesAnswers}
-			/>;
+			if (shouldCheckRules) {
+				ShowRulesCheck = <ContentItemRulesCheck
+					onAllowChange={this.handleAllowSubmission}
+					answers={state.rulesAnswers}
+				/>;
+			}
 			ShowEventPicker = (
 				<ContentCommonNav>
 					<div class="-label">Event</div>
 					<ContentCommonNavButton onclick={this.onSetJam} class={Category == '/jam' && allowJam ? "-selected" : ""} disabled={!allowJam}><SVGIcon>users</SVGIcon><div>Jam</div></ContentCommonNavButton>
 					<ContentCommonNavButton onclick={this.onSetCompo} class={Category == '/compo' && allowCompo ? "-selected" : ""} disabled={!allowCompo}><SVGIcon>user</SVGIcon><div>Compo</div></ContentCommonNavButton>
 					<ContentCommonNavButton onclick={this.onSetUnfinished} class={Category == '/unfinished' && allowUnfinished ? "-selected" : ""} disabled={!allowUnfinished}><SVGIcon>trash</SVGIcon><div>Unfinished</div></ContentCommonNavButton>
-					{tooManyAuthorsForCompo && <div class='-warning'>COMPO option disabled because: Too many authors.</div>}
+					{tooManyAuthorsForCompo && <div class="-warning">COMPO option disabled because: Too many authors.</div>}
 					<div class="-footer">
 						<strong>NOTE</strong>: You <strong>MUST</strong> click this before you will be able to Publish.<br />
 						Please refer to <NavLink blank href="/events/ludum-dare/rules"><strong>the rules</strong></NavLink>. If you {"don't"} know what to pick, pick the <strong>Jam</strong>.

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -422,17 +422,20 @@ export default class ContentItem extends Component {
 		let ShowEventPicker = null;
 		let ShowRulesCheck = null;
 		if ( extra && extra.length && (extra[0] == 'edit') && node_CanPublish(parent) ) {
-			ShowRulesCheck = <ContentItemRulesCheck onAllowChange={this.handleAllowSubmission} />;
+			ShowRulesCheck = <ContentItemRulesCheck
+				onAllowChange={this.handleAllowSubmission}
+				answers={state.rulesAnswers}
+			/>;
 			ShowEventPicker = (
 				<ContentCommonNav>
 					<div class="-label">Event</div>
 					<ContentCommonNavButton onclick={this.onSetJam} class={Category == '/jam' && allowJam ? "-selected" : ""} disabled={!allowJam}><SVGIcon>users</SVGIcon><div>Jam</div></ContentCommonNavButton>
 					<ContentCommonNavButton onclick={this.onSetCompo} class={Category == '/compo' && allowCompo ? "-selected" : ""} disabled={!allowCompo}><SVGIcon>user</SVGIcon><div>Compo</div></ContentCommonNavButton>
 					<ContentCommonNavButton onclick={this.onSetUnfinished} class={Category == '/unfinished' && allowUnfinished ? "-selected" : ""} disabled={!allowUnfinished}><SVGIcon>trash</SVGIcon><div>Unfinished</div></ContentCommonNavButton>
+					{tooManyAuthorsForCompo && <div class='-warning'>COMPO option disabled because: Too many authors.</div>}
 					<div class="-footer">
 						<strong>NOTE</strong>: You <strong>MUST</strong> click this before you will be able to Publish.<br />
 						Please refer to <NavLink blank href="/events/ludum-dare/rules"><strong>the rules</strong></NavLink>. If you {"don't"} know what to pick, pick the <strong>Jam</strong>.
-						{tooManyAuthorsForCompo && <div><strong>COMPO</strong> option disabled because: Too many authors.</div>}
 					</div>
 				</ContentCommonNav>
 			);

--- a/src/com/content-item/item.less
+++ b/src/com/content-item/item.less
@@ -5,6 +5,12 @@
 	color: @MAJOR_LIGHT;
 }
 
+#content .-warning {
+	color: @MAJOR_COLOR1;
+	font-weight: bold;
+	font-size: 80%;
+}
+
 #content .content-item {
 	& .-links {
 		margin: 1rem;


### PR DESCRIPTION
# Contents

* Adds a rules check (only pre-submission, never on edits).
* Has to agree with a number of statements before enabling buttons to select game type
* Disabled buttons are grayish and have special cursor, but still react to hover unfortunately.
* Rules data is only stored in the component and not submitted to the server. Therefore if someone answers questions selects type and only saves, they have to answer the same questions again before seeing what they previously selected and being allowed to submit.
* It supports toggling back and forth between edit and preview without loosing answers to questions.
* Updated to warning about too many authors causes compo to be deactivated so it is more prominent since I missed it myself when working on this PR.

# Demo
![ld_rulescheck](https://user-images.githubusercontent.com/8041100/40873094-55c58406-665a-11e8-90be-e1017f48a2b0.gif)

# Related issues
* #1646 Bring back checkboxes (this resolves it)
* #1626 Adds more restrictions on client side.