### PR TITLE
Disable font ligatures in Raleway

### DIFF
--- a/src/com/fonts.less
+++ b/src/com/fonts.less
@@ -23,6 +23,7 @@ strong, b, h1, h2, h3, h4, h5, h6, ._bold, ._strong {
 	/* Raleway - Title font (Google Fonts) */
 	font-family: "Raleway", "Helvetica Neue", "Roboto", "Arial Nova", "Segoe UI", "Ubuntu Light", sans-serif;
 	font-weight: 600;
+	font-variant-ligatures: none;
 
 	/* slightly heavier bold */
 	& strong,


### PR DESCRIPTION
This fixes `ff` and `fi` looking weird in blog post titles.

Before:
<img width="598" height="197" alt="image" src="https://github.com/user-attachments/assets/6c4c1f88-fafe-4835-976c-dd459394ff65" />

After:
<img width="580" height="197" alt="image" src="https://github.com/user-attachments/assets/2e009cf0-f0a6-48cb-962b-52ef0fa0bb2b" />
