### PR TITLE
fix svg preload warning

### DIFF
--- a/src/main/main.php
+++ b/src/main/main.php
@@ -41,7 +41,7 @@ define( 'FONT_DOMAIN', "//fonts.gstatic.com" );
 if ( !isset($_GET['nopreload']) ) {
 	header( "Link: <".JS_FILE.">; rel=preload; as=script".LINK_SUFFIX, false );
 	header( "Link: <".CSS_FILE.">; rel=preload; as=style".LINK_SUFFIX, false );
-	header( "Link: <".SVG_FILE.">; rel=preload".LINK_SUFFIX, false );
+	header( "Link: <".SVG_FILE.">; rel=preload; as=fetch; crossorigin".LINK_SUFFIX, false );
 //	header( "Link: <".FONT_FILE.">; rel=preload; as=style", false );
 }
 //header("Link: </blah">; rel=canonical"); // https://yoast.com/rel-canonical/


### PR DESCRIPTION
Both the server and dev environment produce this warning 
![Screenshot from 2019-06-02 23-31-09](https://user-images.githubusercontent.com/18352787/58768159-9f8a4500-858e-11e9-880e-644fe616f837.png)
This is fixed by adding `as=fetch; crossorigin`.
`fetch` is used because the svg's are added to the document via javascript fetch request.
I'm not 100% sure why the cross-origin is needed as they're both from ludumdare.org, but it complains if it's not there.


Closes #403 (which was already fixed)