### PR TITLE
Rate Games in feed

### DIFF
--- a/src/com/content-timeline/timeline-rategames.js
+++ b/src/com/content-timeline/timeline-rategames.js
@@ -37,13 +37,17 @@ export default class TimelineRateGames extends Component {
     if (props.featured != nextprops.featured) this.getGames(nextprops);
   }
 
+  event_canRate(featured) {
+    if (!featured || featured.type !== 'event') return false;
+    if (!featured.published || !featured.meta) return false;
+    return featured.meta['can-grade'] == "1";
+  }
 
   getGames(props) {
     console.log('getGames', props);
-    const {featured} = props;
-    if (!featured) return;
+    if (!this.event_canRate(props.featured)) return;
 
-    const {id} = featured;
+    const {id} = props.featured;
     const methods = ['parent', 'superparent'];
     const types = ['item'];
     const subtypes = ['game'];
@@ -87,7 +91,7 @@ export default class TimelineRateGames extends Component {
   }
 
   render(props, {expanded, feed, pick, error, loading}) {
-    if (!props.featured) return null;
+    if (!this.event_canRate(props.featured)) return null;
     const HeaderClass = cN('content-common-header');
     const MainClass = cN('content-base', 'content-common', 'rate-games', !expanded && 'minimized');
 

--- a/src/com/content-timeline/timeline-rategames.js
+++ b/src/com/content-timeline/timeline-rategames.js
@@ -1,0 +1,144 @@
+import {h, Component} from 'preact/preact';
+import SVGIcon from 'com/svg-icon/icon';
+import UIButton from 'com/ui/button/button';
+import FooterButtonMinMax from 'com/content-common/common-footer-button-minmax';
+import ContentItemBox from 'com/content-item/item-box';
+import ContentCommonBody from 'com/content-common/common-body';
+import ContentLoading from 'com/content-loading/loading';
+import $Node from '../../shrub/js/node/node';
+
+export const randomPick = (maxExclusive, n) => {
+  const ret = [];
+  while (ret.length < n) {
+    let v = Math.floor(Math.random() * maxExclusive);
+    if (ret.indexOf(v) === -1) ret.push(v);
+  }
+  return ret;
+};
+
+export default class TimelineRateGames extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {"expanded": true, "loading": true};
+    this.handleMinMax = this.handleMinMax.bind(this);
+  }
+
+  handleMinMax() {
+    this.setState({"expanded": !this.state.expanded});
+  }
+
+  componentDidMount() {
+    this.getGames(this.props);
+  }
+
+  componentWillReceiveProps(nextprops) {
+    const {props} = this;
+    //console.log('receiveProps', props, nextprops);
+    if (props.featured != nextprops.featured) this.getGames(nextprops);
+  }
+
+
+  getGames(props) {
+    console.log('getGames', props);
+    const {featured} = props;
+    if (!featured) return;
+
+    const {id} = featured;
+    const methods = ['parent', 'superparent'];
+    const types = ['item'];
+    const subtypes = ['game'];
+    const subsubtypes = 'compo+jam+craft+release';
+    const tags = null;
+    const more = null;
+    const limit = 30;
+    this.setState({'loading': true});
+    $Node.GetFeed( id, methods, types, subtypes, subsubtypes, tags, more, limit )
+      .then(r => {
+        const l = (r.feed && r.feed.length) || 0;
+        if (l === 0) {
+          this.setState({
+            'feed': [],
+            'pick': [],
+            'loaded': new Date(),
+            'loading': false,
+            'reshuffles': 0,
+          });
+        }
+        else
+        {
+          $Node.Get(r.feed.map(elem => elem.id))
+            .then(r => {
+              this.setState({
+                'feed': r.node,
+                'pick': randomPick(l, 3),
+                'loaded': new Date(),
+                'loading': false,
+                'reshuffles': 0,
+              });
+            })
+            .catch(err => {
+              this.setState({'error': err, 'loading': false});
+            });
+        }
+      })
+      .catch(err => {
+        this.setState({'error': err, 'loading': false});
+      });
+  }
+
+  render(props, {expanded, feed, pick, error, loading}) {
+    if (!props.featured) return null;
+    const HeaderClass = cN('content-common-header');
+    const MainClass = cN('content-base', 'content-common', 'rate-games', !expanded && 'minimized');
+
+    let Games;
+    if (error) {
+      Games = <div class="-warning"><SVGIcon>bug</SVGIcon><span>An error occurred while loading the games.</span></div>;
+    }
+    else if (loading) {
+      Games = <ContentLoading />;
+    }
+    else if (feed.length == 0) {
+      Games = <ContentCommonBody>Sorry, there are no published games yet</ContentCommonBody>;
+    }
+    else {
+      //Continue here and don't forget all new imports
+      Games = pick.map(idx => (
+        <ContentItemBox
+            node={r.node}
+            user={props.user}
+            path={props.path}
+            noevent={props.noevent ? props.noevent : null}
+        />
+      ));
+    }
+
+    const FooterLeft = [];
+    const FooterRight = [];
+    FooterLeft.push(<FooterButtonMinMax onclick={this.handleMinMax} />);
+    FooterRight.push((
+      <UIButton class={cN("content-common-footer-button", '-all-games')} href={props.featured && `${props.featured.slug}/games`}>
+          <SVGIcon>forward</SVGIcon><div> All Games</div>
+      </UIButton>
+    ));
+
+    return (
+      <div class={MainClass}>
+        <div class={HeaderClass}><SVGIcon>gamepad</SVGIcon> <span>RATE GAMES</span></div>
+                <div class="-bodies">
+          <div class="-inline-if-not-minimized">
+            {Games}
+          </div>
+        </div>
+        <div class={cN('content-common-footer', (FooterLeft.length + FooterRight.length) ? '-has-items' : '')}>
+            <div class="-left">
+                {FooterLeft}
+            </div>
+            <div class="-right">
+                {FooterRight}
+            </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/com/content-timeline/timeline-rategames.less
+++ b/src/com/content-timeline/timeline-rategames.less
@@ -1,0 +1,21 @@
+@import 'defs.less';
+
+#content {
+  & .rate-games {
+    & > .content-common-header {
+      background: @COL_CAM;
+    }
+
+    & > .content-common-header::after {
+      color: @COL_CAM;
+    }
+
+    & > .-bodies {
+      position: relative;
+      left: -14em;
+      right: 0.5em;
+      padding-top: 3.75em;
+      padding-bottom: 0.5em;
+    }
+  }
+}

--- a/src/com/content-timeline/timeline-rategames.less
+++ b/src/com/content-timeline/timeline-rategames.less
@@ -12,10 +12,19 @@
 
     & > .-bodies {
       position: relative;
-      left: -14em;
-      right: 0.5em;
-      padding-top: 3.75em;
+      padding-top: 0.5em;
       padding-bottom: 0.5em;
+      padding-left: 1em;
+      width: 95%;
+
+      & .games-pick {
+        display: flex;
+        justify-content: center;
+
+        & > a {
+          margin: 0 0.25em;
+        }
+      }
     }
   }
 }

--- a/src/com/content-timeline/timeline.js
+++ b/src/com/content-timeline/timeline.js
@@ -7,6 +7,7 @@ import ContentMore						from 'com/content-more/more';
 
 import ContentCommon					from 'com/content-common/common';
 import ContentCommonBody				from 'com/content-common/common-body';
+import TimelineRateGames from 'com/content-timeline/timeline-rategames';
 
 import $Node							from '../../shrub/js/node/node';
 
@@ -161,9 +162,11 @@ export default class ContentTimeline extends Component {
 			ShowFeed.push(<ContentCommon node={props.node}><ContentCommonBody>error</ContentCommonBody></ContentCommon>);
 		}
 		else if ( feed && feed.length ) {
+			ShowFeed.push(<TimelineRateGames featured={props.featured} />);
 			ShowFeed = ShowFeed.concat(feed.map(this.makeFeedItem));
 		}
 		else if ( feed && (feed.length == 0) ) {
+			ShowFeed.push(<TimelineRateGames featured={props.featured} />);
 			if ( !props.noemptymessage ) {
 				ShowFeed.push(<ContentCommon node={props.node}><ContentCommonBody>Feed is empty</ContentCommonBody></ContentCommon>);
 			}

--- a/src/com/page/root/home/home.js
+++ b/src/com/page/root/home/home.js
@@ -1,20 +1,20 @@
-import {h, Component}					from 'preact/preact';
+import {h, Component} from 'preact/preact';
 
-import ContentList						from 'com/content-list/list';
-import ContentTimeline					from 'com/content-timeline/timeline';
-import ContentHeadlinerFeed				from 'com/content-headliner/headliner-feed';
+import ContentList from 'com/content-list/list';
+import ContentTimeline from 'com/content-timeline/timeline';
+import ContentHeadlinerFeed from 'com/content-headliner/headliner-feed';
 
 export default class PageRootHome extends Component {
-	render( props ) {
-		let {node, user, path, extra} = props;
+    render( props ) {
+        const {node, user, path, extra, featured} = props;
 
-		return (
-			<ContentList class="page-home-home">
-				<ContentHeadlinerFeed node={node} types={['post']} subtypes={['news']} methods={['all']} limit={1} name="news" icon="news" class="-col-c" published love comments more="/news" />
-				<ContentTimeline class="content-timeline-posts" types={['post']} methods={['all']} node={node} user={user} path={path} extra={extra} />
-			</ContentList>
-		);
-	}
-//				<ContentTimeline class="content-timeline-news" types={['post']} subtypes={['news']} methods={['all']} minimized nomore noemptymessage limit={1} node={node} user={user} path={path} extra={extra} />
-//				<ContentHeadliner node={[node, node]} />
+        return (
+            <ContentList class="page-home-home">
+                <ContentHeadlinerFeed node={node} types={['post']} subtypes={['news']} methods={['all']} limit={1} name="news" icon="news" class="-col-c" published love comments more="/news" />
+                <ContentTimeline class="content-timeline-posts" types={['post']} methods={['all']} node={node} user={user} path={path} extra={extra} featured={featured} />
+            </ContentList>
+        );
+    }
+//                <ContentTimeline class="content-timeline-news" types={['post']} subtypes={['news']} methods={['all']} minimized nomore noemptymessage limit={1} node={node} user={user} path={path} extra={extra} />
+//                <ContentHeadliner node={[node, node]} />
 }


### PR DESCRIPTION
![ld_rategames](https://user-images.githubusercontent.com/8041100/41309208-680d17c4-6e7e-11e8-8d0a-e5558ef6db23.gif)

# Features

* Adds an item into the root page feed on top, before all other things, that will display 3 games at a time.
* Only visible when there's a featured event on which there is currently voting.
* It randomly selects 3 out of the top 30 on the smart feed. If it wasn't random there would be a big risk of it being useless since many times after a while the top 1-3 games are unplayable to the majority of participants due to requirements or other issues.
* It collapses and expands like other posts in the feed.
* There's a refresh that re-picks the random 3 out of the same 30 games to be shown (without fetching). Re-picking happens up to 7 times. After that it does a new fetch (you see the spinner breifly in the gif) and you have 7 new iterations of 3 random picked games.
* Adds a button/link to the main page for browsing games to vote on.

# To discuss

* I'm not very happy with selection of `SVGIcon`s for reshuffle and all games in the lower right. Which is also why I wrote the text next to them.
* In my box, for some reason, the event won't list all games (not if I go there the normal way either), so I'm not 100% the `href` is correctly built from the `featured.slug`.
* There's no text about the importance of playing and rating, but I'd prefer to keep the noise down.
* If there's news, it will come below this however important the news is.
* There's no separate default for small screens such as mobile

# Related issues

* Resolves #1644 
