### PR TITLE
Fix #1081: Remember that you clicked the X on the "noob" popup

### DIFF
--- a/src/com/header/noob/noob.js
+++ b/src/com/header/noob/noob.js
@@ -3,28 +3,11 @@ import SVGIcon 						from 'com/svg-icon/icon';
 import NavLink 						from 'com/nav-link/link';
 
 export default class HeaderNoob extends Component {
-	constructor( props ) {
-		super(props);
-
-		this.state = {
-			'hidden': false
-		};
-
-		this.onClick = this.onClick.bind(this);
-	}
-
-	onClick( e ) {
-		this.setState({'hidden': true});
-	}
 
 	render( props, state ) {
-		if ( state.hidden ) {
-			return null;
-		}
-
 		return (
 			<div class="content-base content-common content-simple content-noob">
-				<div class="-close" onclick={this.onClick}><SVGIcon>cross</SVGIcon></div>
+				<div class="-close" onclick={props.onDismiss.bind(this)}><SVGIcon>cross</SVGIcon></div>
 				<div class="-title -gap _font2">What is Ludum Dare?</div>
 				<div><NavLink href="/about"><strong>Ludum Dare</strong></NavLink> is an online event where games are made from scratch in a weekend. Check us out every April and October!</div>
 			</div>

--- a/src/com/page/root/root.js
+++ b/src/com/page/root/root.js
@@ -25,14 +25,32 @@ import PageDevPalette 					from 'com/page/dev/palette';
 
 import HeaderNoob						from 'com/header/noob/noob';
 
+const STORAGE_HEADER_DISMISSED = 'isNoobHeaderDismissed';
+
 export default class PageRoot extends Component {
+
+	constructor(props) {
+		super(props);
+		this.state = {
+			isNoobHeaderDisplayed: (!props.user || !props.user.id) &&
+				!localStorage.getItem(STORAGE_HEADER_DISMISSED),
+		};
+	}
+
+	dismissNoobHeader() {
+		localStorage.setItem(STORAGE_HEADER_DISMISSED, 'true');
+		this.setState({
+			isNoobHeaderDisplayed: false,
+		});
+	}
+
 	render( props ) {
 		const {node, user, path, extra, featured} = props;
 		let Dummy = <div />;
 
 		let ShowIntro = null;
-		if (!user || !user.id) {
-			ShowIntro = <HeaderNoob featured={props.featured} />;
+		if (this.state.isNoobHeaderDisplayed) {
+			ShowIntro = <HeaderNoob onDismiss={this.dismissNoobHeader.bind(this)} />;
 		}
 
 		return (


### PR DESCRIPTION
This adds a new variable `isNoobHeaderDismissed` in the local storage to remember the fact that a guest has dismissed the noob panel in the Feed page.

![bug-1081](https://user-images.githubusercontent.com/3528822/66708993-cfe9a900-ed0f-11e9-9e5c-57934afa2ada.gif)

