### PR TITLE
Item/Game remove link and link fixes in general

### DIFF
--- a/src/com/content-common/common-body-link.js
+++ b/src/com/content-common/common-body-link.js
@@ -7,6 +7,7 @@ import SVGIcon							from 'com/svg-icon/icon';
 
 import InputText						from 'com/input-text/text';
 import InputDropdown					from 'com/input-dropdown/dropdown';
+import UIButton from 'com/ui/button/button';
 
 import $Tag								from 'shrub/js/tag/tag';
 
@@ -46,10 +47,24 @@ export default class ContentCommonBodyLink extends Component {
 			});
 	}
 
+	getTagAndIndex() {
+		const { state, props } = this;
+		const index = ((props.tag > 0) && state.indexes) ? state.indexes[props.tag] : props.defaultIndex;
+		const tag = (state.itemlist && state.itemlist[index]) || [props.defaultValue, props.defaultText];
+		return {index, tag};
+	}
+
+	componentDidUpdate() {
+		if (!this.props.tag && this.props.onModifyTag) {
+			const { index, tag } = this.getTagAndIndex();
+			this.props.onModifyTag(tag[0]);
+		}
+	}
+
 	render( props, state ) {
 		let UrlPlaceholder = props.urlPlaceholder ? props.urlPlaceholder : 'URL (example: http://some.website.com/file.zip)';
-		const index = ((props.tag != null) && state.indexes) ? state.indexes[props.tag] : 0;
-		const tag = (state.itemlist && state.itemlist[index]) || [props.defaultValue, props.defaultText];
+		const { index, tag } = this.getTagAndIndex();
+		console.log(index, tag, props.tag);
 		if ( props.editing && state.itemlist && state.indexes ) {
 			return (
 				<div class={cN('content-common-link', '-editing', props.class)}>
@@ -72,6 +87,7 @@ export default class ContentCommonBodyLink extends Component {
 						placeholder={UrlPlaceholder}
 						maxlength={512}
 					/>
+					<UIButton onclick={props.onRemove} title="Remove"><SVGIcon>cross</SVGIcon></UIButton>
 				</div>
 			);
 		}

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -22,6 +22,8 @@ import $Node							from '../../shrub/js/node/node';
 import $Grade							from '../../shrub/js/grade/grade';
 import $Asset							from '../../shrub/js/asset/asset';
 
+const MAX_LINKS = 9;
+
 export default class ContentItem extends Component {
 	constructor( props ) {
 		super(props);
@@ -41,7 +43,7 @@ export default class ContentItem extends Component {
 			'allowAnonymous': parseInt(node.meta['allow-anonymous-comments']),
 		};
 
-		for ( let i = 0; i < 9; i++ ) {
+		for ( let i = 0; i < MAX_LINKS; i++ ) {
 			this.state.linkUrls[i] = node.meta['link-0'+(i+1)] ? node.meta['link-0'+(i+1)] : '';
 			this.state.linkTags[i] = node.meta['link-0'+(i+1)+'-tag'] ? parseInt(node.meta['link-0'+(i+1)+'-tag']) : 0;
 			this.state.linkNames[i] = node.meta['link-0'+(i+1)+'-name'] ? node.meta['link-0'+(i+1)+'-name'] : '';
@@ -248,6 +250,28 @@ export default class ContentItem extends Component {
 		this.contentSimple.setState({'modified': true});
 	}
 
+	onRemoveLink( index ) {
+		const {linkTags, linkNames, linkUrls, linksShown} = this.state;
+		if ((index < 0) || (index >= linkTags.length)) return;
+
+		// Never modify existing state directly and splice is in place
+		const newTags = linkTags.slice();
+		const newUrls = linkUrls.slice();
+		const newNames = linkNames.slice();
+
+		newTags.splice(index, 1);
+		newUrls.splice(index, 1);
+		newNames.splice(index, 1);
+
+		this.setState({
+			"linkTags": newTags,
+			"linkNames": newNames,
+			"linkUrls": newUrls,
+			"linksShown": Math.max(linksShown - 1, 1),
+		});
+		this.contentSimple.setState({'modified': true});
+	}
+
 	onSave( e ) {
 		let {node, user} = this.props;
 
@@ -326,13 +350,15 @@ export default class ContentItem extends Component {
 					onModifyName={this.onModifyLinkName.bind(this, idx)}
 					onModifyTag={this.onModifyLinkTag.bind(this, idx)}
 					onModifyUrl={this.onModifyLinkUrl.bind(this, idx)}
+					onRemove={this.onRemoveLink.bind(this, idx)}
+					defaultIndex={idx}
 					defaultValue={50}
 					defaultText="Source Code"
 				/>
 			);
 		}
 
-		if ( editing && this.state.linksShown < 9 ) {
+		if ( editing && this.state.linksShown < MAX_LINKS ) {
 			LinkMeta.push(
 				<button onclick={e => this.setState({'linksShown': ++this.state.linksShown})}>+</button>
 			);

--- a/src/com/content-item/item.js
+++ b/src/com/content-item/item.js
@@ -5,6 +5,7 @@ import SVGIcon 							from 'com/svg-icon/icon';
 import IMG2 							from 'com/img2/img2';
 
 import ButtonBase						from 'com/button-base/base';
+import UIButton from 'com/ui/button/button';
 
 import ContentCommonBody				from 'com/content-common/common-body';
 import ContentCommonBodyField			from 'com/content-common/common-body-field';
@@ -360,7 +361,7 @@ export default class ContentItem extends Component {
 
 		if ( editing && this.state.linksShown < MAX_LINKS ) {
 			LinkMeta.push(
-				<button onclick={e => this.setState({'linksShown': ++this.state.linksShown})}>+</button>
+				<UIButton onclick={e => this.setState({'linksShown': ++this.state.linksShown})} class="content-common-nav-button"><SVGIcon>plus</SVGIcon><div>More links</div></UIButton>
 			);
 		}
 

--- a/src/com/input-dropdown/dropdown.js
+++ b/src/com/input-dropdown/dropdown.js
@@ -63,7 +63,9 @@ export default class InputDropdown extends Component {
 		}
 	}
 
-	render( props, {show, value} ) {
+	render( props, state ) {
+		const { show } = state;
+		let value = props.value != null ? props.value : state.value;
 		if ( props.items && props.items.length ) {
 			let {selfManaged, useClickCatcher} = props;
 			let ClickCatcher = null;


### PR DESCRIPTION
![ld_remove_links_and_more](https://user-images.githubusercontent.com/8041100/41200958-cc1e939a-6cae-11e8-96ff-a1d810a63319.gif)

* Adds remove link __X__-button.
* Will always show one link minimum and thus the remove button works as reset if you only have one link
* Fixes the style of the add link button
* Adds text to add link button
* Updates `input-dropdown` because it had a flaw in getting its `value` from two ambiguous directions (`state` and `props`).

# Related issues

* Resolves #1392
* It makes the dropdown stay with the selected value on the games pages now, but the grid/view doesn't respect the selection #1504 #1481 Still I think this is out of scope for this PR and I'll look into those issues after this is merged... should be easy.