### PR TITLE
[WIP] [Scotchbox 3.5] default apache file

### DIFF
--- a/scripts/apache/add-ports.sh
+++ b/scripts/apache/add-ports.sh
@@ -19,9 +19,6 @@ ln -s ../sites-available/custom-port.conf /etc/apache2/sites-enabled/001-custom-
 ln -s ../sites-available/jammer-work.conf /etc/apache2/sites-enabled/010-jammer-work.conf
 ln -s ../sites-available/ludumdare-org.conf /etc/apache2/sites-enabled/011-ludumdare-org.conf
 
-# Disable default ScotchBox mount
-rm /etc/apache2/sites-enabled/scotchbox.local.conf
-
 echo "Restarting Apache..."
 apache2ctl restart
 echo "Done (Apache Ports)."


### PR DESCRIPTION
provisioning show error
`    default: rm: cannot remove '/etc/apache2/sites-enabled/scotchbox.local.conf': No such file or directory`

because this file no longer exists
```
agrant@dairybox:~$ cd /etc/apache2/sites-enabled/
vagrant@dairybox:/etc/apache2/sites-enabled$ ls
000-default.conf  001-custom-port.conf  010-jammer-work.conf  011-ludumdare-org.conf
```

so I removed attempt to remove it from add-ports.sh
```
# Disable default ScotchBox mount	
rm /etc/apache2/sites-enabled/scotchbox.local.conf
```
