### PR TITLE
Spoof calendar shrub

### DIFF
--- a/src/com/sidebar/upcoming/upcoming.js
+++ b/src/com/sidebar/upcoming/upcoming.js
@@ -1,6 +1,6 @@
-import {h, Component}					from 'preact/preact';
+import {h, Component} from 'preact/preact';
 import UIIcon from 'com/ui/icon/icon';
-import ButtonLink						from 'com/button-link/link';
+import ButtonLink from 'com/button-link/link';
 
 import $Calendar from 'shrub/js/calendar/calendar';
 
@@ -11,34 +11,40 @@ export default class SidebarUpcoming extends Component {
 	}
 
 	componentDidMount() {
-			$Calendar.Get(new Date(), null, 5).then(r => {
-				console.log(r);
-				if (r.status === 200) {
-					this.setState({'calendar': r.calendar});
-				}
-			});
+		$Calendar.Get(new Date(), null, 5).then(r => {
+			if (r.status === 200) {
+				this.setState({'calendar': r.calendar});
+			}
+		});
 	}
 
 	render( props, state ) {
 		const {calendar} = state;
 		const Items = [];
+		const currentYear = new Date().getFullYear();
 		if (calendar) {
-			Object.values(calendar).forEach(item => {
+			calendar.forEach(item => {
 				let options;
 				if (item.precision === 'month') {
-					options = {'year': 'numeric', 'month': 'long'};
+					if (item.when.getFullYear() === currentYear) {
+						options = {'month': 'long'};
+					}
+					else {
+						options = {'year': 'numeric', 'month': 'long'};
+					}
 				}
 				else if (item.precision === 'day') {
-					if (item.getFullYear() === currentYear) {
+					if (item.when.getFullYear() === currentYear) {
 						options = {'month': 'long', 'day': 'numeric'};
 					}
 					else {
 						options = {'year': 'numeric', 'month': 'short', 'day': 'numeric'};
 					}
 				}
+				const dateString = item.when.toLocaleDateString(undefined, options);
 				Items.push(
 					<div class="-item">
-						<strong>{item.when.toLocalDateString(undefined, options)}</strong> - {item.what} <UIIcon baseline small>{item.icon}</UIIcon>
+						<strong>{dateString}</strong> - {item.what} <UIIcon baseline small>{item.icon}</UIIcon>
 					</div>
 				);
 			});

--- a/src/com/sidebar/upcoming/upcoming.js
+++ b/src/com/sidebar/upcoming/upcoming.js
@@ -1,33 +1,53 @@
 import {h, Component}					from 'preact/preact';
-import SVGIcon							from 'com/svg-icon/icon';
+import UIIcon from 'com/ui/icon/icon';
 import ButtonLink						from 'com/button-link/link';
+
+import $Calendar from 'shrub/js/calendar/calendar';
 
 export default class SidebarUpcoming extends Component {
 	constructor( props ) {
 		super(props);
+		this.state = {};
 	}
 
-	render( props ) {
-		var Items = [
-//			<div class="-item"><strong>Mar 24th</strong> - Theme Suggestions Open <SVGIcon baseline small>suggestion</SVGIcon></div>,
-//			<div class="-item"><strong>Apr 7th</strong> - Theme Selection Starts <SVGIcon baseline small>mallet</SVGIcon></div>,
-//			<div class="-item"><strong>Apr 21st</strong> - Ludum Dare 38 <SVGIcon baseline small>trophy</SVGIcon></div>,
-//			<div class="-item"><strong>May 19th</strong> - Results <SVGIcon baseline small>checker</SVGIcon></div>,
-//			<div class="-item"><strong>July 28th</strong> - Ludum Dare 39 <SVGIcon baseline small>trophy</SVGIcon></div>,
-//			<div class="-item"><strong>August 23rd</strong> - Results <SVGIcon baseline small>checker</SVGIcon></div>,
-//			<div class="-item"><strong>April 20th</strong> - Ludum Dare 41 <SVGIcon baseline small>trophy</SVGIcon></div>,
-//			<div class="-item"><strong>December 28th</strong> - Results <SVGIcon baseline small>checker</SVGIcon></div>,
-			<div class="-item"><strong>August 10th</strong> - Ludum Dare 42 <SVGIcon baseline small>trophy</SVGIcon></div>,
-			<div class="-item"><strong>December 2018</strong> - Ludum Dare 43 <SVGIcon baseline small>trophy</SVGIcon></div>,
-			<div class="-item"><strong>April 2019</strong> - Ludum Dare 44 <SVGIcon baseline small>trophy</SVGIcon></div>,
-		];
+	componentDidMount() {
+			$Calendar.Get(new Date(), null, 5).then(r => {
+				console.log(r);
+				if (r.status === 200) {
+					this.setState({'calendar': r.calendar});
+				}
+			});
+	}
 
+	render( props, state ) {
+		const {calendar} = state;
+		const Items = [];
+		if (calendar) {
+			Object.values(calendar).forEach(item => {
+				let options;
+				if (item.precision === 'month') {
+					options = {'year': 'numeric', 'month': 'long'};
+				}
+				else if (item.precision === 'day') {
+					if (item.getFullYear() === currentYear) {
+						options = {'month': 'long', 'day': 'numeric'};
+					}
+					else {
+						options = {'year': 'numeric', 'month': 'short', 'day': 'numeric'};
+					}
+				}
+				Items.push(
+					<div class="-item">
+						<strong>{item.when.toLocalDateString(undefined, options)}</strong> - {item.what} <UIIcon baseline small>{item.icon}</UIIcon>
+					</div>
+				);
+			});
+		}
 		return (
 			<div class="sidebar-base sidebar-shortlist sidebar-upcoming">
-				<div class="-title _font2"><SVGIcon baseline>calendar-wide</SVGIcon> <span class="-text">Coming Up</span></div>
+				<div class="-title _font2"><UIIcon baseline>calendar-wide</UIIcon> <span class="-text">Coming Up</span></div>
 				{Items}
 			</div>
 		);
 	}
 }
-//				<ButtonLink class="-footer" href="/cal">Full Schedule</ButtonLink>

--- a/src/com/view/sidebar/sidebar.js
+++ b/src/com/view/sidebar/sidebar.js
@@ -8,54 +8,90 @@ import SidebarTrending					from 'com/sidebar/trending/trending';
 import SidebarSponsor					from 'com/sidebar/sponsor/sponsor';
 import SidebarSupport					from 'com/sidebar/support/support';
 
+import $Calendar from 'shrub/js/calendar/calendar';
+
 export default class ViewSidebar extends Component {
 	constructor( props ) {
 		super(props);
+		this.state = {};
 	}
 
-	render( props ) {
-		// TODO: cleanup
-		let ldName = "Ludum Dare 42";
-		let ldStartDate = new Date(Date.UTC(2018, 7, 10, 22, 0, 0));
+	componentDidMount() {
+		if (this.props.featured) {
+			this.fetchFeatured(this.props.featured);
+		}
+	}
 
-		let compoEndDate = new Date(Date.UTC(2018, 7, 12, 22, 0, 0));
-		let compoEndDate2 = new Date(Date.UTC(2018, 7, 12, 23, 0, 0));
+	componentWillReceiveProps(newProps) {
+		const oldProps = this.props;
+		if (
+			(!!oldProps.featured != !!newProps.featured)
+			|| (oldProps.featured && newProps.featured && oldProps.featured.id !== newProps.featured.id)
+		) {
+			this.fetchCalendar(newProps.featured);
+		}
+	}
 
-		let jamEndDate = new Date(Date.UTC(2018, 7, 13, 22, 0, 0));
-		//let jamEndDate2 = new Date(Date.UTC(2018, 7, 13, 23, 0, 0));
-		let jamEndDate2 = new Date(Date.UTC(2018, 7, 14, 22, 0, 0));
+	fetchCalendar(featured) {
+		if (!featured) {
+			this.setState({'calendar': null});
+			return;
+		}
+		$Calendar.GetEvent(featured.id)
+			.then(r => {
+				if (r.status === 200) {
+					this.setState({'calendar': r.calendar});
+				}
+			});
+	}
 
-		let gradeEndDate = new Date(Date.UTC(2018, 8, 4, 20, 0, 0));
-		let resultsDate = new Date(Date.UTC(2018, 8, 4, 24, 0, 0));
-
+	render( props, state ) {
+		let ldStartDate;
+		let compoEndDate;
+		let compoEndDate2;
+		let jamEndDate;
+		let jamEndDate2;
+		let gradeEndDate;
+		let resultsDate;
+		const {calendar} = state;
+		if (calendar) {
+			ldStartDate = calendar['event-start'];
+			compoEndDate = calendar['event-compo-end'];
+			compoEndDate2 = calendar['event-compo-end-submission'];
+			jamEndDate = calendar['event-jam-end'];
+			jamEndDate2 = calendar['event-jam-end-submission'];
+			gradeEndDate = calendar['event-grade-end'];
+			resultsDate = calendar['event-results-publish'];
+		}
+		let ldName = props.featured && props.featured.name;
 		let now = new Date();
 
 		let ShowCountdown = [];
-		if ( now < ldStartDate ) {
+		if (ldStartDate && now < ldStartDate ) {
 			ShowCountdown.push(<SidebarCountdown date={ ldStartDate } nc="ld" to={ldName} tt="Starts" />);
 		}
 		else {
-			if ( (now < compoEndDate) && (ShowCountdown.length < 2) ) {
+			if ( compoEndDate && (now < compoEndDate) && (ShowCountdown.length < 2) ) {
 				ShowCountdown.push(<SidebarCountdown date={ compoEndDate } nc="compo" to="Compo" tt="Ends" />);
 			}
-			else if ( (now < compoEndDate2) && (ShowCountdown.length < 2) ) {
+			else if ( compoEndDate2 && (now < compoEndDate2) && (ShowCountdown.length < 2) ) {
 				ShowCountdown.push(<SidebarCountdown date={ compoEndDate2 } nc="compo" to="Submission Hour" tt="Ends" />);
 			}
 
-			if ( (now < jamEndDate) && (ShowCountdown.length < 2) ) {
+			if ( jamEndDate && (now < jamEndDate) && (ShowCountdown.length < 2) ) {
 				ShowCountdown.push(<SidebarCountdown date={ jamEndDate } nc="jam" to="Jam" tt="Ends" />);
 			}
-			else if ( (now < jamEndDate2) && (ShowCountdown.length < 2) ) {
+			else if ( jamEndDate2 && (now < jamEndDate2) && (ShowCountdown.length < 2) ) {
 				//ShowCountdown.push(<SidebarCountdown date={ jamEndDate2 } nc="jam" to="Submission Hour+" tt="Ends" />);
 				ShowCountdown.push(<SidebarCountdown date={ jamEndDate2 } nc="jam" to="Submission Day*" tt="Ends" />);
 			}
 
-			if ( (now < gradeEndDate) && props.featured && props.featured.meta && props.featured.meta['can-grade'] && (ShowCountdown.length < 2) ) { //now < compoEndDate2 || now < jamEndDate2 || now < gradeEndDate ) {
+			if ( gradeEndDate && (now < gradeEndDate) && props.featured && props.featured.meta && props.featured.meta['can-grade'] && (ShowCountdown.length < 2) ) { //now < compoEndDate2 || now < jamEndDate2 || now < gradeEndDate ) {
 				ShowCountdown.push(<SidebarCountdown date={ gradeEndDate } nc="jam" to="Play+Rate games" tt="Ends" />);
 			}
 
 			// TODO: make this only appear a few hours before grading ends
-			if ( (now < resultsDate) && (ShowCountdown.length < 2) ) {
+			if ( resultsDate && (now < resultsDate) && (ShowCountdown.length < 2) ) {
 				ShowCountdown.push(<SidebarCountdown date={ resultsDate } nc="jam" to="Results" tt="" />);
 			}
 		}

--- a/src/com/view/sidebar/sidebar.js
+++ b/src/com/view/sidebar/sidebar.js
@@ -17,27 +17,7 @@ export default class ViewSidebar extends Component {
 	}
 
 	componentDidMount() {
-		if (this.props.featured) {
-			this.fetchFeatured(this.props.featured);
-		}
-	}
-
-	componentWillReceiveProps(newProps) {
-		const oldProps = this.props;
-		if (
-			(!!oldProps.featured != !!newProps.featured)
-			|| (oldProps.featured && newProps.featured && oldProps.featured.id !== newProps.featured.id)
-		) {
-			this.fetchCalendar(newProps.featured);
-		}
-	}
-
-	fetchCalendar(featured) {
-		if (!featured) {
-			this.setState({'calendar': null});
-			return;
-		}
-		$Calendar.GetEvent(featured.id)
+		$Calendar.GetEvent()
 			.then(r => {
 				if (r.status === 200) {
 					this.setState({'calendar': r.calendar});
@@ -53,6 +33,7 @@ export default class ViewSidebar extends Component {
 		let jamEndDate2;
 		let gradeEndDate;
 		let resultsDate;
+		let ldName;
 		const {calendar} = state;
 		if (calendar) {
 			ldStartDate = calendar['event-start'];
@@ -62,8 +43,8 @@ export default class ViewSidebar extends Component {
 			jamEndDate2 = calendar['event-jam-end-submission'];
 			gradeEndDate = calendar['event-grade-end'];
 			resultsDate = calendar['event-results-publish'];
+			ldName = calendar.name;
 		}
-		let ldName = props.featured && props.featured.name;
 		let now = new Date();
 
 		let ShowCountdown = [];

--- a/src/shrub/js/calendar/calendar.js
+++ b/src/shrub/js/calendar/calendar.js
@@ -1,0 +1,121 @@
+const DefaultEvent = 97793;
+const EventDetails = {
+  '97793': {
+		'event-start': new Date(Date.UTC(2018, 7, 10, 22, 0, 0)),
+		'event-compo-end': new Date(Date.UTC(2018, 7, 12, 22, 0, 0)),
+		'event-compo-end-submission': new Date(Date.UTC(2018, 7, 12, 23, 0, 0)),
+    'event-jam-end': new Date(Date.UTC(2018, 7, 13, 22, 0, 0)),
+    'event-jam-end-submission': new Date(Date.UTC(2018, 7, 14, 22, 0, 0)),
+		'event-grade-end': new Date(Date.UTC(2018, 8, 4, 20, 0, 0)),
+		'event-results-publish': new Date(Date.UTC(2018, 8, 4, 24, 0, 0)),
+  },
+};
+
+const Calendar = {
+  '0': {
+    'when': new Date(Date.UTC(2018, 2, 24)),
+    'what': 'Theme Suggestions Open',
+    'icon': 'suggestion',
+    'precision': 'day',
+  },
+  '1': {
+    'when': new Date(Date.UTC(2018, 3, 7)),
+    'what': 'Theme Selection Starts',
+    'icon': 'mallet',
+    'precision': 'day',
+  },
+  '2': {
+    'when': new Date(Date.UTC(2018, 3, 21)),
+    'what': 'Ludum Dare 38',
+    'icon': 'trophy',
+    'precision': 'day',
+  },
+  '3': {
+    'when': new Date(Date.UTC(2018, 4, 19)),
+    'what': 'Results',
+    'icon': 'checker',
+    'precision': 'day',
+  },
+  '4': {
+    'when': new Date(Date.UTC(2018, 5, 28)),
+    'what': 'Ludum Dare 39',
+    'icon': 'trophy',
+    'precision': 'day',
+  },
+  '5': {
+    'when': new Date(Date.UTC(2018, 7, 23)),
+    'what': 'Results',
+    'icon': 'checker',
+    'precision': 'day',
+  },
+  '6': {
+    'when': new Date(Date.UTC(2018, 3, 20)),
+    'what': 'Ludum Dare 41',
+    'icon': 'trophy',
+    'precision': 'day',
+  },
+  '7': {
+    'when': new Date(Date.UTC(2018, 11, 28)),
+    'what': 'Results',
+    'icon': 'checker',
+    'precision': 'day',
+  },
+  '8': {
+    'when': new Date(Date.UTC(2018, 7, 10)),
+    'what': 'Ludum Dare 42',
+    'icon': 'trophy',
+    'precision': 'day',
+  },
+  '9': {
+    'when': new Date(Date.UTC(2018, 11, 1)),
+    'what': 'Ludum Dare 43',
+    'icon': 'trophy',
+    'precision': 'month',
+  },
+  '10': {
+    'when': new Date(Date.UTC(2019, 3, 1)),
+    'what': 'Ludum Dare 43',
+    'icon': 'trophy',
+    'precision': 'month',
+  },
+};
+
+const GetEvent = (node) => {
+  let calendar;
+  if ( History[node] ) {
+    calendar = Object.assign({}, History[node]);
+  }
+  else if ( !!node ) {
+    calendar = Object.assign({}, History[DefaultEvent]);
+  }
+  return Promise.resolve({
+    'status': 200,
+    'calendar': calendar,
+  });
+};
+
+const Get = (fromDate=null, toDate=null, maxCount=null) => {
+    return Promise.resolve({
+      'status': 200,
+      'calendar':
+          Object.assign(...Object.entries(Calendar)
+            .filter(([id, val]) => {
+              if (!fromDate && !toDate) return true;
+              if (!(fromDate && fromDate <= val.when)) {
+                return false;
+              }
+              if (!(toDate && toDate >= val.when)) {
+                return false;
+              }
+              return true;
+            })
+            .sort(([id, val], [id2, val2]) => val2.when - val.when)
+            .slice(0, maxCount == null ? Object.keys(Calendar).length : maxCount)
+            .map(([k, v]) => ({[k]: v}))),
+    });
+};
+
+export default {
+	GetEvent,
+  Get,
+};

--- a/src/shrub/js/calendar/calendar.js
+++ b/src/shrub/js/calendar/calendar.js
@@ -1,6 +1,7 @@
-const DefaultEvent = 97793;
+const DefaultEvent = 'next';
 const EventDetails = {
   '97793': {
+    'name': 'Ludum Dare 42',
 		'event-start': new Date(Date.UTC(2018, 7, 10, 22, 0, 0)),
 		'event-compo-end': new Date(Date.UTC(2018, 7, 12, 22, 0, 0)),
 		'event-compo-end-submission': new Date(Date.UTC(2018, 7, 12, 23, 0, 0)),
@@ -10,7 +11,14 @@ const EventDetails = {
 		'event-results-publish': new Date(Date.UTC(2018, 8, 4, 24, 0, 0)),
   },
   'next': {
-
+    'name': 'Ludum Dare 43',
+		'event-start': new Date(Date.UTC(2018, 11, 1, 2, 0, 0)),
+		'event-compo-end': new Date(Date.UTC(2018, 11, 3, 2, 0, 0)),
+		'event-compo-end-submission': new Date(Date.UTC(2018, 11, 3, 3, 0, 0)),
+    'event-jam-end': new Date(Date.UTC(2018, 11, 4, 2, 0, 0)),
+    'event-jam-end-submission': new Date(Date.UTC(2018, 11, 4, 3, 0, 0)),
+		'event-grade-end': new Date(Date.UTC(2018, 11, 31, 20, 0, 0)),
+		'event-results-publish': new Date(Date.UTC(2018, 11, 31, 24, 0, 0)),
   }
 };
 
@@ -103,11 +111,11 @@ const Calendar = {
 
 const GetEvent = (node) => {
   let calendar;
-  if ( History[node] ) {
-    calendar = Object.assign({}, History[node]);
+  if ( EventDetails[node] ) {
+    calendar = Object.assign({}, EventDetails[node]);
   }
-  else if ( !!node ) {
-    calendar = Object.assign({}, History[DefaultEvent]);
+  else if (!node) {
+    calendar = Object.assign({}, EventDetails[DefaultEvent]);
   }
   return Promise.resolve({
     'status': 200,

--- a/src/shrub/js/calendar/calendar.js
+++ b/src/shrub/js/calendar/calendar.js
@@ -95,24 +95,23 @@ const GetEvent = (node) => {
 };
 
 const Get = (fromDate=null, toDate=null, maxCount=null) => {
-    return Promise.resolve({
-      'status': 200,
-      'calendar':
-          Object.assign(...Object.entries(Calendar)
-            .filter(([id, val]) => {
-              if (!fromDate && !toDate) return true;
-              if (!(fromDate && fromDate <= val.when)) {
-                return false;
-              }
-              if (!(toDate && toDate >= val.when)) {
-                return false;
-              }
-              return true;
-            })
-            .sort(([id, val], [id2, val2]) => val2.when - val.when)
-            .slice(0, maxCount == null ? Object.keys(Calendar).length : maxCount)
-            .map(([k, v]) => ({[k]: v}))),
-    });
+  return Promise.resolve({
+    'status': 200,
+    'calendar': Object.entries(Calendar)
+        .filter(([id, val]) => {
+          if (!fromDate && !toDate) return true;
+          if (fromDate && fromDate > val.when) {
+            return false;
+          }
+          if (toDate && toDate < val.when) {
+            return false;
+          }
+          return true;
+        })
+        .sort(([id, val], [id2, val2]) => val2.when > val.when ? -1 : 1)
+        .slice(0, maxCount == null ? Object.keys(Calendar).length : maxCount)
+        .map(([k, v]) => v)
+  });
 };
 
 export default {

--- a/src/shrub/js/calendar/calendar.js
+++ b/src/shrub/js/calendar/calendar.js
@@ -9,41 +9,44 @@ const EventDetails = {
 		'event-grade-end': new Date(Date.UTC(2018, 8, 4, 20, 0, 0)),
 		'event-results-publish': new Date(Date.UTC(2018, 8, 4, 24, 0, 0)),
   },
+  'next': {
+
+  }
 };
 
 const Calendar = {
   '0': {
-    'when': new Date(Date.UTC(2018, 2, 24)),
+    'when': new Date(Date.UTC(2017, 2, 24)),
     'what': 'Theme Suggestions Open',
     'icon': 'suggestion',
     'precision': 'day',
   },
   '1': {
-    'when': new Date(Date.UTC(2018, 3, 7)),
+    'when': new Date(Date.UTC(2017, 3, 7)),
     'what': 'Theme Selection Starts',
     'icon': 'mallet',
     'precision': 'day',
   },
   '2': {
-    'when': new Date(Date.UTC(2018, 3, 21)),
+    'when': new Date(Date.UTC(2017, 3, 21)),
     'what': 'Ludum Dare 38',
     'icon': 'trophy',
     'precision': 'day',
   },
   '3': {
-    'when': new Date(Date.UTC(2018, 4, 19)),
+    'when': new Date(Date.UTC(2017, 4, 19)),
     'what': 'Results',
     'icon': 'checker',
     'precision': 'day',
   },
   '4': {
-    'when': new Date(Date.UTC(2018, 5, 28)),
+    'when': new Date(Date.UTC(2017, 5, 28)),
     'what': 'Ludum Dare 39',
     'icon': 'trophy',
     'precision': 'day',
   },
   '5': {
-    'when': new Date(Date.UTC(2018, 7, 23)),
+    'when': new Date(Date.UTC(2017, 7, 23)),
     'what': 'Results',
     'icon': 'checker',
     'precision': 'day',
@@ -55,26 +58,44 @@ const Calendar = {
     'precision': 'day',
   },
   '7': {
-    'when': new Date(Date.UTC(2018, 11, 28)),
-    'what': 'Results',
-    'icon': 'checker',
-    'precision': 'day',
-  },
-  '8': {
     'when': new Date(Date.UTC(2018, 7, 10)),
     'what': 'Ludum Dare 42',
     'icon': 'trophy',
     'precision': 'day',
   },
+  '8': {
+    'when': new Date(Date.UTC(2018, 8, 5)),
+    'what': 'Results',
+    'icon': 'checker',
+    'precision': 'day',
+  },
   '9': {
-    'when': new Date(Date.UTC(2018, 11, 1)),
+    'when': new Date(Date.UTC(2018, 10, 30)),
     'what': 'Ludum Dare 43',
     'icon': 'trophy',
     'precision': 'month',
   },
   '10': {
     'when': new Date(Date.UTC(2019, 3, 1)),
-    'what': 'Ludum Dare 43',
+    'what': 'Ludum Dare 44',
+    'icon': 'trophy',
+    'precision': 'month',
+  },
+  '11': {
+    'when': new Date(Date.UTC(2019, 9, 1)),
+    'what': 'Ludum Dare 45',
+    'icon': 'trophy',
+    'precision': 'month',
+  },
+  '12': {
+    'when': new Date(Date.UTC(2020, 3, 1)),
+    'what': 'Ludum Dare 44',
+    'icon': 'trophy',
+    'precision': 'month',
+  },
+  '13': {
+    'when': new Date(Date.UTC(2020, 9, 1)),
+    'what': 'Ludum Dare 45',
     'icon': 'trophy',
     'precision': 'month',
   },


### PR DESCRIPTION
Moving those things about calendars that I found into `$Calendar` in js-shrub.
This PR should be in sync with @mikekasprzak recent merges, but that should probably be verified.

Resolves #1768 