### PR TITLE
Proposing a rework of the smart algorithm

### DIFF
--- a/private/magic.php
+++ b/private/magic.php
@@ -15,12 +15,6 @@ const MAX_ITEMS_TO_CALC = 500;
 // TODO: Adjust the maximum effectiveness as the weeks go by. Start with like 50 initially (more than enough), but let it go up after.
 const FEEDBACK_PER_COMMENT = 2.0;
 
-const COOL_MIN_POINTS = 1;		// In the future, set this to 3 or 4
-const COOL_MIN_GRADES = 1;		// In the future, set this to 3 or 4
-const COOL_MIN_FEEDBACK = 1;	// In the future, set this to 3 or 4
-const COOL_MAX_GRADES = 15;//50;
-const COOL_MAX_FEEDBACK = 50;
-
 const CLASSIC_MAX_GRADES = 100;
 
 
@@ -52,6 +46,10 @@ function AddMagic( $name, $parent, $initial_value = 0 ) {
 	}
 }
 
+function ScaleKarma( $x ) {
+    return 90.798311 * (1 - exp(-0.008 * x));
+}
+
 // Get the root node
 $root = nodeComplete_GetById(1);
 
@@ -76,21 +74,6 @@ if ( $featured_id ) {
 			}
 			else if ( $key == 'event-start' ) {
 				$event_start = new DateTime($featured['meta'][$key]);
-			}
-		}
-
-		// initialize to max grades
-		$cool_max_grades = COOL_MAX_GRADES;
-
-		// If start time is set
-		if ( $event_start ) {
-			// use the number of days since the start as the max grade
-			$event_diff = $event_start->diff(new DateTime("now"));
-			$cool_max_grades = intval($event_diff->format('%a'));
-
-			// Clamp to max grade
-			if ( $cool_max_grades > COOL_MAX_GRADES ) {
-				$cool_max_grades = COOL_MAX_GRADES;
 			}
 		}
 
@@ -167,7 +150,6 @@ if ( $featured_id ) {
 				// 100, 100 = 100
 
 				$smart = 0;
-				$unbound = 0;
 				$cool = 0;
 
 				$team_grades = 0;
@@ -202,10 +184,6 @@ if ( $featured_id ) {
 					$team_grades = $raw_team_grades / $team_grade_value;
 					$given_grades = $raw_given_grades / $given_grade_value;
 
-					// Given grade is unbound, so inactive participants will still get seen and get a few grades
-					$bound_grade = (sqrt(min($cool_max_grades, max(COOL_MIN_GRADES, $team_grades)) * 100.0 / max(1.0, $given_grades)) * 100.0 / 10.0) - 100.0;
-					$unbound_grade = (sqrt(max(COOL_MIN_GRADES, $team_grades) * 100.0 / max(1.0, $given_grades)) * 100.0 / 10.0) - 100.0;
-
 					// ** Classic Grade Algorithm **************************************
 					// (TODO: Double check that it even needs '/ $team_grade_value')
 					$classic_team_grades = max(0, min(CLASSIC_MAX_GRADES, $raw_team_grades / $team_grade_value));
@@ -219,22 +197,11 @@ if ( $featured_id ) {
 					$team_feedback = $raw_team_feedback / FEEDBACK_PER_COMMENT;
 					$given_feedback = $raw_given_feedback / FEEDBACK_PER_COMMENT;
 
-					// Unlke grade, given feedback is bound, so excessive feedback doesn't accidentially drown-out the grades
-					$bound_feedback = (sqrt(min(COOL_MAX_FEEDBACK, max(COOL_MIN_FEEDBACK, $team_feedback)) * 100.0 / min(COOL_MAX_FEEDBACK, max(1.0, $given_feedback))) * 100.0 / 10.0) - 100.0;
-					$unbound_feedback = (sqrt(max(COOL_MIN_FEEDBACK, $team_feedback) * 100.0 / max(1.0, $given_feedback)) * 100.0 / 10.0) - 100.0;
-
-
-					// Final
-					//$smart = $bound_grade + $bound_feedback;				// bound, so it will hit upper limits
-					//$unbound = $unbound_grade + $unbound_feedback;			// unbound
-
-//					$smart_for = max(COOL_MIN_POINTS, (min($cool_max_grades, $team_grades) + min(COOL_MAX_FEEDBACK, $team_feedback));
-//					$smart_against = max(1.0, (min($cool_max_grades, $given_grades) + min(COOL_MAX_FEEDBACK, $given_feedback));
-
-					// Bound everything except given grades, so a game can score below a game with no votes
-					$smart_for = max(COOL_MIN_POINTS, (min($cool_max_grades, $team_grades) + min(COOL_MAX_FEEDBACK, $team_feedback)));
-					$smart_against = max(1.0, ($given_grades + min(COOL_MAX_FEEDBACK, $given_feedback)));
-					$smart = (sqrt($smart_for * 100.0 / $smart_against) * 100.0 / 10.0) - 100.0;
+					// Diminishing returns on high grades/feedback
+					$smart = 10 * sqrt(
+                        (ScaleKarma($team_grades) / 2.0 + ScaleKarma($raw_team_feedback))
+                        * 100 / max(1, $given_grades)
+                    );
 
 					$cool = $classic_grade;									// ratings only, old algorithm
 				}


### PR DESCRIPTION
Visualized on [Desmos](https://www.desmos.com/calculator/wrwunxgwl2) where:
* `z(x)` is the final smart rating.
* `f(k|rg)` is the function that scales smart rating based on comment karma, or based on ratings given in the proposed new version.
* `k` is the comment karma.
* `rg` is the number of ratings given.
* `x` is the number of ratings received (in `z(x)`).
 
Alongside these fields I want to get rid of:
* `kmax` is the hard cap on comment value (currently 50, aka `COOL_MAX_FEEDBACK`).
* `grief hearts` is the number of hearts that weren't given by the author(s) of the game.
  * I call them grief hearts because the current implementation makes them completely tank the game's smart rating and it's a catastrophe that goes directly against the idea of hearts. 
    * A single comment some two random users found "heartable" can never be more valuable than two "regular" comments, but the current algorithm treats those scenarios as equal.
    * A malicious third party could reduce someone's karma by `(number of comments) / 2` simply by hearting every comment.
* `t` is the number of days since the event started.
  * This is another awful band-aid solution. While relaxing the limit over time is not a bad idea in itself, 1 rating per day is horrifically low. The 15 hardcap is lower than the 20 ratings received threshold, which means you **expect** people to give out fewer ratings than they receive. In an ideal circle in a vacuum scenario, everyone would give out exactly 20 ratings, but in reality the average has to be much higher, *not lower*, in order to ensure as many people are ranked as possible.   

The main point is to:
* Use diminishing returns instead of hard caps.
* Restore any meaning to the "ratings given" metric as it's the only metric that works immediately, i.e. doesn't need to wait for an interaction from someone else.
  * But comments still have more weight of course.
* Remove grief hearts, as they only disincentivize further interaction with the site, and [can in fact make the 20 rating threshold difficult to achieve](https://ldjam.com/events/ludum-dare/51/far/psa-do-not-heart-comments-on-other-peoples-games). They punish games with a sizable number of comments (*[quality or not](https://i.imgur.com/dBWbPBB.jpeg)*), and can allow a single person to tank someone's game. They are also opaque–they don't show up in your stats, and they're not described or mentioned anywhere on the website. 
  * Supersedes #2267
* Prevent negative results (the final `-100` in the formula) as they introduce unnecessary confusion and are ugly (they are still present in the Desmos graph for easier comparison).

The values selected are arbitrary and can be adjusted immediately or over time. It's not critical for the smart algorithm to be "correct" at all times, i.e. having the queue be slightly off for a few hours (until the values are adjusted) won't cause severe damage. I also think it would be *difficult* to make the new algorithm any worse than the current broken one.

Diminishing returns are already present in the old algorithm to some extent because the whole thing is under a square root, which makes those hard caps even more baffling. I'm not getting rid of the square root because I want this to be a gentle, one change at a time adjustment. (Actually, two changes, but grief hearts should have been patched out years ago.)

> But this will give more karma to games that already have over 20 ratings, therefore decreasing the number of ranked games.

The reality is more nuanced, but a proper discussion is out of scope for this PR. In short, rating/commenting an inactive game has never been incentivized on the new site because:
* The author will not heart your comment.
* The game is less visible, making it less likely for a non-author to give you a heart. 
* The "ratings given" metric is completely meaningless with the current hard cap. 

Giving feedback to an inactive game **usually comes with no reward whatsoever**.
 
On the other hand, the current caps disincentivize interacting with the site and reduce the overall amount of feedback. Since the last comment under my game was published, I recorded five gameplay videos and my game is still nowhere close to the top of the smart queue; that is really demotivating.

These past 9 years have taught us that this heart-based karma ought to be burned to the ground. Is it better than coolness? Yes. Is it better than any algorithm that involves popularity? Yes!! Does it still suck? Very much so. This proposal is meant to be a temporary fix for the low hanging fruit problems.

Open problems not addressed here:
* The smart algorithm **vastly** favors sizable teams and punishes Compo/solo Jam participants.
* For the average user, a heart reaction does not parse as "quality feedback".

Relevant discussions:
* #1748
* #2068

Note: the PHP is untested because I don't know how to set up the event simulator; I asked about it on gitter 4 years ago.