### PR TITLE
Fixed race condition where comments would not load sometimes

### DIFF
--- a/src/com/content-comments/comments.less
+++ b/src/com/content-comments/comments.less
@@ -2,6 +2,8 @@
 
 #content .content-common.content-comments {
 	position: relative;
+	/*Grow the comments box a little by default so the spinner does not show on the header*/
+	min-height: 200px;
 
 	background: @COL_NLLLL;
 	/*border-top: 4px solid @COL_NDDD;*/


### PR DESCRIPTION
Resubmitting because I changed the branch, since I want to work on different issues
Fix #1912 

There is an error if the user has not loaded when the comments render for the first time, this is due to ```getComments``` referencing the user and trying to get the Id of the object that is null at the time

The reason why this was not surfaced in the JS console is because is being caught by the catch for the ```$Comment.GetByNode``` call, but when I try to print it inside the catch this is what I get:

```js
///src/com/content-comments/comments.js:102
.catch(err => {
    console.log(err);
    this.setState({'error': err});
});
```
![Screenshot from 2021-08-28 18-50-10](https://user-images.githubusercontent.com/940231/131235998-7d670dce-e005-4bd4-a3a3-81cb5611d344.png)

My fix is to extract the code that uses the user object to a different function, and execute it only if the user is already loaded, otherwise I added the same call to ```componentWillUpdate``` with a check to see if the user was updated from null


Some minor changes that I also made: 
I hid the 'Sign in to post comments' message if the user is null, since it means the user has not loaded yet (When there is a not logged in user, we actually have a User object, but with Id 0)

I also put a min-height on the comments so that the spinner is not cramped in the headline, this is how it looks:
![Screenshot from 2021-08-28 18-43-50](https://user-images.githubusercontent.com/940231/131236075-b04f6d0f-57e7-4a18-9fcc-c702482743de.png)

There was also a bracket that was causing a warning when running make

A bit out of scope, so I have no problem reverting these changes if you find them intrusive, so let me know
