### PR TITLE
Fixing toggle bug for subscribing

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -328,7 +328,7 @@ export default class ContentCommentsComment extends Component {
 
 				var ShowRight = [];
 
-				ShowRight.push(<UICheckbox onclick={this.onSubscribe} value={props.cansubscribe} tooltip="You always receive notifications for mentions">Recieve notifications</UICheckbox>);
+				ShowRight.push(<UICheckbox onclick={this.onSubscribe} value={props.subscribed} tooltip="You always receive notifications for mentions">Recieve notifications</UICheckbox>);
 
 				if ( props.publish ) {
 					if ( props.allowAnonymous ) {


### PR DESCRIPTION
New behavior:

When viewing a page/post/item you haven't interacted with the checkbox will not be checked indicating that you are currently not subscribing to it.

If you click it, you will subscribe even if you don't post a comment and the checkbox will always reflect your current subscription status.

If you instead write a comment one of two things will happen:
* If you had no subscription status before (had not clicked and not commented) you will automatically subscribe as you comment. The checkbox will reflect this updated
* If you had a subscription status before (had clicked it to any state or commented), that state will remain unchanged.

Resolves #1715 

