### PR TITLE
Copy short link button

### DIFF
--- a/src/com/button-clipboard/clipboard.js
+++ b/src/com/button-clipboard/clipboard.js
@@ -1,0 +1,74 @@
+import {h, Component}					from 'preact/preact';
+import ButtonBase						from 'com/button-base/base';
+import SVGIcon							from 'com/svg-icon/icon';
+
+export default class CopyToClipboardButton extends ButtonBase {
+
+	constructor( props ) {
+		super(props);
+		this.onClick = this.onClick.bind(this);
+
+		this.state = {
+			"data": props.data,
+			"state": "IDEL"
+		};
+	}
+
+
+
+	onClick(e) {
+
+		let info = e.target.getElementsByTagName('div')[0];
+
+		this.copy(this.state.data).then( () => {
+			console.log("Copied to clipboard");
+
+			if (this.state.state === "IDEL") {
+				this.setState({"state": "SUCCESS"});
+				window.setTimeout(() => {
+					if (this.state.state === "SUCCESS") {
+						this.setState({"state": "IDEL"});
+					}
+				}, 2000);
+			}
+
+		}).catch((e) => {
+			console.log("Error copying short link to clipborad", e);
+
+			this.setState({"state": "ERROR"});
+
+		});
+
+	}
+
+	// Edited from https://gist.github.com/lgarron/d1dee380f4ed9d825ca7
+	copy(str) {
+		return new Promise(
+			(resolve, reject) => {
+				var success = false;
+
+				listener = (e) => {
+					e.clipboardData.setData("text/plain", str);
+					e.preventDefault();
+					success = true;
+				};
+
+				document.addEventListener("copy", listener);
+				document.execCommand("copy");
+				document.removeEventListener("copy", listener);
+				success ? resolve(): reject();
+			}
+		);
+	}
+
+	render(props, state) {
+
+		let {children} = Object.assign({}, props);
+
+		return (
+			<div class={cN("-c2cbutton", props.class)} onclick={this.onClick}>
+				{children}
+			</div>
+		);
+	}
+}

--- a/src/com/button-clipboard/clipboard.js
+++ b/src/com/button-clipboard/clipboard.js
@@ -63,9 +63,6 @@ export default class CopyToClipboardButton extends ButtonBase {
 
 	render(props, state) {
 
-		console.log(STATIC_DOMAIN);
-		console.log(SHORTNER_DOMAIN);
-
 		let {children} = Object.assign({}, props);
 
 		let icon, style, tooltip;

--- a/src/com/button-clipboard/clipboard.js
+++ b/src/com/button-clipboard/clipboard.js
@@ -65,26 +65,29 @@ export default class CopyToClipboardButton extends ButtonBase {
 
 		let {children} = Object.assign({}, props);
 
-		let icon, style;
+		let icon, style, tooltip;
 		switch (state.state) {
 			case "SUCCESS":
 				icon = "checkmark";
 				style = "-success";
+				tooltip = "Copied to clipboard succesfully!";
 				break;
 
 			case "ERROR":
 				icon = "cross";
 				style = "-error";
+				tooltip = "Failed to copy to clipboard";
 				break;
 
 			case "IDEL":
 			default:
 				icon =(this.props.icon === undefined)? "link" : props.icon;
+				tooltip =(this.props.tooltip === undefined)? "Copy to clipboard" : props.tooltip;
 				break;
 		}
 
 		return (
-			<div class={cN("-c2cbutton", props.class)} onclick={this.onClick}>
+			<div title={tooltip} class={cN("-c2cbutton", props.class)} onclick={this.onClick}>
 				<SVGIcon class={(style === undefined) ? null : style} baseline>{icon}</SVGIcon>
 				{children}
 			</div>

--- a/src/com/button-clipboard/clipboard.js
+++ b/src/com/button-clipboard/clipboard.js
@@ -21,7 +21,7 @@ export default class CopyToClipboardButton extends ButtonBase {
 		let info = e.target.getElementsByTagName('div')[0];
 
 		this.copy(this.state.data).then( () => {
-			console.log("Copied to clipboard");
+			console.log("Copied " + this.state.data + " to clipboard");
 
 			if (this.state.state === "IDEL") {
 				this.setState({"state": "SUCCESS"});
@@ -33,7 +33,7 @@ export default class CopyToClipboardButton extends ButtonBase {
 			}
 
 		}).catch((e) => {
-			console.log("Error copying short link to clipborad", e);
+			console.log("Error copying short link to clipboard", e);
 
 			this.setState({"state": "ERROR"});
 
@@ -65,8 +65,27 @@ export default class CopyToClipboardButton extends ButtonBase {
 
 		let {children} = Object.assign({}, props);
 
+		let icon, style;
+		switch (state.state) {
+			case "SUCCESS":
+				icon = "checkmark";
+				style = "-success";
+				break;
+
+			case "ERROR":
+				icon = "cross";
+				style = "-error";
+				break;
+
+			case "IDEL":
+			default:
+				icon =(this.props.icon === undefined)? "link" : props.icon;
+				break;
+		}
+
 		return (
 			<div class={cN("-c2cbutton", props.class)} onclick={this.onClick}>
+				<SVGIcon class={(style === undefined) ? null : style} baseline>{icon}</SVGIcon>
 				{children}
 			</div>
 		);

--- a/src/com/button-clipboard/clipboard.js
+++ b/src/com/button-clipboard/clipboard.js
@@ -63,6 +63,9 @@ export default class CopyToClipboardButton extends ButtonBase {
 
 	render(props, state) {
 
+		console.log(STATIC_DOMAIN);
+		console.log(SHORTNER_DOMAIN);
+
 		let {children} = Object.assign({}, props);
 
 		let icon, style, tooltip;

--- a/src/com/button-clipboard/clipboard.less
+++ b/src/com/button-clipboard/clipboard.less
@@ -1,0 +1,26 @@
+@import 'defs.less';
+
+#content .content-base .content-common-body .-c2cbutton {
+
+	padding: 0.1em;
+	color: @COL_NLLLL;
+
+	margin: 0em 0.25em;
+
+	display:inline-block;
+	vertical-align: middle;
+
+	&:hover,
+	&:focus {
+		background: @COL_A;
+		color: @COL_L;
+	}
+
+	&:active {
+		background: @COL_L;
+		color: @COL_A;
+	}
+
+	& > .svg-icon {
+	}
+}

--- a/src/com/button-clipboard/clipboard.less
+++ b/src/com/button-clipboard/clipboard.less
@@ -22,5 +22,12 @@
 	}
 
 	& > .svg-icon {
+		&.-success {
+			color: @COL_BC;
+		}
+
+		&.-error{
+			color: @COL_A;
+		}
 	}
 }

--- a/src/com/content-common/common-body-title.js
+++ b/src/com/content-common/common-body-title.js
@@ -1,10 +1,11 @@
-import { h, Component } 				from 'preact/preact';
-import { shallowDiff }	 				from 'shallow-compare/index';
+import {h, Component} 				from 'preact/preact';
+import {shallowDiff}	 				from 'shallow-compare/index';
 
 import NavLink							from 'com/nav-link/link';
 import SVGIcon							from 'com/svg-icon/icon';
 
 import InputText						from 'com/input-text/text';
+import CopyToClipboardButton from '../button-clipboard/clipboard';
 
 export default class ContentCommonBodyTitle extends Component {
 	constructor( props ) {
@@ -16,6 +17,7 @@ export default class ContentCommonBodyTitle extends Component {
 //	}
 
 	render( props ) {
+
 		props.class = typeof props.class == 'string' ? props.class.split(' ') : [];
 		props.class.push("content-common-body");
 		props.class.push("-title");
@@ -24,7 +26,7 @@ export default class ContentCommonBodyTitle extends Component {
 
 		var Prefix = null;
 		if ( props.titleIcon ) {
-			Prefix = <SVGIcon baseline small>{props.titleIcon}</SVGIcon>;
+			Prefix = <SVGIcon baseline small class="-prefix">{props.titleIcon}</SVGIcon>;
 		}
 
 		var Limit = props.limit ? props.limit : 64;	// True limit is 96
@@ -49,10 +51,18 @@ export default class ContentCommonBodyTitle extends Component {
 
 			var Title = props.title.trim().length ? props.title.trim() : Placeholder;
 			var Body = [];
-			if ( props.href )
+			if ( props.href ) {
 				Body.push(<NavLink class="-text" href={props.href} title={props.hover}>{Prefix}{Title}</NavLink>);
-			else
+				if (!props.minmax && props.id) {
+
+					//TODO:: that data url needs to be generated. Not sure how to get the link shortner address from javascript
+
+					Body.push(<CopyToClipboardButton class={"-shortner"} data={'https://url.ludumdare.org/$' + props.id}><SVGIcon baseline>link</SVGIcon></CopyToClipboardButton>);
+				}
+			}
+			else {
 				Body.push(<div class="-text" title={props.hover}>{Prefix}{Title}</div>);
+			}
 
 			if ( props.subtitle ) {
 				Body.push(<span class="-subtext"> ({props.subtitle})</span>);

--- a/src/com/content-common/common-body-title.js
+++ b/src/com/content-common/common-body-title.js
@@ -55,9 +55,7 @@ export default class ContentCommonBodyTitle extends Component {
 				Body.push(<NavLink class="-text" href={props.href} title={props.hover}>{Prefix}{Title}</NavLink>);
 				if (!props.minmax && props.id) {
 
-					//TODO:: that data url needs to be generated. Not sure how to get the link shortner address from javascript
-
-					Body.push(<CopyToClipboardButton tooltip="Copy short link to clipboard" icon={"link"} class={"-shortner"} data={'https://url.ludumdare.org/$' + props.id}></CopyToClipboardButton>);
+					Body.push(<CopyToClipboardButton tooltip="Copy short link to clipboard" icon={"link"} class={"-shortner"} data={SHORTNER_DOMAIN+"/$" + props.id}></CopyToClipboardButton>);
 				}
 			}
 			else {

--- a/src/com/content-common/common-body-title.js
+++ b/src/com/content-common/common-body-title.js
@@ -57,7 +57,7 @@ export default class ContentCommonBodyTitle extends Component {
 
 					//TODO:: that data url needs to be generated. Not sure how to get the link shortner address from javascript
 
-					Body.push(<CopyToClipboardButton class={"-shortner"} data={'https://url.ludumdare.org/$' + props.id}><SVGIcon baseline>link</SVGIcon></CopyToClipboardButton>);
+					Body.push(<CopyToClipboardButton icon={"link"} class={"-shortner"} data={'https://url.ludumdare.org/$' + props.id}></CopyToClipboardButton>);
 				}
 			}
 			else {

--- a/src/com/content-common/common-body-title.js
+++ b/src/com/content-common/common-body-title.js
@@ -57,7 +57,7 @@ export default class ContentCommonBodyTitle extends Component {
 
 					//TODO:: that data url needs to be generated. Not sure how to get the link shortner address from javascript
 
-					Body.push(<CopyToClipboardButton icon={"link"} class={"-shortner"} data={'https://url.ludumdare.org/$' + props.id}></CopyToClipboardButton>);
+					Body.push(<CopyToClipboardButton tooltip="Copy short link to clipboard" icon={"link"} class={"-shortner"} data={'https://url.ludumdare.org/$' + props.id}></CopyToClipboardButton>);
 				}
 			}
 			else {

--- a/src/com/content-common/common-body-title.less
+++ b/src/com/content-common/common-body-title.less
@@ -38,8 +38,8 @@
 		}
 	}
 
-	& > .-text {
-		position: relative;
+	& > .-text,
+	& > .-shortner {
 
 		font-size: 1.75em;
 
@@ -47,6 +47,11 @@
 			font-size: 1.9em;
 		}
 	}
+
+	& > .-text {
+		position: relative;
+	}
+
 
 	& > .-subtext {
 		font-size: 1.5em;
@@ -65,7 +70,7 @@
 		}
 	}
 
-	& svg {
+	& .-prefix {
 		margin-right: 0.5em;
 	}
 }

--- a/src/com/content-simple/simple.js
+++ b/src/com/content-simple/simple.js
@@ -315,6 +315,7 @@ export default class ContentSimple extends Component {
 	}
 
 	render( props, state ) {
+
 		props = Object.assign({}, props);	// Shallow copy we can change props
 		let {node, user, path, extra, featured} = props;
 		let {author, authors} = state;
@@ -424,6 +425,8 @@ export default class ContentSimple extends Component {
 			if ( !props.notitle ) {
 				ShowTitle = <ContentCommonBodyTitle
 					href={node.path}
+					id={node.id}
+					minmax={props.minmax}
 					title={state.name}
 					hover={node.slug+' [$'+node.id+']'}
 					subtitle={props.subtitle}

--- a/src/com/page/layout.js
+++ b/src/com/page/layout.js
@@ -6,7 +6,6 @@ import ViewSidebar						from 'com/view/sidebar/sidebar';
 import ViewContent						from 'com/view/content/content';
 import ViewFooter						from 'com/view/footer/footer';
 
-
 export default class Layout extends Component {
 	render( props ) {
 		let {user, featured, node} = props;

--- a/src/main/main.php
+++ b/src/main/main.php
@@ -16,7 +16,7 @@ if ( !isset($_GET['ignore']) && strpos($_SERVER['HTTP_USER_AGENT'],'MSIE') !== f
 define( 'DEBUG', isset($_GET['debug'])?1:0 );
 define( 'USE_MINIFIED', DEBUG ? '.debug' : '.min' );
 define( 'VERSION_STRING', defined('GIT_VERSION') ? 'v='.GIT_VERSION : '' );
-const STATIC_DOMAINS = [ 
+const STATIC_DOMAINS = [
 	'ludumdare.org' => 'static.jammer.work',
 	'jammer.work' => 'static.jammer.work',
 	'ludumdare.dev' => 'static.jam.dev',
@@ -26,6 +26,17 @@ const DEFAULT_STATIC_DOMAIN = 'static.jam.vg';
 
 define( 'STATIC_DOMAIN', array_key_exists( $_SERVER['SERVER_NAME'], STATIC_DOMAINS ) ? STATIC_DOMAINS[$_SERVER['SERVER_NAME']] : DEFAULT_STATIC_DOMAIN );
 define( 'STATIC_ENDPOINT', '//'.STATIC_DOMAIN );
+const SHORTNER_DOMAINS = [
+	'ludumdare.org' => 'url.ludumdare.org',
+	'ludumdare.dev' => 'url.ludumdare.dev',
+	'jammer.work' => 'url.jammer.work',
+	'jammer.dev' => 'url.jammer.dev',
+	'ldjam.com' => 'ldj.am',
+	'jammer.vg' => 'jam.mr',
+];
+const DEFAULT_SHORTNER_DOMAIN = 'ldj.am';
+
+define( 'SHORTNER_DOMAIN', array_key_exists( $_SERVER['SERVER_NAME'], SHORTNER_DOMAINS ) ? SHORTNER_DOMAINS[$_SERVER['SERVER_NAME']] : DEFAULT_SHORTNER_DOMAIN );
 define( 'LINK_SUFFIX', isset($_GET['nopush']) ? '; nopush' : '' );
 if ( !defined('API_DOMAIN') ) {
 	define( 'API_DOMAIN', 'api.'.$_SERVER['SERVER_NAME'] );
@@ -60,6 +71,7 @@ if ( !isset($_GET['nopreload']) ) {
 		var VERSION_STRING = "<?=VERSION_STRING?>";
 		var STATIC_DOMAIN = "<?=STATIC_DOMAIN?>";
 		var STATIC_ENDPOINT = "<?=STATIC_ENDPOINT?>";
+		var SHORTNER_DOMAIN = "<?=SHORTNER_DOMAIN?>";
 		var API_DOMAIN = "<?=API_DOMAIN?>";
 		var API_ENDPOINT = "<?=API_ENDPOINT?>";
 		var SERVER_TIMESTAMP = "<?=gmdate('Y-m-d\TH:i:s.000\Z'/*DATE_W3C*/);?>";


### PR DESCRIPTION
Closes #1788 

## Features
Adds button at the end of post titles. This only shows when on the post's page and not on the main feed.   
![image](https://user-images.githubusercontent.com/18352787/58762829-ba879580-854b-11e9-9654-2f1d22f5915e.png)

When clicked this copies the correct short link to clipboard. If successful the icon is replaced with a  :heavy_check_mark: for two seconds. If it fails the icon changes to :negative_squared_cross_mark: .
![Screenshot from 2019-06-02 15-34-52](https://user-images.githubusercontent.com/18352787/58762876-13572e00-854c-11e9-9537-6f3b528a811a.png)

Copy to clipboard functionality from https://gist.github.com/lgarron/d1dee380f4ed9d825ca7 we might want to use https://github.com/lgarron/clipboard-polyfill if this simple solution is too buggy but so far it works well.

## Issues
- [x] ~~Not sure how to get the correct shortener link form js, it only appears to be defined in PHP, but not in the section where PHP constants are copied to js. See the below links for those files.~~
  
 https://github.com/ludumdare/ludumdare/blob/e7c1dc6b8d155e774d454374898bfb8a7574203c/src/public-url.redirect/main-redirect.php#L15
    https://github.com/ludumdare/ludumdare/blob/e7c1dc6b8d155e774d454374898bfb8a7574203c/src/main/main.php#L64

~~I'm not sure how to add a constant for the correct link shortener (ldj.am vs url.ludumdare.org). [this section of js](https://github.com/ludumdare/ludumdare/compare/master...zwrawr:short-link-button?expand=1#diff-d93231edb9fe5368a7151a230625e2f9R58) needs updating with the correct shortener URL.~~
  
------------------------------------
- [ ] Not tested on ie (see #1821) or mobile browsers (works on chrome, firefox, edge41 and opera)