### PR TITLE
Comments highlights

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -228,7 +228,7 @@ export default class ContentCommentsComment extends Component {
 	}
 
 	render( props, state ) {
-		let {user, comment, author, error, node} = props;
+		let {user, comment, author, error, node, isNodeAuthor, isMyComment, isMention} = props;
 
 		if ( author || (comment.author == 0) ) {
 			let Name = "Anonymous";
@@ -383,7 +383,15 @@ export default class ContentCommentsComment extends Component {
 			/>;
 
 			return (
-				<div id={"comment-"+comment.id} class={"-item -comment -indent-"+props.indent}>
+				<div
+					id={"comment-"+comment.id}
+					class={cN(
+						"-item", "-comment", "-indent-" + props.indent,
+						isNodeAuthor && "comment-node-author",
+						isMyComment && "comment-self-authored",
+						isMention && "comment-mention"
+					)}
+				>
 					{ShowAvatar}
 					{ShowAutocompleteAt}
 					{ShowAutocompleteEmoji}

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -28,13 +28,6 @@ export default class ContentComments extends Component {
 	}
 
 	componentWillMount() {
-		$Node.GetMy()
-			.then(r => {
-				$Node.Get(r.id)
-					.then(r2 => {
-						this.setState({'userId': r.id, 'userSlug': `@${r2.node[0].slug}`});
-					});
-			});
 		this.getComments(this.props.node);
 	}
 
@@ -184,7 +177,9 @@ export default class ContentComments extends Component {
 
 	renderComments( tree, indent = 0 ) {
 		const {user, node} = this.props;
-		const {authors, lovedComments, userId, userSlug} = this.state;
+		const {authors, lovedComments} = this.state;
+		const userId = user.id !== 0 && user.id;
+		const userSlug = userId && `@${user.slug}`;
 
 		const actualLove = [];
 		for ( var item in lovedComments ) {

--- a/src/com/content-comments/comments.js
+++ b/src/com/content-comments/comments.js
@@ -28,6 +28,13 @@ export default class ContentComments extends Component {
 	}
 
 	componentWillMount() {
+		$Node.GetMy()
+			.then(r => {
+				$Node.Get(r.id)
+					.then(r2 => {
+						this.setState({'userId': r.id, 'userSlug': `@${r2.node[0].slug}`});
+					});
+			});
 		this.getComments(this.props.node);
 	}
 
@@ -177,7 +184,7 @@ export default class ContentComments extends Component {
 
 	renderComments( tree, indent = 0 ) {
 		const {user, node} = this.props;
-		const {authors, lovedComments} = this.state;
+		const {authors, lovedComments, userId, userSlug} = this.state;
 
 		const actualLove = [];
 		for ( var item in lovedComments ) {
@@ -190,12 +197,14 @@ export default class ContentComments extends Component {
 			var comment = tree[item].node;
 			comment.loved = (actualLove.indexOf(comment.id) !== -1) ? true : false;
 			var author = authors[comment.author];
-
+			const isMyComment = comment.author != null && comment.author === userId;
+			const isMention = !isMyComment && userSlug && comment.body.indexOf(userSlug) > -1;
+			const isNodeAuthor = !isMention && node_IsAuthor(node, {'id': comment.author});
 			if ( tree[item].child ) {
-				ret.push(<ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={indent}><div class="-indent">{this.renderComments(tree[item].child, indent+1)}</div></ContentCommentsComment>);
+				ret.push(<ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={indent} isMyComment={isMyComment} isNodeAuthor={isNodeAuthor} isMention={isMention}><div class="-indent">{this.renderComments(tree[item].child, indent+1)}</div></ContentCommentsComment>);
 			}
 			else {
-				ret.push(<ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={indent}/>);
+				ret.push(<ContentCommentsComment user={user} node={node} comment={comment} author={author} indent={indent} isMyComment={isMyComment} isNodeAuthor={isNodeAuthor} isMention={isMention} />);
 			}
 		}
 

--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -51,6 +51,18 @@
 		position: relative;
 		overflow: auto;
 
+		&.comment-self-authored {
+			border-left: 5px solid @COL_C;
+		}
+
+		&.comment-node-author {
+			border-left: 5px solid @COL_BC;
+		}
+
+		&.comment-mention {
+			border-left: 5px solid @COL_CA;
+		}
+
 		/*border-top: 1px solid @COL_NLL;*/
 
 		&:nth-child(odd) {


### PR DESCRIPTION
Resolves #84 

Adds 3 different highlights:
* Node author
* User is author
* Is mention of user

I made the highlight as a border on the left. It's not optimal since meaning is conveyed only by color (not a11y way), and also it makes the content jump in a little.
 
![image](https://user-images.githubusercontent.com/8041100/44105095-e55f9bcc-9ff0-11e8-80d1-aebb9297d5e8.png)
Above you have normal, normal, mention, self authored (not that self authored trumps node author)

![image](https://user-images.githubusercontent.com/8041100/44105191-2fe0c6bc-9ff1-11e8-85e7-4978861a6a5f.png)
And here we have end of a normal, self, self, self, node author.

If you don't like the border solution and have other ideas for the css, either do a PR to this PR or mock it so I have something to work with. 
I attempted using different background colors but that didn't look very good.