### PR TITLE
Making anon a checkbox in the comment and a tooltip

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -6,6 +6,7 @@ import NavLink 							from 'com/nav-link/link';
 import ButtonLink 						from 'com/button-link/link';
 import SVGIcon 							from 'com/svg-icon/icon';
 import IMG2 							from 'com/img2/img2';
+import UICheckbox from 'com/ui/checkbox/checkbox';
 
 import ContentCommentsMarkup			from 'comments-markup';
 import {AutocompleteAtNames, AutocompleteEmojis}			from 'comment-autocomplete';
@@ -42,8 +43,8 @@ export default class ContentCommentsComment extends Component {
 
 		this.onSave = this.onSave.bind(this);
 		this.onCancel = this.onCancel.bind(this);
+		this.onToggleAnon = this.onToggleAnon.bind(this);
 		this.onPublish = this.onPublish.bind(this);
-		this.onPublishAnon = this.onPublishAnon.bind(this);
 		this.onLove = this.onLove.bind(this);
 		this.onReply = this.onReply.bind(this);
 		this.onSubscribe = this.onSubscribe.bind(this);
@@ -141,20 +142,22 @@ export default class ContentCommentsComment extends Component {
 		});
 	}
 
-	onPublishAnon( e ) {
-		if ( this.canSave() ) {
-			if ( this.props.onpublish ) {
-				this.props.onpublish(e, true);
-			}
-		}
+	onToggleAnon() {
+		this.setState({"publishAnon": !this.state.publishAnon});
 	}
 
 	onPublish( e ) {
 		if ( this.canSave() ) {
-			if ( this.props.onpublish ) {
-				this.props.onpublish(e);
+			if ( this.state.publishAnon ) {
+				if ( this.props.onpublish ) {
+					this.props.onpublish(e, true);
+				}
+			} else {
+				if ( this.props.onpublish ) {
+					this.props.onpublish(e);
 
-				//this.setState({'modified': false, 'editing': true, 'preview': false});
+					//this.setState({'modified': false, 'editing': true, 'preview': false});
+				}
 			}
 		}
 	}
@@ -325,16 +328,11 @@ export default class ContentCommentsComment extends Component {
 
 				var ShowRight = [];
 
-				if ( props.cansubscribe ) {
-					ShowRight.push(<div class={"-button -subscribe"} onclick={this.onSubscribe}><SVGIcon>bubble</SVGIcon><div>Follow Thread</div></div>);
-				}
-				else {
-					ShowRight.push(<div class={"-button -unsubscribe"} onclick={this.onSubscribe}><SVGIcon>bubble-empty</SVGIcon><div>Unfollow Thread</div></div>);
-				}
+				ShowRight.push(<UICheckbox onclick={this.onSubscribe} value={props.cansubscribe} tooltip="You always receive notifications for mentions">Recieve notifications</UICheckbox>);
 
 				if ( props.publish ) {
 					if ( props.allowAnonymous ) {
-						ShowRight.push(<div class={"-button -publish"+(state.modified?" -modified":"")} onclick={this.onPublishAnon}><SVGIcon>publish</SVGIcon><div>Publish Anonymously</div></div>);
+						ShowRight.push(<UICheckbox onclick={this.onToggleAnon} value={state.publishAnon} tooltip="NOTE: Your identity is always available to the administrators.">Anonymous</UICheckbox>);
 					}
 					ShowRight.push(<div class={"-button -publish"+(state.modified?" -modified":"")} onclick={this.onPublish}><SVGIcon>publish</SVGIcon><div>Publish</div></div>);
 				}

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -207,9 +207,10 @@
 				}
 
 				& .-right {
+					display: flex;
 					float: right;
 
-					& > div {
+					& > * {
 						margin-left: 0.5em;
 
 						&:first-child {

--- a/src/com/ui/checkbox/checkbox.js
+++ b/src/com/ui/checkbox/checkbox.js
@@ -7,7 +7,7 @@ export default class UICheckbox extends Component {
 	render( props ) {
 		const iconName = (props.radio ? 'radio' : 'checkbox') + (props.value ? '-checked' : '-unchecked');
 		return (
-			<UIButton class={cN('ui-checkbox', props.class)} onclick={props.onclick} >
+			<UIButton class={cN('ui-checkbox', props.class)} onclick={props.onclick} title={props.tooltip} >
 				<UIIcon name={iconName} />
 				<span class="-text">{props.children}</span>
 			</UIButton>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8041100/41189930-ce12d258-6bd5-11e8-9af6-044a5443e9c3.png)


Note that I changed the toggle button for getting notifications on the post to a checkbox because it looked weird with all the mixing of checkboxes and buttons.

Somewhat unrelated, it is a bit strange that the notifications subscription is placed inside the new comments as there's no direct link between subscribing and posting comments. You can subscribe without posting. The action is also performed independently of posting which is contrary to the feeling it gives from its location. Even slightly worse so now that it is a checkbox. What would happen if someone clicks subscribe, and then posts? Does that equal unsubscribe? Or if someone had subscribed before, clicks to unsubscribe and then posts a new comment? This should be its own issue, but since that issue depends on how we handle this PR, I await thee fallout of the PR.

# Related issues

* First implementation of #1262 
* Resolves #1657 
