### PR TITLE
Fixes to get environment up and running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,9 @@ ROLLUP				=	$(NODEJS)/rollup/dist/bin/rollup $(ROLLUP_ARGS) $(1) > $(2)
 # JS Preprocessor: https://github.com/moisesbaez/preprocess-cli-tool
 JS_PP_DEBUG			=	$(NODEJS)/preprocess-cli-tool/bin/preprocess.js -f $(1) -d $(2) -c '{"DEBUG": true}' -t js
 JS_PP_RELEASE		=	$(NODEJS)/preprocess-cli-tool/bin/preprocess.js -f $(1) -d $(2) -t js
-# JS Minifier: https://github.com/mishoo/UglifyJS2
+# JS Minifier: https://www.npmjs.com/package/uglify-js
 MINIFY_JS_RESERVED	:=	VERSION_STRING,STATIC_DOMAIN
-MINIFY_JS_ARGS		:=	--compress --mangle -r "$(MINIFY_JS_RESERVED)"
+MINIFY_JS_ARGS		:=	--compress --mangle reserved=["$(MINIFY_JS_RESERVED)"]
 MINIFY_JS			=	$(NODEJS)/uglify-js/bin/uglifyjs $(MINIFY_JS_ARGS) -o $(2) -- $(1)
 
 # CSS Compiler: http://lesscss.org/

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ROLLUP_ARGS			:=	-c src/config/rollup.config.js
 ifdef SOURCEMAPS
 ROLLUP_ARGS			+=	-m inline
 endif # SOURCEMAPS
-ROLLUP				=	$(NODEJS)/rollup/bin/rollup $(ROLLUP_ARGS) $(1) > $(2)
+ROLLUP				=	$(NODEJS)/rollup/dist/bin/rollup $(ROLLUP_ARGS) $(1) > $(2)
 # JS Preprocessor: https://github.com/moisesbaez/preprocess-cli-tool
 JS_PP_DEBUG			=	$(NODEJS)/preprocess-cli-tool/bin/preprocess.js -f $(1) -d $(2) -c '{"DEBUG": true}' -t js
 JS_PP_RELEASE		=	$(NODEJS)/preprocess-cli-tool/bin/preprocess.js -f $(1) -d $(2) -t js

--- a/src/config/eslint.config.json
+++ b/src/config/eslint.config.json
@@ -1,6 +1,6 @@
 {
 	"parserOptions": {
-		"ecmaVersion": 2017,
+		"ecmaVersion": 2018,
 		"sourceType": "module",
 		"ecmaFeatures": {
 			"jsx": true,


### PR DESCRIPTION
Rest/spread in object literals was introduced in ECMAScript 2018, so tell ESLint to use that or we'll get `"Parsing error: Unexpected token .."` errors.

`rollup` binary has been moved into a `dist/` directory.

`uglify-js` has updated to version 3 and is now doing `--mangle reserved=["stuff"]` instead of `--mangle -r "stuff"`