### PR TITLE
Fixes dropdown so it always fit screen

### DIFF
--- a/src/com/view/bar/bar-notifications.less
+++ b/src/com/view/bar/bar-notifications.less
@@ -5,7 +5,7 @@
 
 	& .-items {
 		width: 480px;
-		max-width: 480px !important;
+		max-width: calc(~"100vw - 100px");
 		right: 0px;
 		top: 55px;
 		background: @COL_W !important;


### PR DESCRIPTION
Updated less so it will always fit given that the origin of the dropdown isn't moved further from right of the screen.

# Related issues
* Resolves #1645 