### PR TITLE
Adding helparea for comments below the comment

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -225,7 +225,7 @@ export default class ContentCommentsComment extends Component {
 	}
 
 	render( props, state ) {
-		let {user, comment, author, error} = props;
+		let {user, comment, author, error, node} = props;
 
 		if ( author || (comment.author == 0) ) {
 			let Name = "Anonymous";
@@ -396,6 +396,7 @@ export default class ContentCommentsComment extends Component {
 							<div class="-title">{ShowTitle}</div>
 							<ContentCommentsMarkup
 								user={user}
+								node={node}
 								editing={state.editing && !state.preview}
 								onmodify={this.onModify}
 								onkeydown={this.onKeyDown}

--- a/src/com/content-comments/comments-markup.less
+++ b/src/com/content-comments/comments-markup.less
@@ -7,11 +7,25 @@
 		border: 1px solid @COL_NLL;
 		background: @COL_NLLL;
 	}
+
 }
 
 #content .content-comments .-indent .-markup {
 	& .-textarea {
 		border: 1px solid @COL_NL;
 		background: @COL_NLL;
+	}
+}
+
+.-helparea {
+  font-weight: bold;
+	color: @MAJOR_COLOR1;
+	font-size: 80%;
+	margin-top: 0.5rem;
+	padding: 0.5rem;
+	border: 1px solid @MAJOR_COLOR1;
+
+	& > * {
+		margin-bottom: 0.5rem;
 	}
 }

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -176,16 +176,15 @@ export default class ContentComments extends Component {
 	}
 
 	renderComments( tree, indent = 0 ) {
-		var user = this.props.user;
-		var authors = this.state.authors;
+		const {user, node} = this.props;
+		const {authors, lovedComments} = this.state;
 
-		var lovedComments = this.state.lovedComments;
-		var actualLove = [];
+		const actualLove = [];
 		for ( var item in lovedComments ) {
 			actualLove.push(lovedComments[item]['note']);
 		}
 
-		var ret = [];
+		const ret = [];
 
 		for ( var item in tree ) {
 			var comment = tree[item].node;
@@ -193,10 +192,10 @@ export default class ContentComments extends Component {
 			var author = authors[comment.author];
 
 			if ( tree[item].child ) {
-				ret.push(<ContentCommentsComment user={user} comment={comment} author={author} indent={indent}><div class="-indent">{this.renderComments(tree[item].child, indent+1)}</div></ContentCommentsComment>);
+				ret.push(<ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={indent}><div class="-indent">{this.renderComments(tree[item].child, indent+1)}</div></ContentCommentsComment>);
 			}
 			else {
-				ret.push(<ContentCommentsComment user={user} comment={comment} author={author} indent={indent}/>);
+				ret.push(<ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={indent}/>);
 			}
 		}
 
@@ -204,17 +203,15 @@ export default class ContentComments extends Component {
 	}
 
 	renderPostNew() {
-		const user = this.props.user;
-		const authors = this.state.authors;
-		const comment = this.state.newcomment;
-		const error = this.state.error;
+		const {user, node} = this.props;
+		const {authors, error, "newcomment": comment} = this.state;
 		const author = authors[comment.author];
 		const allowAnonymous = parseInt(this.props.node.meta['allow-anonymous-comments']);
 
 		// We can subscribe if we haven't subscribed and we don't have a comment in this thread, and we're not an author. Otherwise we can unsubscribe.
 		let canSubscribe = (this.state.subscribed === null) ? !( this.state.hascomment || this.state.isauthor ) : !this.state.subscribed;
 
-		return <div class="-new-comment"><ContentCommentsComment user={user} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} cansubscribe={canSubscribe} onsubscribe={this.onSubscribe} authors={authors}/></div>;
+		return <div class="-new-comment"><ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={0} editing publish onpublish={this.onPublish} nolove allowAnonymous={allowAnonymous} error={error} cansubscribe={canSubscribe} onsubscribe={this.onSubscribe} authors={authors}/></div>;
 	}
 
 	onPublish( e, publishAnon ) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8041100/41201827-c5594440-6cbf-11e8-8acf-70a46ac6b02a.png)

* No disabling of publish/submit comment since that was not popular.
* Adds area blow the input that gives helpful feedback
* Adds "You've reached max comment length" feedback
* Adds "You should not link to own game if commenting on others' games" feedback (Note rule will __not__ activate if (a) commenting on your own game or (b) commenting on a post/non-game).

# Related issues

* Resolves #1636 