### PR TITLE
[WIP] [Scotchbox 3.5] Don't attempt make dir's if they already exist

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,14 +13,14 @@ cd $SCRIPTPATH
 # Create tables
 (cd /vagrant/www/src/shrub/tools; echo YES | php table-create)
 
-# Create upload folders
-mkdir /vagrant/www/public-static/content
-mkdir /vagrant/www/public-static/raw
-ln -s ../internal /vagrant/www/public-static/raw/internal
+# Create upload folders if they don't exist
+mkdir -p /vagrant/www/public-static/content
+mkdir -p /vagrant/www/public-static/raw
+ln -sfn ../internal /vagrant/www/public-static/raw/internal
 
 # Setup Sphinx
 mv /etc/sphinxsearch/sphinx.conf /etc/sphinxsearch/_sphinx.conf
-ln -s /vagrant/www/private-search/sphinx.conf /etc/sphinxsearch/sphinx.conf
-ln -s /var/lib/sphinxsearch/data /home/vagrant/sphinx-data
-ln -s /vagrant/www/private-search/sphinx.conf /home/vagrant/sphinx.conf
+ln -sfn /vagrant/www/private-search/sphinx.conf /etc/sphinxsearch/sphinx.conf
+ln -sfn /var/lib/sphinxsearch/data /home/vagrant/sphinx-data
+ln -sfn /vagrant/www/private-search/sphinx.conf /home/vagrant/sphinx.conf
 service sphinxsearch restart


### PR DESCRIPTION
These get run every time Dairy box is provisioned, which could be more than once.

-p on mkdir means it won't attempt to create a dir if it already exists
-sfn is similar and respects symlinks https://unix.stackexchange.com/questions/207294/create-symlink-overwrite-if-one-exists

Also that internal symlink looks wrong to me. Isn't it making `DairyBox/www/public-static/internal/internal` when is should be `DairyBox/www/public-static/internal`