### PR TITLE
Added font display swap to google fonts

### DIFF
--- a/src/main/main.php
+++ b/src/main/main.php
@@ -35,7 +35,7 @@ define( 'API_ENDPOINT', '//'.API_DOMAIN );
 define( 'JS_FILE',   "/-/all".USE_MINIFIED.".js?".VERSION_STRING );
 define( 'CSS_FILE',  "/-/all".USE_MINIFIED.".css?".VERSION_STRING );
 define( 'SVG_FILE',  "/-/all.min.svg?".VERSION_STRING );
-define( 'FONT_FILE', "//fonts.googleapis.com/css?family=Raleway:600,600italic,800,800italic|Roboto:300,300italic,700,700italic" );
+define( 'FONT_FILE', "//fonts.googleapis.com/css?family=Raleway:600,600italic,800,800italic|Roboto:300,300italic,700,700italic&display=swap" );
 define( 'FONT_DOMAIN', "//fonts.gstatic.com" );
 
 if ( !isset($_GET['nopreload']) ) {


### PR DESCRIPTION
Closes #1823 .

This adds font-display swap to the google fonts request. This means font loading will not block text from being displayed. The text will immediately be displayed using the fallback font until the correct font is loaded.

#### Screen traces
**with swap**
![Screenshot from 2019-06-20 16-24-44](https://user-images.githubusercontent.com/18352787/59862025-e1323280-9379-11e9-8b49-eaaf3283523c.png)
**default**
![Screenshot from 2019-06-20 16-32-52](https://user-images.githubusercontent.com/18352787/59862026-e1323280-9379-11e9-898b-c314ad9078bc.png)

In the default screenshot, you can see the text is loaded and taking up room on the page but not being rendered yet. Whereas in the swap screenshot you can see the text is being displayed with a slightly different fallback font.
