### PR TITLE
Notifications update

### DIFF
--- a/src/com/input-dropdown/dropdown.js
+++ b/src/com/input-dropdown/dropdown.js
@@ -9,7 +9,7 @@ export default class InputDropdown extends Component {
 		super(props);
 
 		this.state = {
-			'show': props.startExpanded,
+			'show': false,
 			'value': props.value ? props.value : 0
 		};
 
@@ -17,6 +17,7 @@ export default class InputDropdown extends Component {
 
 		this.onShow = this.onShow.bind(this);
 		this.onHide = this.onHide.bind(this);
+		this.doShow = this.doShow.bind(this);
 	}
 
 	doShow( e ) {
@@ -27,6 +28,7 @@ export default class InputDropdown extends Component {
 	doHide( e ) {
 		this.setState({'show': false});
 		document.removeEventListener('click', this.onHide);
+		if (this.props.onhide) this.props.onhide(e);
 	}
 
 	// Clicking on the button
@@ -61,6 +63,20 @@ export default class InputDropdown extends Component {
 			this.setState({'value': parseInt(e.target.dataset.id)});
 			this.doHide(e);
 		}
+	}
+
+	componentWillReceiveProps(nextProps) {
+			if (nextProps.expanded && !this.state.show) {
+				this.setState({'show': true});
+				setTimeout(this.doShow, 100);
+			}
+	}
+
+	componentDidMount() {
+			if (this.props.expanded && !this.state.show) {
+				this.setState({'show': true});
+				setTimeout(this.doShow, 100);
+			}
 	}
 
 	render( props, state ) {

--- a/src/com/layout/grid/grid-selector.js
+++ b/src/com/layout/grid/grid-selector.js
@@ -14,6 +14,7 @@ export default class GridSelector extends Component {
 
         this.onSelectLayout = this.onSelectLayout.bind(this);
         this.onToggleDropDown = this.onToggleDropDown.bind(this);
+        this.onHideDropDown = this.onHideDropDown.bind(this);
     }
 
     componentDidMount() {
@@ -38,6 +39,10 @@ export default class GridSelector extends Component {
     onToggleDropDown() {
         console.log('toggle dropdown', this.state);
         this.setState({'expanded': !this.state.expanded});
+    }
+
+    onHideDropDown() {
+      this.setState({'expanded': false});
     }
 
     onSelectLayout( index ) {
@@ -67,9 +72,10 @@ export default class GridSelector extends Component {
                <Dropdown
                     items={options}
                     onmodify={this.onSelectLayout}
-                    startExpanded={true}
+                    expanded={expanded}
                     value={selected}
                     selfManaged={false}
+                    onhide={this.onHideDropDown}
                 />
             );
        }

--- a/src/com/view/bar/bar-notifications.js
+++ b/src/com/view/bar/bar-notifications.js
@@ -30,6 +30,7 @@ export default class DropdownNotification extends NotificationsBase {
 
 	componentDidMount() {
 		this.processNotificationFeed(this.props.feed);
+		if (this.props.anythingToMark) this.markAndClearNotifications();
 	}
 
 	hasNewNotification(feed) {
@@ -49,6 +50,7 @@ export default class DropdownNotification extends NotificationsBase {
 		if (this.hasNewNotification(nextProps.feed)) {
 			this.clearNotifications();
 			this.processNotificationFeed(nextProps.feed);
+			if (nextProps.anythingToMark) this.markAndClearNotifications();
 		}
 	}
 
@@ -97,14 +99,10 @@ export default class DropdownNotification extends NotificationsBase {
 			Notifications.push([-3, (<div>You have no notifications.</div>)]);
 		}
 
-		if ( !loading && this.hasUnreadNotifications() ) {
-			Notifications.push([-2, (<ButtonLink onclick={this.markAndClearNotifications} ><em>Mark all as read</em></ButtonLink>)]);
-		}
-
 		Notifications.push([-1, (<ButtonLink onclick={this.hide} href="/my/notifications"><em>Open notifications feed...</em></ButtonLink>)]);
 
 		return (
-			<Dropdown class="-notifications" items={Notifications} startExpanded={true} hideSelectedField={true} />
+			<Dropdown class="-notifications" items={Notifications} expanded={true} hideSelectedField={true} onhide={this.hide} />
 		);
 	}
 }


### PR DESCRIPTION
This makes notifications fetching more aggressively try and limit api-calls by not getting the notifications-feed if there seems to be no new notifications.

It also switches behavior so that it marks all notifications as read when you expand the drop-down (and see/read them). Since there's a notifications feed for you to look at all old notifications, I think this is the best way of limiting the annoying extra clicking that was involved before.

I attempted using the new `ui/dropdown` but that would have needed a substantial refactor of both that component and the notifications-code so instead I stuck with the `input-dropdown/dropdown` and managed to get it work on my computer so that the dropdown collapses when you click anywhere outside the dropdown and when you click on something in it. I also verified that the cog for the games grid still work with this update as well as the game-links when composing `my game`. It was a bit of a hack, relying on a timeout but since I couldn't get and onfocusout or onblur, it was impossibly to attach the general click event callback immediately without compeletely destroying the notifications and game grid dropdowns.

Resolves #1365 