### PR TITLE
Fix #1062: typo minumum => minimum

### DIFF
--- a/public-api/vx/node.php
+++ b/public-api/vx/node.php
@@ -810,7 +810,7 @@ switch ( $action ) {
 				$new_slug = node_GetUniqueSlugByParentSlug($node['parent'], $slug);
 
 				if ( strlen($new_slug) < 3 ) {
-					json_EmitFatalError_BadRequest("Name is too short (minumum 3 alphanumeric characters)", $RESPONSE);
+					json_EmitFatalError_BadRequest("Name is too short (minimum 3 alphanumeric characters)", $RESPONSE);
 				}
 
 				$RESPONSE['edit'] = node_Edit(


### PR DESCRIPTION
Looks like #1062 is already addressed and ready to be closed as the text was replaced from "min 3 characters" to "min 3 alphanumeric characters". There's just a tiny typo that this PR fixes.