### PR TITLE
Show anonymous comments by default

### DIFF
--- a/src/com/content-comments/comments-comment.js
+++ b/src/com/content-comments/comments-comment.js
@@ -238,7 +238,7 @@ export default class ContentCommentsComment extends Component {
 		let {user, comment, author, error, node, isNodeAuthor, isMyComment, isMention} = props;
 
 		// Allow authored comments, or non-authored (i.e. anonymous)
-		if ( comment && ((author && author._trust >= 0 && comment._trust >= 0) || (comment.author == 0 && comment._trust > 0)) ) {
+		if ( comment && comment._trust >= 0 && ((author && author._trust >= 0) || comment.author == 0) ) {
 			let Name = "Anonymous";
 			let Avatar = "///other/dummy/user64.png";
 
@@ -443,7 +443,7 @@ export default class ContentCommentsComment extends Component {
 				</div>
 			);
 		}
-		else if ( comment && ((author && author._trust < 0) || (comment && comment._trust <= 0)) ) {
+		else if ( comment && ((author && author._trust < 0) || comment._trust < 0) ) {
 			return (
 				<div
 					id={"comment-"+comment.id}


### PR DESCRIPTION
Currently, anonymous comments (when enabled) don't actually show (see [here](https://ldjam.com/events/ludum-dare/59/yai-presents-himari-the-beautiful-super-genius-artificial-intelligence/psa-dont-write-anonymous-comments) or [here](https://ldjam.com/events/ludum-dare/59/dearest-friend)), instead showing a "-". It seems anonymous comments get a default `_trust` value of `0` but are only rendered when `_trust` is `1` or more (so manually approved...?).