### PR TITLE
Fix textarea focus colour on dark themes.

### DIFF
--- a/src/com/input-textarea/input-textarea.less
+++ b/src/com/input-textarea/input-textarea.less
@@ -29,6 +29,7 @@
 
 			&:focus {
 				background: @COL_W;
+				color: @COL_K;
 			}
 		}
 	}


### PR DESCRIPTION
Since the textarea background is set to white and the font color is not set, for dark theme users the focused textarea ends up being white on white and unreadable. 

I picked COL_K from this file since it seems to be the opposite of COL_W: https://github.com/ludumdare/ludumdare/blob/master/src/public-ludumdare.com/defs.less , and (presumably?) comes out to black on all sites, but I don't have the stack setup to test this at the moment. If there's a more on brand colour to pick, can update this PR.